### PR TITLE
Add Debug and defmt::Format impls for fieldsets and interrupt enums.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ documentation = "https://docs.embassy.dev/nrf-pac"
 [dependencies]
 cortex-m = "0.7.1"
 cortex-m-rt = { version = ">=0.6.15,<0.8", optional = true }
+defmt = { version = "0.3.10", optional = true }
 
 [features]
 rt = ["cortex-m-rt/device"]
+defmt = ["dep:defmt"]
 
 nrf51 = []
 nrf52805 = []

--- a/src/chips/nrf51/pac.rs
+++ b/src/chips/nrf51/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -305,6 +306,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -350,6 +371,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of Identity root Keys in the IRK data structure."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -371,6 +418,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral power control."]
@@ -396,6 +459,26 @@ pub mod aar {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -419,10 +502,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disabled AAR."]
             DISABLED = 0x0,
@@ -547,6 +651,22 @@ pub mod adc {
                 Busy(0)
             }
         }
+        impl core::fmt::Debug for Busy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Busy").field("busy", &self.busy()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Busy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Busy {
+                    busy: super::vals::Busy,
+                }
+                let proxy = Busy { busy: self.busy() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "ADC configuration register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -615,6 +735,38 @@ pub mod adc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("res", &self.res())
+                    .field("inpsel", &self.inpsel())
+                    .field("refsel", &self.refsel())
+                    .field("psel", &self.psel())
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    res: super::vals::Res,
+                    inpsel: super::vals::Inpsel,
+                    refsel: super::vals::Refsel,
+                    psel: super::vals::Psel,
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Config {
+                    res: self.res(),
+                    inpsel: self.inpsel(),
+                    refsel: self.refsel(),
+                    psel: self.psel(),
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "ADC enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -636,6 +788,26 @@ pub mod adc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -661,6 +833,22 @@ pub mod adc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("end", &self.end()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                }
+                let proxy = Int { end: self.end() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -682,6 +870,26 @@ pub mod adc {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of ADC conversion."]
@@ -707,10 +915,31 @@ pub mod adc {
                 Result(0)
             }
         }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: u16,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Busy {
             #[doc = "No ongoing ADC conversion is taking place. ADC is ready."]
             READY = 0x0,
@@ -740,7 +969,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "ADC is disabled."]
             DISABLED = 0x0,
@@ -772,7 +1002,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Analog external reference inputs disabled."]
             NONE = 0x0,
@@ -805,7 +1036,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Inpsel {
             #[doc = "Analog input specified by PSEL with no prescaling used as input for the conversion."]
             ANALOG_INPUT_NO_PRESCALING = 0x0,
@@ -844,7 +1076,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Analog input pins disabled."]
             DISABLED = 0x0,
@@ -1135,7 +1368,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Use internal 1.2V bandgap voltage as reference for conversion."]
             VBG = 0x0,
@@ -1169,7 +1403,8 @@ pub mod adc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Res {
             #[doc = "8bit ADC resolution."]
             _8BIT = 0x0,
@@ -1330,6 +1565,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1375,6 +1630,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CCM RX MIC check result."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1396,6 +1677,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode."]
@@ -1421,6 +1722,22 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1442,6 +1759,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for the CCM."]
@@ -1467,10 +1804,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "CCM is disabled."]
             DISABLED = 0x0,
@@ -1502,7 +1860,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed."]
             CHECK_FAILED = 0x0,
@@ -1532,7 +1891,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "CCM mode TX"]
             ENCRYPTION = 0x0,
@@ -1712,6 +2072,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Task HFCLKSTART trigger status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1733,6 +2109,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "High frequency clock status."]
@@ -1767,6 +2163,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -1825,6 +2244,35 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Task LFCLKSTART triggered status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1846,6 +2294,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK clock."]
@@ -1871,6 +2339,24 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for the LFCLK clock, set when task LKCLKSTART is triggered."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1892,6 +2378,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Low frequency clock status."]
@@ -1928,6 +2432,29 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Crystal frequency."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1951,10 +2478,31 @@ pub mod clock {
                 Xtalfreq(0)
             }
         }
+        impl core::fmt::Debug for Xtalfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xtalfreq")
+                    .field("xtalfreq", &self.xtalfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xtalfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xtalfreq {
+                    xtalfreq: super::vals::Xtalfreq,
+                }
+                let proxy = Xtalfreq {
+                    xtalfreq: self.xtalfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "Internal 16MHz RC oscillator running and generating the HFCLK clock."]
             RC = 0x0,
@@ -1984,7 +2532,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "Internal 32KiHz RC oscillator."]
             RC = 0x0,
@@ -2031,6 +2580,25 @@ pub mod clock {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Xtalfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("_32MHZ"),
+                    0xff => f.write_str("_16MHZ"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xtalfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "_32MHZ"),
+                    0xff => defmt::write!(f, "_16MHZ"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Xtalfreq {
@@ -2217,6 +2785,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2238,6 +2829,26 @@ pub mod ecb {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -2384,6 +2995,29 @@ pub mod ficr {
                 Configid(0)
             }
         }
+        impl core::fmt::Debug for Configid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configid")
+                    .field("hwid", &self.hwid())
+                    .field("fwid", &self.fwid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configid {
+                    hwid: u16,
+                    fwid: u16,
+                }
+                let proxy = Configid {
+                    hwid: self.hwid(),
+                    fwid: self.fwid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2405,6 +3039,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio calibration override enable."]
@@ -2441,6 +3095,29 @@ pub mod ficr {
                 Overrideen(0)
             }
         }
+        impl core::fmt::Debug for Overrideen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Overrideen")
+                    .field("nrf_1mbit", &self.nrf_1mbit())
+                    .field("ble_1mbit", &self.ble_1mbit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Overrideen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Overrideen {
+                    nrf_1mbit: super::vals::Nrf1mbit,
+                    ble_1mbit: super::vals::Ble1mbit,
+                }
+                let proxy = Overrideen {
+                    nrf_1mbit: self.nrf_1mbit(),
+                    ble_1mbit: self.ble_1mbit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pre-programmed factory code present."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2464,10 +3141,27 @@ pub mod ficr {
                 Ppfc(0)
             }
         }
+        impl core::fmt::Debug for Ppfc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ppfc").field("ppfc", &self.ppfc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ppfc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ppfc {
+                    ppfc: super::vals::Ppfc,
+                }
+                let proxy = Ppfc { ppfc: self.ppfc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ble1mbit {
             #[doc = "Override the default values for BLE_1Mbit mode."]
             OVERRIDE = 0x0,
@@ -2497,7 +3191,8 @@ pub mod ficr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address."]
             PUBLIC = 0x0,
@@ -2527,7 +3222,8 @@ pub mod ficr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nrf1mbit {
             #[doc = "Override the default values for NRF_1Mbit mode."]
             OVERRIDE = 0x0,
@@ -2571,6 +3267,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ppfc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PRESENT"),
+                    0xff => f.write_str("NOT_PRESENT"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ppfc {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PRESENT"),
+                    0xff => defmt::write!(f, "NOT_PRESENT"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Ppfc {
@@ -2677,6 +3392,95 @@ pub mod gpio {
                 Dir(0)
             }
         }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2702,6 +3506,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirclr {
                 Dirclr(0)
+            }
+        }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR set register."]
@@ -2731,6 +3624,95 @@ pub mod gpio {
                 Dirset(0)
             }
         }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read GPIO port."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2756,6 +3738,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> In {
                 In(0)
+            }
+        }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port."]
@@ -2785,6 +3856,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2812,6 +3972,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2837,6 +4086,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of GPIO pins."]
@@ -2907,10 +4245,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin."]
             INPUT = 0x0,
@@ -2940,7 +4311,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', Standard '1'."]
             S0S1 = 0x0,
@@ -2982,7 +4354,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input pin."]
             CONNECT = 0x0,
@@ -3012,7 +4385,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull."]
             DISABLED = 0x0,
@@ -3045,7 +4419,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled."]
             DISABLED = 0x0,
@@ -3194,6 +4569,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3232,6 +4636,42 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 4usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3255,10 +4695,31 @@ pub mod gpiote {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled."]
             DISABLED = 0x0,
@@ -3291,7 +4752,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Initial low output when in task mode."]
             LOW = 0x0,
@@ -3321,7 +4783,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "No task or event."]
             NONE = 0x0,
@@ -3483,6 +4946,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the LPCOMP."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3506,6 +4989,26 @@ pub mod lpcomp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3527,6 +5030,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Extrefsel {
                 Extrefsel(0)
+            }
+        }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -3585,6 +5108,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3606,6 +5158,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Input pin select."]
@@ -3631,6 +5203,22 @@ pub mod lpcomp {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reference select."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3654,6 +5242,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Result of last compare."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3675,6 +5283,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for the LPCOMP."]
@@ -3744,10 +5372,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETEC on crossing, both upwards and downwards crossing."]
             CROSS = 0x0,
@@ -3780,7 +5441,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disabled LPCOMP."]
             DISABLED = 0x0,
@@ -3812,7 +5474,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use analog reference 0 as reference."]
             ANALOG_REFERENCE0 = 0x0,
@@ -3842,7 +5505,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "Use analog input 0 as analog input."]
             ANALOG_INPUT0 = 0x0,
@@ -3884,7 +5548,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Use supply with a 1/8 prescaler as reference."]
             SUPPLY_ONE_EIGHTH_PRESCALING = 0x0,
@@ -3926,7 +5591,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is bellow the reference threshold."]
             BELOW = 0x0,
@@ -4031,6 +5697,26 @@ pub mod mpu {
             #[inline(always)]
             fn default() -> Disableindebug {
                 Disableindebug(0)
+            }
+        }
+        impl core::fmt::Debug for Disableindebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disableindebug")
+                    .field("disableindebug", &self.disableindebug())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disableindebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disableindebug {
+                    disableindebug: super::vals::Disableindebug,
+                }
+                let proxy = Disableindebug {
+                    disableindebug: self.disableindebug(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of peripherals in mpu regions."]
@@ -4288,6 +5974,86 @@ pub mod mpu {
                 Perr0(0)
             }
         }
+        impl core::fmt::Debug for Perr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perr0")
+                    .field("power_clock", &self.power_clock())
+                    .field("radio", &self.radio())
+                    .field("uart0", &self.uart0())
+                    .field("spi0_twi0", &self.spi0_twi0())
+                    .field("spi1_twi1", &self.spi1_twi1())
+                    .field("gpiote", &self.gpiote())
+                    .field("adc", &self.adc())
+                    .field("timer0", &self.timer0())
+                    .field("timer1", &self.timer1())
+                    .field("timer2", &self.timer2())
+                    .field("rtc0", &self.rtc0())
+                    .field("temp", &self.temp())
+                    .field("rng", &self.rng())
+                    .field("ecb", &self.ecb())
+                    .field("ccm_aar", &self.ccm_aar())
+                    .field("wdt", &self.wdt())
+                    .field("rtc1", &self.rtc1())
+                    .field("qdec", &self.qdec())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("nvmc", &self.nvmc())
+                    .field("ppi", &self.ppi())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perr0 {
+                    power_clock: super::vals::PowerClock,
+                    radio: super::vals::Radio,
+                    uart0: super::vals::Uart0,
+                    spi0_twi0: super::vals::Spi0Twi0,
+                    spi1_twi1: super::vals::Spi1Twi1,
+                    gpiote: super::vals::Gpiote,
+                    adc: super::vals::Adc,
+                    timer0: super::vals::Timer0,
+                    timer1: super::vals::Timer1,
+                    timer2: super::vals::Timer2,
+                    rtc0: super::vals::Rtc0,
+                    temp: super::vals::Temp,
+                    rng: super::vals::Rng,
+                    ecb: super::vals::Ecb,
+                    ccm_aar: super::vals::CcmAar,
+                    wdt: super::vals::Wdt,
+                    rtc1: super::vals::Rtc1,
+                    qdec: super::vals::Qdec,
+                    lpcomp: super::vals::Lpcomp,
+                    nvmc: super::vals::Nvmc,
+                    ppi: super::vals::Ppi,
+                }
+                let proxy = Perr0 {
+                    power_clock: self.power_clock(),
+                    radio: self.radio(),
+                    uart0: self.uart0(),
+                    spi0_twi0: self.spi0_twi0(),
+                    spi1_twi1: self.spi1_twi1(),
+                    gpiote: self.gpiote(),
+                    adc: self.adc(),
+                    timer0: self.timer0(),
+                    timer1: self.timer1(),
+                    timer2: self.timer2(),
+                    rtc0: self.rtc0(),
+                    temp: self.temp(),
+                    rng: self.rng(),
+                    ecb: self.ecb(),
+                    ccm_aar: self.ccm_aar(),
+                    wdt: self.wdt(),
+                    rtc1: self.rtc1(),
+                    qdec: self.qdec(),
+                    lpcomp: self.lpcomp(),
+                    nvmc: self.nvmc(),
+                    ppi: self.ppi(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Erase and write protection block size."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4309,6 +6075,26 @@ pub mod mpu {
             #[inline(always)]
             fn default() -> Protblocksize {
                 Protblocksize(0)
+            }
+        }
+        impl core::fmt::Debug for Protblocksize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Protblocksize")
+                    .field("protblocksize", &self.protblocksize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Protblocksize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Protblocksize {
+                    protblocksize: super::vals::Protblocksize,
+                }
+                let proxy = Protblocksize {
+                    protblocksize: self.protblocksize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Erase and write protection bit enable set register."]
@@ -4697,6 +6483,119 @@ pub mod mpu {
                 Protenset0(0)
             }
         }
+        impl core::fmt::Debug for Protenset0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Protenset0")
+                    .field("protreg0", &self.protreg0())
+                    .field("protreg1", &self.protreg1())
+                    .field("protreg2", &self.protreg2())
+                    .field("protreg3", &self.protreg3())
+                    .field("protreg4", &self.protreg4())
+                    .field("protreg5", &self.protreg5())
+                    .field("protreg6", &self.protreg6())
+                    .field("protreg7", &self.protreg7())
+                    .field("protreg8", &self.protreg8())
+                    .field("protreg9", &self.protreg9())
+                    .field("protreg10", &self.protreg10())
+                    .field("protreg11", &self.protreg11())
+                    .field("protreg12", &self.protreg12())
+                    .field("protreg13", &self.protreg13())
+                    .field("protreg14", &self.protreg14())
+                    .field("protreg15", &self.protreg15())
+                    .field("protreg16", &self.protreg16())
+                    .field("protreg17", &self.protreg17())
+                    .field("protreg18", &self.protreg18())
+                    .field("protreg19", &self.protreg19())
+                    .field("protreg20", &self.protreg20())
+                    .field("protreg21", &self.protreg21())
+                    .field("protreg22", &self.protreg22())
+                    .field("protreg23", &self.protreg23())
+                    .field("protreg24", &self.protreg24())
+                    .field("protreg25", &self.protreg25())
+                    .field("protreg26", &self.protreg26())
+                    .field("protreg27", &self.protreg27())
+                    .field("protreg28", &self.protreg28())
+                    .field("protreg29", &self.protreg29())
+                    .field("protreg30", &self.protreg30())
+                    .field("protreg31", &self.protreg31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Protenset0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Protenset0 {
+                    protreg0: super::vals::Protreg0,
+                    protreg1: super::vals::Protreg1,
+                    protreg2: super::vals::Protreg2,
+                    protreg3: super::vals::Protreg3,
+                    protreg4: super::vals::Protreg4,
+                    protreg5: super::vals::Protreg5,
+                    protreg6: super::vals::Protreg6,
+                    protreg7: super::vals::Protreg7,
+                    protreg8: super::vals::Protreg8,
+                    protreg9: super::vals::Protreg9,
+                    protreg10: super::vals::Protreg10,
+                    protreg11: super::vals::Protreg11,
+                    protreg12: super::vals::Protreg12,
+                    protreg13: super::vals::Protreg13,
+                    protreg14: super::vals::Protreg14,
+                    protreg15: super::vals::Protreg15,
+                    protreg16: super::vals::Protreg16,
+                    protreg17: super::vals::Protreg17,
+                    protreg18: super::vals::Protreg18,
+                    protreg19: super::vals::Protreg19,
+                    protreg20: super::vals::Protreg20,
+                    protreg21: super::vals::Protreg21,
+                    protreg22: super::vals::Protreg22,
+                    protreg23: super::vals::Protreg23,
+                    protreg24: super::vals::Protreg24,
+                    protreg25: super::vals::Protreg25,
+                    protreg26: super::vals::Protreg26,
+                    protreg27: super::vals::Protreg27,
+                    protreg28: super::vals::Protreg28,
+                    protreg29: super::vals::Protreg29,
+                    protreg30: super::vals::Protreg30,
+                    protreg31: super::vals::Protreg31,
+                }
+                let proxy = Protenset0 {
+                    protreg0: self.protreg0(),
+                    protreg1: self.protreg1(),
+                    protreg2: self.protreg2(),
+                    protreg3: self.protreg3(),
+                    protreg4: self.protreg4(),
+                    protreg5: self.protreg5(),
+                    protreg6: self.protreg6(),
+                    protreg7: self.protreg7(),
+                    protreg8: self.protreg8(),
+                    protreg9: self.protreg9(),
+                    protreg10: self.protreg10(),
+                    protreg11: self.protreg11(),
+                    protreg12: self.protreg12(),
+                    protreg13: self.protreg13(),
+                    protreg14: self.protreg14(),
+                    protreg15: self.protreg15(),
+                    protreg16: self.protreg16(),
+                    protreg17: self.protreg17(),
+                    protreg18: self.protreg18(),
+                    protreg19: self.protreg19(),
+                    protreg20: self.protreg20(),
+                    protreg21: self.protreg21(),
+                    protreg22: self.protreg22(),
+                    protreg23: self.protreg23(),
+                    protreg24: self.protreg24(),
+                    protreg25: self.protreg25(),
+                    protreg26: self.protreg26(),
+                    protreg27: self.protreg27(),
+                    protreg28: self.protreg28(),
+                    protreg29: self.protreg29(),
+                    protreg30: self.protreg30(),
+                    protreg31: self.protreg31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Erase and write protection bit enable set register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5083,10 +6982,124 @@ pub mod mpu {
                 Protenset1(0)
             }
         }
+        impl core::fmt::Debug for Protenset1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Protenset1")
+                    .field("protreg32", &self.protreg32())
+                    .field("protreg33", &self.protreg33())
+                    .field("protreg34", &self.protreg34())
+                    .field("protreg35", &self.protreg35())
+                    .field("protreg36", &self.protreg36())
+                    .field("protreg37", &self.protreg37())
+                    .field("protreg38", &self.protreg38())
+                    .field("protreg39", &self.protreg39())
+                    .field("protreg40", &self.protreg40())
+                    .field("protreg41", &self.protreg41())
+                    .field("protreg42", &self.protreg42())
+                    .field("protreg43", &self.protreg43())
+                    .field("protreg44", &self.protreg44())
+                    .field("protreg45", &self.protreg45())
+                    .field("protreg46", &self.protreg46())
+                    .field("protreg47", &self.protreg47())
+                    .field("protreg48", &self.protreg48())
+                    .field("protreg49", &self.protreg49())
+                    .field("protreg50", &self.protreg50())
+                    .field("protreg51", &self.protreg51())
+                    .field("protreg52", &self.protreg52())
+                    .field("protreg53", &self.protreg53())
+                    .field("protreg54", &self.protreg54())
+                    .field("protreg55", &self.protreg55())
+                    .field("protreg56", &self.protreg56())
+                    .field("protreg57", &self.protreg57())
+                    .field("protreg58", &self.protreg58())
+                    .field("protreg59", &self.protreg59())
+                    .field("protreg60", &self.protreg60())
+                    .field("protreg61", &self.protreg61())
+                    .field("protreg62", &self.protreg62())
+                    .field("protreg63", &self.protreg63())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Protenset1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Protenset1 {
+                    protreg32: super::vals::Protreg32,
+                    protreg33: super::vals::Protreg33,
+                    protreg34: super::vals::Protreg34,
+                    protreg35: super::vals::Protreg35,
+                    protreg36: super::vals::Protreg36,
+                    protreg37: super::vals::Protreg37,
+                    protreg38: super::vals::Protreg38,
+                    protreg39: super::vals::Protreg39,
+                    protreg40: super::vals::Protreg40,
+                    protreg41: super::vals::Protreg41,
+                    protreg42: super::vals::Protreg42,
+                    protreg43: super::vals::Protreg43,
+                    protreg44: super::vals::Protreg44,
+                    protreg45: super::vals::Protreg45,
+                    protreg46: super::vals::Protreg46,
+                    protreg47: super::vals::Protreg47,
+                    protreg48: super::vals::Protreg48,
+                    protreg49: super::vals::Protreg49,
+                    protreg50: super::vals::Protreg50,
+                    protreg51: super::vals::Protreg51,
+                    protreg52: super::vals::Protreg52,
+                    protreg53: super::vals::Protreg53,
+                    protreg54: super::vals::Protreg54,
+                    protreg55: super::vals::Protreg55,
+                    protreg56: super::vals::Protreg56,
+                    protreg57: super::vals::Protreg57,
+                    protreg58: super::vals::Protreg58,
+                    protreg59: super::vals::Protreg59,
+                    protreg60: super::vals::Protreg60,
+                    protreg61: super::vals::Protreg61,
+                    protreg62: super::vals::Protreg62,
+                    protreg63: super::vals::Protreg63,
+                }
+                let proxy = Protenset1 {
+                    protreg32: self.protreg32(),
+                    protreg33: self.protreg33(),
+                    protreg34: self.protreg34(),
+                    protreg35: self.protreg35(),
+                    protreg36: self.protreg36(),
+                    protreg37: self.protreg37(),
+                    protreg38: self.protreg38(),
+                    protreg39: self.protreg39(),
+                    protreg40: self.protreg40(),
+                    protreg41: self.protreg41(),
+                    protreg42: self.protreg42(),
+                    protreg43: self.protreg43(),
+                    protreg44: self.protreg44(),
+                    protreg45: self.protreg45(),
+                    protreg46: self.protreg46(),
+                    protreg47: self.protreg47(),
+                    protreg48: self.protreg48(),
+                    protreg49: self.protreg49(),
+                    protreg50: self.protreg50(),
+                    protreg51: self.protreg51(),
+                    protreg52: self.protreg52(),
+                    protreg53: self.protreg53(),
+                    protreg54: self.protreg54(),
+                    protreg55: self.protreg55(),
+                    protreg56: self.protreg56(),
+                    protreg57: self.protreg57(),
+                    protreg58: self.protreg58(),
+                    protreg59: self.protreg59(),
+                    protreg60: self.protreg60(),
+                    protreg61: self.protreg61(),
+                    protreg62: self.protreg62(),
+                    protreg63: self.protreg63(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Adc {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5116,7 +7129,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CcmAar {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5146,7 +7160,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Disableindebug {
             #[doc = "Protection enabled."]
             ENABLED = 0x0,
@@ -5176,7 +7191,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ecb {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5206,7 +7222,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gpiote {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5236,7 +7253,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lpcomp {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5266,7 +7284,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nvmc {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5296,7 +7315,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PowerClock {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5326,7 +7346,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ppi {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -5356,7 +7377,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protblocksize {
             #[doc = "Erase and write protection block size is 4k."]
             _4K = 0x0,
@@ -5387,7 +7409,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg0 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5417,7 +7440,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg1 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5447,7 +7471,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg10 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5477,7 +7502,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg11 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5507,7 +7533,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg12 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5537,7 +7564,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg13 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5567,7 +7595,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg14 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5597,7 +7626,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg15 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5627,7 +7657,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg16 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5657,7 +7688,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg17 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5687,7 +7719,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg18 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5717,7 +7750,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg19 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5747,7 +7781,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg2 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5777,7 +7812,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg20 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5807,7 +7843,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg21 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5837,7 +7874,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg22 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5867,7 +7905,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg23 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5897,7 +7936,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg24 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5927,7 +7967,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg25 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5957,7 +7998,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg26 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -5987,7 +8029,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg27 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6017,7 +8060,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg28 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6047,7 +8091,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg29 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6077,7 +8122,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg3 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6107,7 +8153,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg30 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6137,7 +8184,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg31 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6167,7 +8215,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg32 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6197,7 +8246,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg33 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6227,7 +8277,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg34 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6257,7 +8308,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg35 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6287,7 +8339,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg36 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6317,7 +8370,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg37 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6347,7 +8401,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg38 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6377,7 +8432,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg39 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6407,7 +8463,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg4 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6437,7 +8494,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg40 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6467,7 +8525,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg41 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6497,7 +8556,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg42 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6527,7 +8587,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg43 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6557,7 +8618,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg44 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6587,7 +8649,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg45 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6617,7 +8680,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg46 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6647,7 +8711,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg47 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6677,7 +8742,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg48 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6707,7 +8773,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg49 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6737,7 +8804,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg5 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6767,7 +8835,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg50 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6797,7 +8866,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg51 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6827,7 +8897,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg52 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6857,7 +8928,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg53 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6887,7 +8959,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg54 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6917,7 +8990,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg55 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6947,7 +9021,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg56 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -6977,7 +9052,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg57 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7007,7 +9083,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg58 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7037,7 +9114,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg59 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7067,7 +9145,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg6 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7097,7 +9176,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg60 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7127,7 +9207,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg61 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7157,7 +9238,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg62 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7187,7 +9269,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg63 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7217,7 +9300,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg7 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7247,7 +9331,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg8 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7277,7 +9362,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protreg9 {
             #[doc = "Protection disabled."]
             DISABLED = 0x0,
@@ -7307,7 +9393,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Qdec {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7337,7 +9424,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Radio {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7367,7 +9455,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rng {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7397,7 +9486,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rtc0 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7427,7 +9517,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rtc1 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7457,7 +9548,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Spi0Twi0 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7487,7 +9579,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Spi1Twi1 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7517,7 +9610,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Temp {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7547,7 +9641,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Timer0 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7577,7 +9672,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Timer1 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7607,7 +9703,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Timer2 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7637,7 +9734,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Uart0 {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7667,7 +9765,8 @@ pub mod mpu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wdt {
             #[doc = "Peripheral configured in region 1."]
             IN_REGION1 = 0x0,
@@ -7775,6 +9874,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7796,6 +9911,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for start erasing User Information Congfiguration Registers."]
@@ -7821,6 +9956,26 @@ pub mod nvmc {
                 Eraseuicr(0)
             }
         }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7844,10 +9999,31 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access."]
             REN = 0x0,
@@ -7998,6 +10174,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DCDC power-up force register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8032,6 +10228,29 @@ pub mod power {
                 Dcdcforce(0)
             }
         }
+        impl core::fmt::Debug for Dcdcforce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcforce")
+                    .field("forceoff", &self.forceoff())
+                    .field("forceon", &self.forceon())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcforce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcforce {
+                    forceoff: bool,
+                    forceon: bool,
+                }
+                let proxy = Dcdcforce {
+                    forceoff: self.forceoff(),
+                    forceon: self.forceon(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register. This register is a retained register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8055,6 +10274,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8076,6 +10315,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power failure configuration."]
@@ -8110,6 +10369,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Pofcon {
                 Pofcon(0)
+            }
+        }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ram on/off."]
@@ -8170,6 +10452,35 @@ pub mod power {
                 Ramon(0)
             }
         }
+        impl core::fmt::Debug for Ramon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramon")
+                    .field("onram0", &self.onram0())
+                    .field("onram1", &self.onram1())
+                    .field("offram0", &self.offram0())
+                    .field("offram1", &self.offram1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramon {
+                    onram0: super::vals::Onram0,
+                    onram1: super::vals::Onram1,
+                    offram0: super::vals::Offram0,
+                    offram1: super::vals::Offram1,
+                }
+                let proxy = Ramon {
+                    onram0: self.onram0(),
+                    onram1: self.onram1(),
+                    offram0: self.offram0(),
+                    offram1: self.offram1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ram on/off."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8228,6 +10539,35 @@ pub mod power {
                 Ramonb(0)
             }
         }
+        impl core::fmt::Debug for Ramonb {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramonb")
+                    .field("onram2", &self.onram2())
+                    .field("onram3", &self.onram3())
+                    .field("offram2", &self.offram2())
+                    .field("offram3", &self.offram3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramonb {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramonb {
+                    onram2: super::vals::Onram2,
+                    onram3: super::vals::Onram3,
+                    offram2: super::vals::Offram2,
+                    offram3: super::vals::Offram3,
+                }
+                let proxy = Ramonb {
+                    onram2: self.onram2(),
+                    onram3: self.onram3(),
+                    offram2: self.offram2(),
+                    offram3: self.offram3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ram status register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8284,6 +10624,35 @@ pub mod power {
                 Ramstatus(0)
             }
         }
+        impl core::fmt::Debug for Ramstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramstatus")
+                    .field("ramblock0", &self.ramblock0())
+                    .field("ramblock1", &self.ramblock1())
+                    .field("ramblock2", &self.ramblock2())
+                    .field("ramblock3", &self.ramblock3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramstatus {
+                    ramblock0: bool,
+                    ramblock1: bool,
+                    ramblock2: bool,
+                    ramblock3: bool,
+                }
+                let proxy = Ramstatus {
+                    ramblock0: self.ramblock0(),
+                    ramblock1: self.ramblock1(),
+                    ramblock2: self.ramblock2(),
+                    ramblock3: self.ramblock3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin reset functionality configuration register. This register is a retained register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8305,6 +10674,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Reset {
                 Reset(0)
+            }
+        }
+        impl core::fmt::Debug for Reset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reset {
+                    reset: bool,
+                }
+                let proxy = Reset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason."]
@@ -8396,6 +10785,44 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System off register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8419,10 +10846,31 @@ pub mod power {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram0 {
             #[doc = "RAM block 0 OFF in OFF mode."]
             RAM0OFF = 0x0,
@@ -8452,7 +10900,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram1 {
             #[doc = "RAM block 1 OFF in OFF mode."]
             RAM1OFF = 0x0,
@@ -8482,7 +10931,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram2 {
             #[doc = "RAM block 2 OFF in OFF mode."]
             RAM2OFF = 0x0,
@@ -8512,7 +10962,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram3 {
             #[doc = "RAM block 3 OFF in OFF mode."]
             RAM3OFF = 0x0,
@@ -8542,7 +10993,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram0 {
             #[doc = "RAM block 0 OFF in ON mode."]
             RAM0OFF = 0x0,
@@ -8572,7 +11024,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram1 {
             #[doc = "RAM block 1 OFF in ON mode."]
             RAM1OFF = 0x0,
@@ -8602,7 +11055,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram2 {
             #[doc = "RAM block 2 OFF in ON mode."]
             RAM2OFF = 0x0,
@@ -8632,7 +11086,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram3 {
             #[doc = "RAM block 33 OFF in ON mode."]
             RAM3OFF = 0x0,
@@ -8662,7 +11117,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             #[doc = "Set threshold to 2.1Volts."]
             V21 = 0x0,
@@ -8830,6 +11286,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Channel group configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8855,6 +11400,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -9021,6 +11655,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of ACCDBL register. Value generated by the TASKS_READCLEACC task."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9042,6 +11696,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable debouncer input filters."]
@@ -9067,6 +11741,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the QDEC."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9088,6 +11782,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -9135,6 +11849,32 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9156,6 +11896,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time LED is switched ON before the sample."]
@@ -9181,6 +11941,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9202,6 +11982,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of samples to generate an EVENT_REPORTRDY."]
@@ -9227,6 +12027,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9248,6 +12068,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for the QDEC."]
@@ -9284,10 +12124,34 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "LED output is active low."]
             ACTIVE_LOW = 0x0,
@@ -9317,7 +12181,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples per report."]
             _10SMPL = 0x0,
@@ -9359,7 +12224,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128us sample period."]
             _128US = 0x0,
@@ -9732,6 +12598,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9754,6 +12643,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial."]
@@ -9780,6 +12689,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status of received packet."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9801,6 +12730,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration."]
@@ -9991,6 +12940,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10012,6 +13026,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address prefix."]
@@ -10037,6 +13067,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10060,6 +13106,26 @@ pub mod radio {
                 Datawhiteiv(0)
             }
         }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frequency."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10081,6 +13147,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -10194,6 +13280,50 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10215,6 +13345,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Trim value override register 4."]
@@ -10250,6 +13396,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Override4 {
                 Override4(0)
+            }
+        }
+        impl core::fmt::Debug for Override4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Override4")
+                    .field("override4", &self.override4())
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Override4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Override4 {
+                    override4: u32,
+                    enable: bool,
+                }
+                let proxy = Override4 {
+                    override4: self.override4(),
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration 0."]
@@ -10295,6 +13464,32 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Pcnf0 {
                 Pcnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration 1."]
@@ -10365,6 +13560,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10386,6 +13613,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0 to 3."]
@@ -10444,6 +13691,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4 to 7."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10500,6 +13776,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10521,6 +13826,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select."]
@@ -10623,6 +13948,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Received CRC."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10647,6 +14013,26 @@ pub mod radio {
                 Rxcrc(0)
             }
         }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Received address."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10668,6 +14054,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxmatch {
                 Rxmatch(0)
+            }
+        }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for the radio."]
@@ -10770,6 +14176,47 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10791,6 +14238,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Test features enable register."]
@@ -10827,6 +14294,29 @@ pub mod radio {
                 Test(0)
             }
         }
+        impl core::fmt::Debug for Test {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Test")
+                    .field("constcarrier", &self.constcarrier())
+                    .field("plllock", &self.plllock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Test {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Test {
+                    constcarrier: bool,
+                    plllock: bool,
+                }
+                let proxy = Test {
+                    constcarrier: self.constcarrier(),
+                    plllock: self.plllock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Inter Frame Spacing in microseconds."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10848,6 +14338,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u8,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmit address select."]
@@ -10873,6 +14379,26 @@ pub mod radio {
                 Txaddress(0)
             }
         }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output power."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10896,10 +14422,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error."]
             CRCERROR = 0x0,
@@ -10929,7 +14476,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -10959,7 +14507,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC calculation disabled."]
             DISABLED = 0x0,
@@ -10993,7 +14542,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1Mbit/s Nordic propietary radio mode."]
             NRF_1MBIT = 0x0,
@@ -11027,7 +14577,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "Include packet address in CRC calculation."]
             INCLUDE = 0x0,
@@ -11057,7 +14608,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Radio is in the Disabled state."]
             DISABLED = 0x0,
@@ -11108,7 +14660,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0dBm."]
             _0_DBM = 0x0,
@@ -11486,6 +15039,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11507,6 +15080,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral power control."]
@@ -11532,6 +15125,26 @@ pub mod rng {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts for the RNG."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11555,6 +15168,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RNG random number."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11576,6 +15209,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11705,6 +15358,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11727,6 +15400,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configures event enable routing to PPI for each RTC event."]
@@ -11778,6 +15471,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11827,6 +15559,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11850,6 +15621,26 @@ pub mod rtc {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for COUNTER frequency (32768/(PRESCALER+1)). Must be written when RTC is STOPed."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11871,6 +15662,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11999,6 +15810,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12020,6 +15857,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency"]
@@ -12046,6 +15903,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12067,6 +15944,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral power control."]
@@ -12092,6 +15987,26 @@ pub mod spi {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RX data."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12113,6 +16028,22 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "TX data."]
@@ -12138,10 +16069,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of the clock. Shift serial data on trailing edge."]
             LEADING = 0x0,
@@ -12171,7 +16119,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high."]
             ACTIVE_HIGH = 0x0,
@@ -12201,7 +16150,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disabled SPI."]
             DISABLED = 0x0,
@@ -12263,6 +16213,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -12276,7 +16255,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit transmitted out first."]
             MSB_FIRST = 0x0,
@@ -12474,6 +16454,26 @@ pub mod spis {
                 Amountrx(0)
             }
         }
+        impl core::fmt::Debug for Amountrx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amountrx")
+                    .field("amountrx", &self.amountrx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amountrx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amountrx {
+                    amountrx: u8,
+                }
+                let proxy = Amountrx {
+                    amountrx: self.amountrx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12495,6 +16495,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Amounttx {
                 Amounttx(0)
+            }
+        }
+        impl core::fmt::Debug for Amounttx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amounttx")
+                    .field("amounttx", &self.amounttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amounttx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amounttx {
+                    amounttx: u8,
+                }
+                let proxy = Amounttx {
+                    amounttx: self.amounttx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration register."]
@@ -12542,6 +16562,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12565,6 +16611,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIS."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12586,6 +16648,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -12633,6 +16715,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in the receive buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12654,6 +16762,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Maxrx {
                 Maxrx(0)
+            }
+        }
+        impl core::fmt::Debug for Maxrx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxrx")
+                    .field("maxrx", &self.maxrx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxrx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxrx {
+                    maxrx: u8,
+                }
+                let proxy = Maxrx {
+                    maxrx: self.maxrx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in the transmit buffer."]
@@ -12679,6 +16807,26 @@ pub mod spis {
                 Maxtx(0)
             }
         }
+        impl core::fmt::Debug for Maxtx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxtx")
+                    .field("maxtx", &self.maxtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxtx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxtx {
+                    maxtx: u8,
+                }
+                let proxy = Maxtx {
+                    maxtx: self.maxtx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12700,6 +16848,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral power control."]
@@ -12725,6 +16889,26 @@ pub mod spis {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12748,6 +16932,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts for SPIS."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12769,6 +16973,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction."]
@@ -12805,10 +17029,34 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of the clock. Shift serial data on trailing edge."]
             LEADING = 0x0,
@@ -12838,7 +17086,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high."]
             ACTIVE_HIGH = 0x0,
@@ -12868,7 +17117,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disabled SPIS."]
             DISABLED = 0x0,
@@ -12904,7 +17154,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit transmitted out first."]
             MSB_FIRST = 0x0,
@@ -12934,7 +17185,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free."]
             FREE = 0x0,
@@ -13070,6 +17322,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13091,6 +17363,26 @@ pub mod temp {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -13215,6 +17507,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13242,6 +17554,39 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer Mode selection."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13263,6 +17608,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral power control."]
@@ -13288,6 +17649,26 @@ pub mod timer {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "4-bit prescaler to source clock frequency (max value 9). Source clock frequency is divided by 2^SCALE."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13309,6 +17690,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for Timer."]
@@ -13353,10 +17754,60 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 4usize],
+                    compare_stop: [bool; 4usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16-bit timer behaviour."]
             _16BIT = 0x0,
@@ -13390,7 +17841,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Timer in Normal mode."]
             TIMER = 0x0,
@@ -13578,6 +18030,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable two-wire master."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13599,6 +18071,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Two-wire error source. Write error field to 1 to clear error."]
@@ -13646,6 +18138,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Two-wire frequency."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13668,6 +18186,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -13748,6 +18286,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13771,6 +18344,26 @@ pub mod twi {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RX data register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13792,6 +18385,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for TWI."]
@@ -13828,6 +18437,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TX data register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13851,10 +18483,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disabled."]
             DISABLED = 0x0,
@@ -13906,6 +18555,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -14090,6 +18760,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14124,6 +18814,29 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART and acquire IOs."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14145,6 +18858,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source. Write error field to 1 to clear error."]
@@ -14201,6 +18934,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt enable clear register."]
@@ -14281,6 +19043,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14304,6 +19101,26 @@ pub mod uart {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register. On read action the buffer pointer is displaced. Once read the character is consumed. If read when no character available, the UART will stop working."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14325,6 +19142,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts for UART."]
@@ -14361,6 +19194,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14382,6 +19238,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14435,6 +19307,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -14448,7 +19371,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Parity bit excluded."]
             EXCLUDED = 0x0,
@@ -14484,7 +19408,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "UART disabled."]
             DISABLED = 0x0,
@@ -14606,6 +19531,22 @@ pub mod uicr {
                 Fwid(0)
             }
         }
+        impl core::fmt::Debug for Fwid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fwid").field("fwid", &self.fwid()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fwid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fwid {
+                    fwid: u16,
+                }
+                let proxy = Fwid { fwid: self.fwid() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Readback protection configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14640,6 +19581,29 @@ pub mod uicr {
                 Rbpconf(0)
             }
         }
+        impl core::fmt::Debug for Rbpconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rbpconf")
+                    .field("pr0", &self.pr0())
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rbpconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rbpconf {
+                    pr0: super::vals::Pr0,
+                    pall: super::vals::Pall,
+                }
+                let proxy = Rbpconf {
+                    pr0: self.pr0(),
+                    pall: self.pall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset value for CLOCK XTALFREQ register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14663,6 +19627,26 @@ pub mod uicr {
                 Xtalfreq(0)
             }
         }
+        impl core::fmt::Debug for Xtalfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xtalfreq")
+                    .field("xtalfreq", &self.xtalfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xtalfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xtalfreq {
+                    xtalfreq: super::vals::Xtalfreq,
+                }
+                let proxy = Xtalfreq {
+                    xtalfreq: self.xtalfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -14680,6 +19664,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Pall {
@@ -14711,6 +19714,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pr0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Pr0 {
             #[inline(always)]
             fn from(val: u8) -> Pr0 {
@@ -14738,6 +19760,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Xtalfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("_32MHZ"),
+                    0xff => f.write_str("_16MHZ"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xtalfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "_32MHZ"),
+                    0xff => defmt::write!(f, "_16MHZ"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Xtalfreq {
@@ -14863,6 +19904,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt enable clear register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14886,6 +19950,26 @@ pub mod wdt {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14907,6 +19991,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status."]
@@ -14936,6 +20040,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reload requests registers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14958,6 +20103,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reload request enable."]
@@ -14987,6 +20148,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Watchdog running status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15010,10 +20212,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger."]
             PAUSE = 0x0,
@@ -15057,6 +20280,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -15070,7 +20310,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is asleep."]
             PAUSE = 0x0,

--- a/src/chips/nrf52805/pac.rs
+++ b/src/chips/nrf52805/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -320,6 +321,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -365,6 +386,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -386,6 +433,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -411,10 +474,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -501,6 +585,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -524,6 +628,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -539,6 +663,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -566,6 +707,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -982,6 +1140,119 @@ pub mod bprot {
                 Config0(0)
             }
         }
+        impl core::fmt::Debug for Config0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config0")
+                    .field("region0", &self.region0())
+                    .field("region1", &self.region1())
+                    .field("region2", &self.region2())
+                    .field("region3", &self.region3())
+                    .field("region4", &self.region4())
+                    .field("region5", &self.region5())
+                    .field("region6", &self.region6())
+                    .field("region7", &self.region7())
+                    .field("region8", &self.region8())
+                    .field("region9", &self.region9())
+                    .field("region10", &self.region10())
+                    .field("region11", &self.region11())
+                    .field("region12", &self.region12())
+                    .field("region13", &self.region13())
+                    .field("region14", &self.region14())
+                    .field("region15", &self.region15())
+                    .field("region16", &self.region16())
+                    .field("region17", &self.region17())
+                    .field("region18", &self.region18())
+                    .field("region19", &self.region19())
+                    .field("region20", &self.region20())
+                    .field("region21", &self.region21())
+                    .field("region22", &self.region22())
+                    .field("region23", &self.region23())
+                    .field("region24", &self.region24())
+                    .field("region25", &self.region25())
+                    .field("region26", &self.region26())
+                    .field("region27", &self.region27())
+                    .field("region28", &self.region28())
+                    .field("region29", &self.region29())
+                    .field("region30", &self.region30())
+                    .field("region31", &self.region31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config0 {
+                    region0: bool,
+                    region1: bool,
+                    region2: bool,
+                    region3: bool,
+                    region4: bool,
+                    region5: bool,
+                    region6: bool,
+                    region7: bool,
+                    region8: bool,
+                    region9: bool,
+                    region10: bool,
+                    region11: bool,
+                    region12: bool,
+                    region13: bool,
+                    region14: bool,
+                    region15: bool,
+                    region16: bool,
+                    region17: bool,
+                    region18: bool,
+                    region19: bool,
+                    region20: bool,
+                    region21: bool,
+                    region22: bool,
+                    region23: bool,
+                    region24: bool,
+                    region25: bool,
+                    region26: bool,
+                    region27: bool,
+                    region28: bool,
+                    region29: bool,
+                    region30: bool,
+                    region31: bool,
+                }
+                let proxy = Config0 {
+                    region0: self.region0(),
+                    region1: self.region1(),
+                    region2: self.region2(),
+                    region3: self.region3(),
+                    region4: self.region4(),
+                    region5: self.region5(),
+                    region6: self.region6(),
+                    region7: self.region7(),
+                    region8: self.region8(),
+                    region9: self.region9(),
+                    region10: self.region10(),
+                    region11: self.region11(),
+                    region12: self.region12(),
+                    region13: self.region13(),
+                    region14: self.region14(),
+                    region15: self.region15(),
+                    region16: self.region16(),
+                    region17: self.region17(),
+                    region18: self.region18(),
+                    region19: self.region19(),
+                    region20: self.region20(),
+                    region21: self.region21(),
+                    region22: self.region22(),
+                    region23: self.region23(),
+                    region24: self.region24(),
+                    region25: self.region25(),
+                    region26: self.region26(),
+                    region27: self.region27(),
+                    region28: self.region28(),
+                    region29: self.region29(),
+                    region30: self.region30(),
+                    region31: self.region31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Block protect configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1170,6 +1441,71 @@ pub mod bprot {
                 Config1(0)
             }
         }
+        impl core::fmt::Debug for Config1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config1")
+                    .field("region32", &self.region32())
+                    .field("region33", &self.region33())
+                    .field("region34", &self.region34())
+                    .field("region35", &self.region35())
+                    .field("region36", &self.region36())
+                    .field("region37", &self.region37())
+                    .field("region38", &self.region38())
+                    .field("region39", &self.region39())
+                    .field("region40", &self.region40())
+                    .field("region41", &self.region41())
+                    .field("region42", &self.region42())
+                    .field("region43", &self.region43())
+                    .field("region44", &self.region44())
+                    .field("region45", &self.region45())
+                    .field("region46", &self.region46())
+                    .field("region47", &self.region47())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config1 {
+                    region32: bool,
+                    region33: bool,
+                    region34: bool,
+                    region35: bool,
+                    region36: bool,
+                    region37: bool,
+                    region38: bool,
+                    region39: bool,
+                    region40: bool,
+                    region41: bool,
+                    region42: bool,
+                    region43: bool,
+                    region44: bool,
+                    region45: bool,
+                    region46: bool,
+                    region47: bool,
+                }
+                let proxy = Config1 {
+                    region32: self.region32(),
+                    region33: self.region33(),
+                    region34: self.region34(),
+                    region35: self.region35(),
+                    region36: self.region36(),
+                    region37: self.region37(),
+                    region38: self.region38(),
+                    region39: self.region39(),
+                    region40: self.region40(),
+                    region41: self.region41(),
+                    region42: self.region42(),
+                    region43: self.region43(),
+                    region44: self.region44(),
+                    region45: self.region45(),
+                    region46: self.region46(),
+                    region47: self.region47(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable protection mechanism in debug mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1193,10 +1529,31 @@ pub mod bprot {
                 Disableindebug(0)
             }
         }
+        impl core::fmt::Debug for Disableindebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disableindebug")
+                    .field("disableindebug", &self.disableindebug())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disableindebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disableindebug {
+                    disableindebug: super::vals::Disableindebug,
+                }
+                let proxy = Disableindebug {
+                    disableindebug: self.disableindebug(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Disableindebug {
             #[doc = "Enabled in debug"]
             ENABLED = 0x0,
@@ -1368,6 +1725,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1413,6 +1790,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1436,6 +1839,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1457,6 +1880,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1506,6 +1949,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1527,6 +1996,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1552,10 +2041,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1589,7 +2099,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1621,7 +2132,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1651,7 +2163,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1681,7 +2194,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1711,7 +2225,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1890,6 +2405,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1911,6 +2442,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -1945,6 +2496,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -2003,6 +2577,35 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2024,6 +2627,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -2071,6 +2694,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2092,6 +2741,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -2128,10 +2795,34 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -2161,7 +2852,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             RC = 0x0,
@@ -2360,6 +3052,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -2436,6 +3151,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -2677,6 +3449,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2698,6 +3486,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -2723,6 +3527,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2744,6 +3564,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -2769,6 +3605,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2790,6 +3642,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -2815,6 +3683,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2836,6 +3720,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -2861,6 +3761,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2882,6 +3798,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -2907,6 +3839,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2930,6 +3878,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2951,6 +3915,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -2977,6 +3961,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2999,6 +4003,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -3025,6 +4049,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3047,6 +4087,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Ram {
                 Ram(0)
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T0"]
@@ -3072,6 +4128,22 @@ pub mod ficr {
                 T0(0)
             }
         }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3093,6 +4165,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T1 {
                 T1(0)
+            }
+        }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T2"]
@@ -3118,6 +4206,22 @@ pub mod ficr {
                 T2(0)
             }
         }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3141,6 +4245,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3162,6 +4282,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part variant, hardware version and production configuration"]
@@ -3188,10 +4324,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -3237,6 +4394,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xc0 => f.write_str("K192"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xc0 => defmt::write!(f, "K192"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -3264,6 +4440,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2004 => f.write_str("CA"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2004 => defmt::write!(f, "CA"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -3301,6 +4496,31 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2805 => f.write_str("N52805"),
+                    0x0005_2810 => f.write_str("N52810"),
+                    0x0005_2811 => f.write_str("N52811"),
+                    0x0005_2832 => f.write_str("N52832"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2805 => defmt::write!(f, "N52805"),
+                    0x0005_2810 => defmt::write!(f, "N52810"),
+                    0x0005_2811 => defmt::write!(f, "N52811"),
+                    0x0005_2832 => defmt::write!(f, "N52832"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -3328,6 +4548,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x18 => f.write_str("K24"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x18 => defmt::write!(f, "K24"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -3371,6 +4610,39 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4241 => f.write_str("AABA"),
+                    0x4141_4242 => f.write_str("AABB"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    0x4141_4341 => f.write_str("AACA"),
+                    0x4141_4342 => f.write_str("AACB"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4241 => defmt::write!(f, "AABA"),
+                    0x4141_4242 => defmt::write!(f, "AABB"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    0x4141_4341 => defmt::write!(f, "AACA"),
+                    0x4141_4342 => defmt::write!(f, "AACB"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -3483,6 +4755,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3508,6 +4800,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -3537,6 +4918,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3562,6 +5032,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -3591,6 +5150,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3616,6 +5264,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -3645,6 +5382,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3672,6 +5498,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3697,6 +5612,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -3767,10 +5771,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -3800,7 +5837,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -3830,7 +5868,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -3872,7 +5911,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -3902,7 +5942,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -3935,7 +5976,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -4091,6 +6133,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4129,10 +6200,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -4165,7 +6281,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -4195,7 +6312,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -4319,6 +6437,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4340,6 +6474,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -4365,6 +6519,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4386,6 +6560,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -4411,10 +6605,31 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -4593,6 +6808,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4616,6 +6851,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4637,6 +6892,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -4684,6 +6959,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power failure comparator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4716,6 +7017,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Pofcon {
                 Pofcon(0)
+            }
+        }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: RAMn power control register. The RAM size will vary depending on product variant, and the RAMn register will only be present if the corresponding RAM AHB slave is present on the device."]
@@ -4758,6 +7082,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("s_power", &[self.s_power(0usize), self.s_power(1usize)])
+                    .field(
+                        "s_retention",
+                        &[self.s_retention(0usize), self.s_retention(1usize)],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 2usize],
+                    s_retention: [bool; 2usize],
+                }
+                let proxy = Power {
+                    s_power: [self.s_power(0usize), self.s_power(1usize)],
+                    s_retention: [self.s_retention(0usize), self.s_retention(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -4838,6 +7188,41 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    dif: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    dif: self.dif(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4861,10 +7246,31 @@ pub mod power {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -5080,6 +7486,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5105,6 +7600,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -5308,6 +7892,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5329,6 +7933,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -5354,6 +7978,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5375,6 +8019,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -5444,6 +8108,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5465,6 +8161,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -5490,6 +8206,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5513,6 +8249,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5534,6 +8290,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -5625,10 +8401,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -5658,7 +8473,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -5709,7 +8525,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -6098,6 +8915,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6120,6 +8960,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -6146,6 +9006,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6167,6 +9047,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -6357,6 +9257,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6378,6 +9343,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -6403,6 +9384,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6424,6 +9421,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -6458,6 +9475,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -6626,6 +9666,65 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("phyend", &self.phyend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    txready: bool,
+                    rxready: bool,
+                    phyend: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    phyend: self.phyend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6647,6 +9746,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -6681,6 +9796,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -6764,6 +9902,41 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6832,6 +10005,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6855,6 +10060,26 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6876,6 +10101,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -6934,6 +10179,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6990,6 +10264,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7011,6 +10314,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -7113,6 +10436,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7137,6 +10501,26 @@ pub mod radio {
                 Rxcrc(0)
             }
         }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Received address"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7158,6 +10542,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxmatch {
                 Rxmatch(0)
+            }
+        }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -7304,6 +10708,59 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7325,6 +10782,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interframe spacing in us"]
@@ -7350,6 +10827,22 @@ pub mod radio {
                 Tifs(0)
             }
         }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7371,6 +10864,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -7396,10 +10909,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -7429,7 +10963,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -7459,7 +10994,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -7492,7 +11028,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -7522,7 +11059,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -7556,7 +11094,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -7586,7 +11125,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -7632,7 +11172,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -7662,7 +11203,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -7694,7 +11236,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -7724,7 +11267,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -7754,7 +11298,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -7786,7 +11331,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -7837,7 +11383,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -8212,6 +11759,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8233,6 +11800,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -8258,6 +11845,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8279,6 +11886,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8403,6 +12030,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8425,6 +12072,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -8476,6 +12143,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8525,6 +12231,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must be written when RTC is stopped"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8546,6 +12291,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8795,6 +12560,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8887,6 +12672,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8908,6 +12731,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -9018,6 +12861,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9052,6 +12978,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last results is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9073,6 +13022,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last results is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -9098,6 +13067,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9119,6 +13108,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -9144,6 +13153,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9165,6 +13194,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -9190,6 +13239,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9211,6 +13280,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -9248,6 +13335,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9271,10 +13381,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -9304,7 +13435,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -9346,7 +13478,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -9397,7 +13530,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -9465,7 +13599,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -9495,7 +13630,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -9529,7 +13665,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -9563,7 +13700,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -9593,7 +13731,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -9623,7 +13762,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -9663,7 +13803,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -9739,10 +13880,34 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -9918,6 +14083,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9939,6 +14130,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -9965,6 +14176,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9986,6 +14217,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -10011,6 +14260,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10034,10 +14299,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -10067,7 +14349,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -10097,7 +14380,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -10167,6 +14451,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -10180,7 +14493,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -10480,6 +14794,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10501,6 +14841,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -10525,6 +14885,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -10594,6 +14974,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case and over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10615,6 +15027,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -10640,6 +15068,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10661,6 +15109,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -10686,6 +15152,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10707,6 +15193,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -10732,6 +15238,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10753,6 +15279,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -10778,10 +15322,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -10811,7 +15376,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -10841,7 +15407,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -10911,6 +15478,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -10924,7 +15520,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -10954,7 +15551,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -10986,7 +15584,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -11283,6 +15882,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11306,6 +15931,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11327,6 +15968,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -11374,6 +16035,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11395,6 +16082,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -11420,6 +16123,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11441,6 +16164,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -11466,6 +16207,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11489,6 +16250,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11510,6 +16291,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -11546,6 +16347,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11567,6 +16391,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -11592,6 +16436,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11615,10 +16477,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -11648,7 +16531,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -11678,7 +16562,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -11722,7 +16607,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -11752,7 +16638,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -11784,7 +16671,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -11818,7 +16706,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -11965,6 +16854,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -12082,6 +16991,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12109,6 +17038,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12132,6 +17098,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12153,6 +17135,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12197,10 +17199,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -12234,7 +17294,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -12442,6 +17503,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12463,6 +17544,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -12510,6 +17611,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12532,6 +17659,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -12612,6 +17759,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12633,6 +17815,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12669,6 +17867,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12692,10 +17913,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -12755,6 +17993,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -13029,6 +18288,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13050,6 +18329,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -13097,6 +18396,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13119,6 +18444,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -13210,6 +18555,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13231,6 +18614,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13256,6 +18659,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13277,6 +18698,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13357,6 +18798,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13378,6 +18854,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13403,6 +18899,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13426,10 +18940,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -13491,6 +19026,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -13504,7 +19060,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13540,7 +19097,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13844,6 +19402,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13878,6 +19456,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13899,6 +19500,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -13944,6 +19565,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14024,6 +19671,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14045,6 +19727,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -14070,6 +19772,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14091,6 +19809,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14116,6 +19854,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14137,6 +19893,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14173,6 +19949,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14194,6 +19993,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14219,6 +20038,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14242,10 +20079,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -14289,7 +20147,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14321,7 +20180,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14539,6 +20399,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14584,6 +20464,32 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14605,6 +20511,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14661,6 +20587,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14741,6 +20696,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14762,6 +20752,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14798,6 +20804,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14819,6 +20848,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14872,6 +20917,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -14885,7 +20981,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -14921,7 +21018,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -14965,7 +21063,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -15275,6 +21374,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15320,6 +21439,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15341,6 +21486,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -15397,6 +21562,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15532,6 +21726,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15555,6 +21799,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15576,6 +21840,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15612,6 +21896,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15635,6 +21942,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15656,6 +21983,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -15709,6 +22056,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -15722,7 +22120,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -15758,7 +22157,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -15802,7 +22202,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -15913,6 +22314,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -15932,6 +22351,27 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Pall {
@@ -16052,6 +22492,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16073,6 +22536,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -16102,6 +22585,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16124,6 +22648,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -16153,6 +22693,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16176,10 +22757,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -16223,6 +22825,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -16236,7 +22855,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52810/pac.rs
+++ b/src/chips/nrf52810/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -339,6 +340,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -384,6 +405,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -405,6 +452,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -430,10 +493,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -520,6 +604,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -543,6 +647,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -558,6 +682,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -585,6 +726,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -1001,6 +1159,119 @@ pub mod bprot {
                 Config0(0)
             }
         }
+        impl core::fmt::Debug for Config0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config0")
+                    .field("region0", &self.region0())
+                    .field("region1", &self.region1())
+                    .field("region2", &self.region2())
+                    .field("region3", &self.region3())
+                    .field("region4", &self.region4())
+                    .field("region5", &self.region5())
+                    .field("region6", &self.region6())
+                    .field("region7", &self.region7())
+                    .field("region8", &self.region8())
+                    .field("region9", &self.region9())
+                    .field("region10", &self.region10())
+                    .field("region11", &self.region11())
+                    .field("region12", &self.region12())
+                    .field("region13", &self.region13())
+                    .field("region14", &self.region14())
+                    .field("region15", &self.region15())
+                    .field("region16", &self.region16())
+                    .field("region17", &self.region17())
+                    .field("region18", &self.region18())
+                    .field("region19", &self.region19())
+                    .field("region20", &self.region20())
+                    .field("region21", &self.region21())
+                    .field("region22", &self.region22())
+                    .field("region23", &self.region23())
+                    .field("region24", &self.region24())
+                    .field("region25", &self.region25())
+                    .field("region26", &self.region26())
+                    .field("region27", &self.region27())
+                    .field("region28", &self.region28())
+                    .field("region29", &self.region29())
+                    .field("region30", &self.region30())
+                    .field("region31", &self.region31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config0 {
+                    region0: bool,
+                    region1: bool,
+                    region2: bool,
+                    region3: bool,
+                    region4: bool,
+                    region5: bool,
+                    region6: bool,
+                    region7: bool,
+                    region8: bool,
+                    region9: bool,
+                    region10: bool,
+                    region11: bool,
+                    region12: bool,
+                    region13: bool,
+                    region14: bool,
+                    region15: bool,
+                    region16: bool,
+                    region17: bool,
+                    region18: bool,
+                    region19: bool,
+                    region20: bool,
+                    region21: bool,
+                    region22: bool,
+                    region23: bool,
+                    region24: bool,
+                    region25: bool,
+                    region26: bool,
+                    region27: bool,
+                    region28: bool,
+                    region29: bool,
+                    region30: bool,
+                    region31: bool,
+                }
+                let proxy = Config0 {
+                    region0: self.region0(),
+                    region1: self.region1(),
+                    region2: self.region2(),
+                    region3: self.region3(),
+                    region4: self.region4(),
+                    region5: self.region5(),
+                    region6: self.region6(),
+                    region7: self.region7(),
+                    region8: self.region8(),
+                    region9: self.region9(),
+                    region10: self.region10(),
+                    region11: self.region11(),
+                    region12: self.region12(),
+                    region13: self.region13(),
+                    region14: self.region14(),
+                    region15: self.region15(),
+                    region16: self.region16(),
+                    region17: self.region17(),
+                    region18: self.region18(),
+                    region19: self.region19(),
+                    region20: self.region20(),
+                    region21: self.region21(),
+                    region22: self.region22(),
+                    region23: self.region23(),
+                    region24: self.region24(),
+                    region25: self.region25(),
+                    region26: self.region26(),
+                    region27: self.region27(),
+                    region28: self.region28(),
+                    region29: self.region29(),
+                    region30: self.region30(),
+                    region31: self.region31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Block protect configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1189,6 +1460,71 @@ pub mod bprot {
                 Config1(0)
             }
         }
+        impl core::fmt::Debug for Config1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config1")
+                    .field("region32", &self.region32())
+                    .field("region33", &self.region33())
+                    .field("region34", &self.region34())
+                    .field("region35", &self.region35())
+                    .field("region36", &self.region36())
+                    .field("region37", &self.region37())
+                    .field("region38", &self.region38())
+                    .field("region39", &self.region39())
+                    .field("region40", &self.region40())
+                    .field("region41", &self.region41())
+                    .field("region42", &self.region42())
+                    .field("region43", &self.region43())
+                    .field("region44", &self.region44())
+                    .field("region45", &self.region45())
+                    .field("region46", &self.region46())
+                    .field("region47", &self.region47())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config1 {
+                    region32: bool,
+                    region33: bool,
+                    region34: bool,
+                    region35: bool,
+                    region36: bool,
+                    region37: bool,
+                    region38: bool,
+                    region39: bool,
+                    region40: bool,
+                    region41: bool,
+                    region42: bool,
+                    region43: bool,
+                    region44: bool,
+                    region45: bool,
+                    region46: bool,
+                    region47: bool,
+                }
+                let proxy = Config1 {
+                    region32: self.region32(),
+                    region33: self.region33(),
+                    region34: self.region34(),
+                    region35: self.region35(),
+                    region36: self.region36(),
+                    region37: self.region37(),
+                    region38: self.region38(),
+                    region39: self.region39(),
+                    region40: self.region40(),
+                    region41: self.region41(),
+                    region42: self.region42(),
+                    region43: self.region43(),
+                    region44: self.region44(),
+                    region45: self.region45(),
+                    region46: self.region46(),
+                    region47: self.region47(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable protection mechanism in debug mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1212,10 +1548,31 @@ pub mod bprot {
                 Disableindebug(0)
             }
         }
+        impl core::fmt::Debug for Disableindebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disableindebug")
+                    .field("disableindebug", &self.disableindebug())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disableindebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disableindebug {
+                    disableindebug: super::vals::Disableindebug,
+                }
+                let proxy = Disableindebug {
+                    disableindebug: self.disableindebug(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Disableindebug {
             #[doc = "Enabled in debug"]
             ENABLED = 0x0,
@@ -1387,6 +1744,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1432,6 +1809,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of key-stream generated when MODE.LENGTH = Extended."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1455,6 +1858,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1476,6 +1899,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1525,6 +1968,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1546,6 +2015,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1571,10 +2060,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1608,7 +2118,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1640,7 +2151,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A key-stream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1670,7 +2182,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1700,7 +2213,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1730,7 +2244,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1909,6 +2424,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1930,6 +2461,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -1964,6 +2515,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -2022,6 +2596,35 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2043,6 +2646,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -2090,6 +2713,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2111,6 +2760,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -2147,10 +2814,34 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -2180,7 +2871,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             RC = 0x0,
@@ -2428,6 +3120,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2451,6 +3163,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2472,6 +3204,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -2530,6 +3278,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2564,6 +3341,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2585,6 +3385,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -2610,6 +3426,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2631,6 +3467,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -2700,6 +3556,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2734,10 +3622,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2769,7 +3681,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -2811,7 +3724,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -2841,7 +3755,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -2871,7 +3786,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -2913,7 +3829,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -2952,7 +3869,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -2982,7 +3900,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -3104,6 +4023,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -3180,6 +4122,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -3421,6 +4420,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3442,6 +4457,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -3467,6 +4498,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3488,6 +4535,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -3513,6 +4576,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3534,6 +4613,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -3559,6 +4654,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3580,6 +4691,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -3605,6 +4732,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3626,6 +4769,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -3651,6 +4810,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3674,6 +4849,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3695,6 +4886,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -3721,6 +4932,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3743,6 +4974,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -3769,6 +5020,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3791,6 +5058,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Ram {
                 Ram(0)
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T0"]
@@ -3816,6 +5099,22 @@ pub mod ficr {
                 T0(0)
             }
         }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3837,6 +5136,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T1 {
                 T1(0)
+            }
+        }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T2"]
@@ -3862,6 +5177,22 @@ pub mod ficr {
                 T2(0)
             }
         }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3885,6 +5216,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3906,6 +5253,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part variant, hardware version and production configuration"]
@@ -3932,10 +5295,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -3981,6 +5365,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xc0 => f.write_str("K192"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xc0 => defmt::write!(f, "K192"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -4012,6 +5415,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QF"),
+                    0x2003 => f.write_str("QC"),
+                    0x2004 => f.write_str("CA"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QF"),
+                    0x2003 => defmt::write!(f, "QC"),
+                    0x2004 => defmt::write!(f, "CA"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -4047,6 +5473,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2810 => f.write_str("N52810"),
+                    0x0005_2811 => f.write_str("N52811"),
+                    0x0005_2832 => f.write_str("N52832"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2810 => defmt::write!(f, "N52810"),
+                    0x0005_2811 => defmt::write!(f, "N52811"),
+                    0x0005_2832 => defmt::write!(f, "N52832"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -4074,6 +5523,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x18 => f.write_str("K24"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x18 => defmt::write!(f, "K24"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -4117,6 +5585,39 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4241 => f.write_str("AABA"),
+                    0x4141_4242 => f.write_str("AABB"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    0x4141_4341 => f.write_str("AACA"),
+                    0x4141_4342 => f.write_str("AACB"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4241 => defmt::write!(f, "AABA"),
+                    0x4141_4242 => defmt::write!(f, "AABB"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    0x4141_4341 => defmt::write!(f, "AACA"),
+                    0x4141_4342 => defmt::write!(f, "AACB"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -4229,6 +5730,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4254,6 +5775,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -4283,6 +5893,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4308,6 +6007,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -4337,6 +6125,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4362,6 +6239,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -4391,6 +6357,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4418,6 +6473,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4443,6 +6587,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -4513,10 +6746,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -4546,7 +6812,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -4576,7 +6843,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -4618,7 +6886,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -4648,7 +6917,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -4681,7 +6951,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -4837,6 +7108,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4875,10 +7175,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -4911,7 +7256,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -4941,7 +7287,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -5065,6 +7412,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5086,6 +7449,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -5111,6 +7494,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5132,6 +7535,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -5157,10 +7580,31 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5365,6 +7809,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5388,6 +7852,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5409,6 +7893,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5456,6 +7960,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5477,6 +8007,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -5513,6 +8063,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5537,10 +8110,29 @@ pub mod pdm {
                 Pdmclkctrl(0)
             }
         }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -5588,6 +8180,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -5619,6 +8232,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -5632,7 +8266,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (Left + Right) of 16bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -5808,6 +8443,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5831,6 +8486,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5852,6 +8527,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -5899,6 +8594,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power failure comparator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5931,6 +8652,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Pofcon {
                 Pofcon(0)
+            }
+        }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: RAMn power control register. The RAM size will vary depending on product variant, and the RAMn register will only be present if the corresponding RAM AHB slave is present on the device."]
@@ -5973,6 +8717,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("s_power", &[self.s_power(0usize), self.s_power(1usize)])
+                    .field(
+                        "s_retention",
+                        &[self.s_retention(0usize), self.s_retention(1usize)],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 2usize],
+                    s_retention: [bool; 2usize],
+                }
+                let proxy = Power {
+                    s_power: [self.s_power(0usize), self.s_power(1usize)],
+                    s_retention: [self.s_retention(0usize), self.s_retention(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -6053,6 +8823,41 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    dif: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    dif: self.dif(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6076,10 +8881,31 @@ pub mod power {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -6295,6 +9121,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6320,6 +9235,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -6537,6 +9541,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6558,6 +9578,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -6594,6 +9634,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6615,6 +9678,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -6639,6 +9722,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6730,6 +9831,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6752,6 +9891,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -6777,6 +9932,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6798,6 +9973,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -6822,6 +10017,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6891,6 +10102,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -6908,6 +10151,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -6921,7 +10181,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -6969,6 +10230,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -6982,7 +10260,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -7012,7 +10291,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -7068,6 +10348,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -7081,7 +10378,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -7311,6 +10609,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7332,6 +10650,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -7357,6 +10695,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7378,6 +10736,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -7447,6 +10825,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7468,6 +10878,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -7493,6 +10923,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7516,6 +10966,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7537,6 +11007,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -7628,10 +11118,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -7661,7 +11190,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples / report"]
             _10SMPL = 0x0,
@@ -7712,7 +11242,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -8081,6 +11612,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8103,6 +11657,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -8129,6 +11703,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8150,6 +11744,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -8340,6 +11954,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8361,6 +12040,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -8386,6 +12081,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8407,6 +12118,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -8441,6 +12172,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -8576,6 +12330,56 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8597,6 +12401,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -8631,6 +12451,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -8702,6 +12545,38 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("plen", &self.plen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    plen: super::vals::Plen,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    plen: self.plen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8770,6 +12645,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8791,6 +12698,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -8849,6 +12776,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8905,6 +12861,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8926,6 +12911,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -9028,6 +13033,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9052,6 +13098,26 @@ pub mod radio {
                 Rxcrc(0)
             }
         }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Received address"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9073,6 +13139,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxmatch {
                 Rxmatch(0)
+            }
+        }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -9175,6 +13261,47 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9196,6 +13323,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Inter Frame Spacing in us"]
@@ -9221,6 +13368,22 @@ pub mod radio {
                 Tifs(0)
             }
         }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u8,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9242,6 +13405,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -9267,10 +13450,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -9300,7 +13504,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -9333,7 +13538,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least Significant bit on air first"]
             LITTLE = 0x0,
@@ -9363,7 +13569,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -9397,7 +13604,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -9427,7 +13635,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbit/s Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -9473,7 +13682,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -9503,7 +13713,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -9533,7 +13744,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -9563,7 +13775,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -9593,7 +13806,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -9644,7 +13858,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -10019,6 +14234,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10040,6 +14275,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -10065,6 +14320,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10086,6 +14361,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10210,6 +14505,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10232,6 +14547,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -10283,6 +14618,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10332,6 +14706,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must be written when RTC is stopped"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10353,6 +14766,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10602,6 +15035,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10694,6 +15147,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10715,6 +15206,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -10825,6 +15336,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10859,6 +15453,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last results is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10880,6 +15497,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last results is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -10905,6 +15542,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10926,6 +15583,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -10951,6 +15628,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10972,6 +15669,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -10997,6 +15714,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11018,6 +15755,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -11055,6 +15810,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11078,10 +15856,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -11111,7 +15910,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -11153,7 +15953,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -11204,7 +16005,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -11272,7 +16074,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -11302,7 +16105,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -11336,7 +16140,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -11370,7 +16175,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -11400,7 +16206,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -11430,7 +16237,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -11470,7 +16278,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -11546,10 +16355,34 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -11725,6 +16558,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11746,6 +16605,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -11772,6 +16651,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11793,6 +16692,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -11818,6 +16735,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11841,10 +16774,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -11874,7 +16824,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -11904,7 +16855,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -11974,6 +16926,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -11987,7 +16968,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -12287,6 +17269,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12308,6 +17316,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -12332,6 +17360,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -12401,6 +17449,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case and over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12422,6 +17502,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -12447,6 +17543,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12468,6 +17584,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -12493,6 +17627,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12514,6 +17668,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -12539,6 +17713,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12560,6 +17754,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -12585,10 +17797,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -12618,7 +17851,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -12648,7 +17882,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -12718,6 +17953,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -12731,7 +17995,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -12761,7 +18026,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -12793,7 +18059,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13090,6 +18357,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13113,6 +18406,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13134,6 +18443,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -13181,6 +18510,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13202,6 +18557,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -13227,6 +18598,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13248,6 +18639,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -13273,6 +18682,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13296,6 +18725,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13317,6 +18766,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -13353,6 +18822,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13374,6 +18866,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13399,6 +18911,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13422,10 +18952,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -13455,7 +19006,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -13485,7 +19037,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -13529,7 +19082,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -13559,7 +19113,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13591,7 +19146,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -13625,7 +19181,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13772,6 +19329,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -13889,6 +19466,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13916,6 +19513,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13939,6 +19573,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13960,6 +19610,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14004,10 +19674,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -14041,7 +19769,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -14249,6 +19978,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14270,6 +20019,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14317,6 +20086,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14339,6 +20134,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14419,6 +20234,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14440,6 +20290,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14476,6 +20342,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14499,10 +20388,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -14562,6 +20468,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -14836,6 +20763,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14857,6 +20804,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14904,6 +20871,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14926,6 +20919,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15017,6 +21030,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15038,6 +21089,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15063,6 +21134,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15084,6 +21173,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15164,6 +21273,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15185,6 +21329,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15210,6 +21374,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15233,10 +21415,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -15298,6 +21501,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -15311,7 +21535,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15347,7 +21572,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15651,6 +21877,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15685,6 +21931,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15706,6 +21975,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -15751,6 +22040,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15831,6 +22146,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15852,6 +22202,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -15877,6 +22247,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15898,6 +22284,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15923,6 +22329,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15944,6 +22368,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15980,6 +22424,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16001,6 +22468,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -16026,6 +22513,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16049,10 +22554,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -16096,7 +22622,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -16128,7 +22655,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -16346,6 +22874,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16391,6 +22939,32 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16412,6 +22986,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -16468,6 +23062,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -16548,6 +23171,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16569,6 +23227,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16605,6 +23279,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16626,6 +23323,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16679,6 +23392,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -16692,7 +23456,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -16728,7 +23493,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -16772,7 +23538,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -17082,6 +23849,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17127,6 +23914,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17148,6 +23961,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source Note : this register is read / write one to clear."]
@@ -17204,6 +24037,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17339,6 +24201,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17362,6 +24274,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17383,6 +24315,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -17419,6 +24371,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17442,6 +24417,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17463,6 +24458,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -17516,6 +24531,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -17529,7 +24595,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -17565,7 +24632,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -17609,7 +24677,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -17720,6 +24789,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -17739,6 +24826,27 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Pall {
@@ -17859,6 +24967,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17880,6 +25011,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -17909,6 +25060,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17931,6 +25123,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -17960,6 +25168,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17983,10 +25232,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -18030,6 +25300,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -18043,7 +25330,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52811/pac.rs
+++ b/src/chips/nrf52811/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -347,6 +348,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -392,6 +413,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -413,6 +460,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -438,10 +501,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -528,6 +612,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -551,6 +655,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -566,6 +690,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -593,6 +734,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -1009,6 +1167,119 @@ pub mod bprot {
                 Config0(0)
             }
         }
+        impl core::fmt::Debug for Config0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config0")
+                    .field("region0", &self.region0())
+                    .field("region1", &self.region1())
+                    .field("region2", &self.region2())
+                    .field("region3", &self.region3())
+                    .field("region4", &self.region4())
+                    .field("region5", &self.region5())
+                    .field("region6", &self.region6())
+                    .field("region7", &self.region7())
+                    .field("region8", &self.region8())
+                    .field("region9", &self.region9())
+                    .field("region10", &self.region10())
+                    .field("region11", &self.region11())
+                    .field("region12", &self.region12())
+                    .field("region13", &self.region13())
+                    .field("region14", &self.region14())
+                    .field("region15", &self.region15())
+                    .field("region16", &self.region16())
+                    .field("region17", &self.region17())
+                    .field("region18", &self.region18())
+                    .field("region19", &self.region19())
+                    .field("region20", &self.region20())
+                    .field("region21", &self.region21())
+                    .field("region22", &self.region22())
+                    .field("region23", &self.region23())
+                    .field("region24", &self.region24())
+                    .field("region25", &self.region25())
+                    .field("region26", &self.region26())
+                    .field("region27", &self.region27())
+                    .field("region28", &self.region28())
+                    .field("region29", &self.region29())
+                    .field("region30", &self.region30())
+                    .field("region31", &self.region31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config0 {
+                    region0: bool,
+                    region1: bool,
+                    region2: bool,
+                    region3: bool,
+                    region4: bool,
+                    region5: bool,
+                    region6: bool,
+                    region7: bool,
+                    region8: bool,
+                    region9: bool,
+                    region10: bool,
+                    region11: bool,
+                    region12: bool,
+                    region13: bool,
+                    region14: bool,
+                    region15: bool,
+                    region16: bool,
+                    region17: bool,
+                    region18: bool,
+                    region19: bool,
+                    region20: bool,
+                    region21: bool,
+                    region22: bool,
+                    region23: bool,
+                    region24: bool,
+                    region25: bool,
+                    region26: bool,
+                    region27: bool,
+                    region28: bool,
+                    region29: bool,
+                    region30: bool,
+                    region31: bool,
+                }
+                let proxy = Config0 {
+                    region0: self.region0(),
+                    region1: self.region1(),
+                    region2: self.region2(),
+                    region3: self.region3(),
+                    region4: self.region4(),
+                    region5: self.region5(),
+                    region6: self.region6(),
+                    region7: self.region7(),
+                    region8: self.region8(),
+                    region9: self.region9(),
+                    region10: self.region10(),
+                    region11: self.region11(),
+                    region12: self.region12(),
+                    region13: self.region13(),
+                    region14: self.region14(),
+                    region15: self.region15(),
+                    region16: self.region16(),
+                    region17: self.region17(),
+                    region18: self.region18(),
+                    region19: self.region19(),
+                    region20: self.region20(),
+                    region21: self.region21(),
+                    region22: self.region22(),
+                    region23: self.region23(),
+                    region24: self.region24(),
+                    region25: self.region25(),
+                    region26: self.region26(),
+                    region27: self.region27(),
+                    region28: self.region28(),
+                    region29: self.region29(),
+                    region30: self.region30(),
+                    region31: self.region31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Block protect configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1197,6 +1468,71 @@ pub mod bprot {
                 Config1(0)
             }
         }
+        impl core::fmt::Debug for Config1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config1")
+                    .field("region32", &self.region32())
+                    .field("region33", &self.region33())
+                    .field("region34", &self.region34())
+                    .field("region35", &self.region35())
+                    .field("region36", &self.region36())
+                    .field("region37", &self.region37())
+                    .field("region38", &self.region38())
+                    .field("region39", &self.region39())
+                    .field("region40", &self.region40())
+                    .field("region41", &self.region41())
+                    .field("region42", &self.region42())
+                    .field("region43", &self.region43())
+                    .field("region44", &self.region44())
+                    .field("region45", &self.region45())
+                    .field("region46", &self.region46())
+                    .field("region47", &self.region47())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config1 {
+                    region32: bool,
+                    region33: bool,
+                    region34: bool,
+                    region35: bool,
+                    region36: bool,
+                    region37: bool,
+                    region38: bool,
+                    region39: bool,
+                    region40: bool,
+                    region41: bool,
+                    region42: bool,
+                    region43: bool,
+                    region44: bool,
+                    region45: bool,
+                    region46: bool,
+                    region47: bool,
+                }
+                let proxy = Config1 {
+                    region32: self.region32(),
+                    region33: self.region33(),
+                    region34: self.region34(),
+                    region35: self.region35(),
+                    region36: self.region36(),
+                    region37: self.region37(),
+                    region38: self.region38(),
+                    region39: self.region39(),
+                    region40: self.region40(),
+                    region41: self.region41(),
+                    region42: self.region42(),
+                    region43: self.region43(),
+                    region44: self.region44(),
+                    region45: self.region45(),
+                    region46: self.region46(),
+                    region47: self.region47(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable protection mechanism in debug mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1220,10 +1556,31 @@ pub mod bprot {
                 Disableindebug(0)
             }
         }
+        impl core::fmt::Debug for Disableindebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disableindebug")
+                    .field("disableindebug", &self.disableindebug())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disableindebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disableindebug {
+                    disableindebug: super::vals::Disableindebug,
+                }
+                let proxy = Disableindebug {
+                    disableindebug: self.disableindebug(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Disableindebug {
             #[doc = "Enabled in debug"]
             ENABLED = 0x0,
@@ -1395,6 +1752,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1440,6 +1817,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1463,6 +1866,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1484,6 +1907,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1533,6 +1976,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1554,6 +2023,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1579,10 +2068,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1616,7 +2126,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1648,7 +2159,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1678,7 +2190,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1708,7 +2221,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1738,7 +2252,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1917,6 +2432,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1938,6 +2469,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -1972,6 +2523,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -2030,6 +2604,35 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2051,6 +2654,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -2098,6 +2721,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2119,6 +2768,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -2155,10 +2822,34 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -2188,7 +2879,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             RC = 0x0,
@@ -2436,6 +3128,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2459,6 +3171,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2480,6 +3212,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -2538,6 +3286,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2572,6 +3349,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2593,6 +3393,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -2618,6 +3434,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2639,6 +3475,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -2708,6 +3564,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2742,10 +3630,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2777,7 +3689,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -2819,7 +3732,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -2849,7 +3763,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -2879,7 +3794,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -2921,7 +3837,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -2960,7 +3877,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -2990,7 +3908,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -3112,6 +4031,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -3188,6 +4130,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -3429,6 +4428,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3450,6 +4465,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -3475,6 +4506,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3496,6 +4543,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -3521,6 +4584,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3542,6 +4621,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -3567,6 +4662,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3588,6 +4699,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -3613,6 +4740,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3634,6 +4777,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -3659,6 +4818,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3682,6 +4857,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3703,6 +4894,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -3729,6 +4940,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3751,6 +4982,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -3777,6 +5028,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3799,6 +5066,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Ram {
                 Ram(0)
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T0"]
@@ -3824,6 +5107,22 @@ pub mod ficr {
                 T0(0)
             }
         }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3845,6 +5144,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T1 {
                 T1(0)
+            }
+        }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T2"]
@@ -3870,6 +5185,22 @@ pub mod ficr {
                 T2(0)
             }
         }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3893,6 +5224,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3914,6 +5261,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part variant, hardware version and production configuration"]
@@ -3940,10 +5303,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -3989,6 +5373,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xc0 => f.write_str("K192"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xc0 => defmt::write!(f, "K192"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -4020,6 +5423,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QF"),
+                    0x2003 => f.write_str("QC"),
+                    0x2004 => f.write_str("CA"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QF"),
+                    0x2003 => defmt::write!(f, "QC"),
+                    0x2004 => defmt::write!(f, "CA"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -4055,6 +5481,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2810 => f.write_str("N52810"),
+                    0x0005_2811 => f.write_str("N52811"),
+                    0x0005_2832 => f.write_str("N52832"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2810 => defmt::write!(f, "N52810"),
+                    0x0005_2811 => defmt::write!(f, "N52811"),
+                    0x0005_2832 => defmt::write!(f, "N52832"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -4082,6 +5531,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x18 => f.write_str("K24"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x18 => defmt::write!(f, "K24"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -4125,6 +5593,39 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4241 => f.write_str("AABA"),
+                    0x4141_4242 => f.write_str("AABB"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    0x4141_4341 => f.write_str("AACA"),
+                    0x4141_4342 => f.write_str("AACB"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4241 => defmt::write!(f, "AABA"),
+                    0x4141_4242 => defmt::write!(f, "AABB"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    0x4141_4341 => defmt::write!(f, "AACA"),
+                    0x4141_4342 => defmt::write!(f, "AACB"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -4237,6 +5738,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4262,6 +5783,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -4291,6 +5901,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4316,6 +6015,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -4345,6 +6133,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4370,6 +6247,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -4399,6 +6365,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4426,6 +6481,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4451,6 +6595,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -4521,10 +6754,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -4554,7 +6820,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -4584,7 +6851,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -4626,7 +6894,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -4656,7 +6925,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -4689,7 +6959,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -4845,6 +7116,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4883,10 +7183,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -4919,7 +7264,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -4949,7 +7295,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -5073,6 +7420,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5094,6 +7457,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -5119,6 +7502,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5140,6 +7543,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -5165,10 +7588,31 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5373,6 +7817,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5396,6 +7860,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5417,6 +7901,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5464,6 +7968,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5485,6 +8015,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -5521,6 +8071,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5545,10 +8118,29 @@ pub mod pdm {
                 Pdmclkctrl(0)
             }
         }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -5596,6 +8188,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -5627,6 +8240,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -5640,7 +8274,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (Left + Right) of 16bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -5816,6 +8451,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5839,6 +8494,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5860,6 +8535,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -5907,6 +8602,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power failure comparator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5939,6 +8660,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Pofcon {
                 Pofcon(0)
+            }
+        }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: RAMn power control register. The RAM size will vary depending on product variant, and the RAMn register will only be present if the corresponding RAM AHB slave is present on the device."]
@@ -5981,6 +8725,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("s_power", &[self.s_power(0usize), self.s_power(1usize)])
+                    .field(
+                        "s_retention",
+                        &[self.s_retention(0usize), self.s_retention(1usize)],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 2usize],
+                    s_retention: [bool; 2usize],
+                }
+                let proxy = Power {
+                    s_power: [self.s_power(0usize), self.s_power(1usize)],
+                    s_retention: [self.s_retention(0usize), self.s_retention(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -6061,6 +8831,41 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    dif: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    dif: self.dif(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6084,10 +8889,31 @@ pub mod power {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -6303,6 +9129,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6328,6 +9243,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -6545,6 +9549,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6566,6 +9586,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -6602,6 +9642,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6623,6 +9686,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -6647,6 +9730,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6738,6 +9839,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6760,6 +9899,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -6785,6 +9940,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6806,6 +9981,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -6830,6 +10025,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6899,6 +10110,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -6916,6 +10159,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -6929,7 +10189,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -6977,6 +10238,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -6990,7 +10268,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -7020,7 +10299,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -7076,6 +10356,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -7089,7 +10386,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -7319,6 +10617,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7340,6 +10658,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -7365,6 +10703,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7386,6 +10744,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -7455,6 +10833,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7476,6 +10886,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -7501,6 +10931,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7524,6 +10974,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7545,6 +11015,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -7636,10 +11126,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -7669,7 +11198,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples / report"]
             _10SMPL = 0x0,
@@ -7720,7 +11250,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -8312,6 +11843,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8368,6 +11919,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear the GPIO pattern array for antenna control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8389,6 +11969,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC configuration"]
@@ -8425,6 +12025,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8447,6 +12070,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -8473,6 +12116,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8494,6 +12157,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -8598,6 +12281,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8641,6 +12365,32 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ctestatus {
                 Ctestatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -8831,6 +12581,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8852,6 +12667,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -8877,6 +12708,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8898,6 +12745,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -8992,6 +12859,44 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9026,6 +12931,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9047,6 +12975,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -9083,6 +13031,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect loop count"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9107,6 +13078,26 @@ pub mod radio {
                 Edcnt(0)
             }
         }
+        impl core::fmt::Debug for Edcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edcnt")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edcnt {
+                    edcnt: u32,
+                }
+                let proxy = Edcnt {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect level"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9128,6 +13119,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edsample {
                 Edsample(0)
+            }
+        }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -9162,6 +13173,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -9440,6 +13474,95 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("framestart", &self.framestart())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("phyend", &self.phyend())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    framestart: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    txready: bool,
+                    rxready: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    phyend: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    framestart: self.framestart(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    phyend: self.phyend(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9463,6 +13586,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9484,6 +13627,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -9518,6 +13677,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -9623,6 +13805,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9691,6 +13914,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9725,6 +13980,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9746,6 +14024,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -9804,6 +14102,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9860,6 +14187,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9881,6 +14237,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -9983,6 +14359,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10005,6 +14422,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -10030,6 +14467,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10051,6 +14508,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -10274,6 +14747,80 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10295,6 +14842,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -10320,6 +14887,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10341,6 +14928,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmit address select"]
@@ -10366,6 +14969,26 @@ pub mod radio {
                 Txaddress(0)
             }
         }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output power"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10389,10 +15012,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -10431,7 +15075,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -10463,7 +15108,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -10493,7 +15139,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -10523,7 +15170,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10563,7 +15211,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10603,7 +15252,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8 us unit (default) Set to 20 if parsed CTETime is larger than 20"]
             _20 = 0x0,
@@ -10636,7 +15286,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -10666,7 +15317,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -10699,7 +15351,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -10732,7 +15385,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -10762,7 +15416,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -10796,7 +15451,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -10826,7 +15482,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -10875,7 +15532,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -10905,7 +15563,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -10939,7 +15598,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -10969,7 +15629,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -10999,7 +15660,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -11029,7 +15691,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -11059,7 +15722,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -11092,7 +15756,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -11143,7 +15808,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -11183,7 +15849,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11223,7 +15890,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11263,7 +15931,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11300,7 +15969,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -11675,6 +16345,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11696,6 +16386,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -11721,6 +16431,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11742,6 +16472,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11866,6 +16616,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11888,6 +16658,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -11939,6 +16729,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11988,6 +16817,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must be written when RTC is stopped"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12009,6 +16877,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -12258,6 +17146,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12350,6 +17258,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12371,6 +17317,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -12481,6 +17447,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12515,6 +17564,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last results is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12536,6 +17608,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last results is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -12561,6 +17653,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12582,6 +17694,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -12607,6 +17739,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12628,6 +17780,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -12653,6 +17825,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12674,6 +17866,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -12711,6 +17921,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12734,10 +17967,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -12767,7 +18021,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -12809,7 +18064,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -12860,7 +18116,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -12928,7 +18185,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -12958,7 +18216,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -12992,7 +18251,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -13026,7 +18286,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -13056,7 +18317,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -13086,7 +18348,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -13126,7 +18389,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -13202,10 +18466,34 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -13381,6 +18669,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13402,6 +18716,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -13428,6 +18762,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13449,6 +18803,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -13474,6 +18846,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13497,10 +18885,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -13530,7 +18935,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -13560,7 +18966,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -13630,6 +19037,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -13643,7 +19079,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -13943,6 +19380,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13964,6 +19427,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -13988,6 +19471,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14057,6 +19560,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case and over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14078,6 +19613,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -14103,6 +19654,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14124,6 +19695,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -14149,6 +19738,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14170,6 +19779,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -14195,6 +19824,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14216,6 +19865,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -14241,10 +19908,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -14274,7 +19962,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -14304,7 +19993,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -14374,6 +20064,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -14387,7 +20106,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -14417,7 +20137,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14449,7 +20170,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14746,6 +20468,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14769,6 +20517,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14790,6 +20554,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14837,6 +20621,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14858,6 +20668,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -14883,6 +20709,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14904,6 +20750,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -14929,6 +20793,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14952,6 +20836,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14973,6 +20877,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -15009,6 +20933,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15030,6 +20977,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15055,6 +21022,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15078,10 +21063,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -15111,7 +21117,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -15141,7 +21148,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -15185,7 +21193,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -15215,7 +21224,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15247,7 +21257,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -15281,7 +21292,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15428,6 +21440,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -15545,6 +21577,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15572,6 +21624,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15595,6 +21684,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15616,6 +21721,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15660,10 +21785,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -15697,7 +21880,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -15905,6 +22089,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15926,6 +22130,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -15973,6 +22197,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15995,6 +22245,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -16075,6 +22345,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16096,6 +22401,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16132,6 +22453,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16155,10 +22499,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -16218,6 +22579,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -16492,6 +22874,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16513,6 +22915,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -16560,6 +22982,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16582,6 +23030,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16673,6 +23141,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16694,6 +23200,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -16719,6 +23245,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16740,6 +23284,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16820,6 +23384,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16841,6 +23440,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -16866,6 +23485,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16889,10 +23526,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -16954,6 +23612,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -16967,7 +23646,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -17003,7 +23683,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -17307,6 +23988,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17341,6 +24042,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17362,6 +24086,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -17407,6 +24151,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17487,6 +24257,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17508,6 +24313,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -17533,6 +24358,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17554,6 +24395,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -17579,6 +24440,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17600,6 +24479,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -17636,6 +24535,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17657,6 +24579,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -17682,6 +24624,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17705,10 +24665,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -17752,7 +24733,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -17784,7 +24766,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -18002,6 +24985,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18047,6 +25050,32 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18068,6 +25097,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -18124,6 +25173,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -18204,6 +25282,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18225,6 +25338,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -18261,6 +25390,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18282,6 +25434,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -18335,6 +25503,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -18348,7 +25567,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -18384,7 +25604,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -18428,7 +25649,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -18738,6 +25960,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18783,6 +26025,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18804,6 +26072,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source Note : this register is read / write one to clear."]
@@ -18860,6 +26148,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -18995,6 +26312,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19018,6 +26385,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19039,6 +26426,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -19075,6 +26482,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19098,6 +26528,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19119,6 +26569,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -19172,6 +26642,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -19185,7 +26706,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -19221,7 +26743,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -19265,7 +26788,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -19376,6 +26900,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -19395,6 +26937,27 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Pall {
@@ -19515,6 +27078,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19536,6 +27122,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -19565,6 +27171,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19587,6 +27234,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -19616,6 +27279,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19639,10 +27343,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -19686,6 +27411,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -19699,7 +27441,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52820/pac.rs
+++ b/src/chips/nrf52820/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -372,6 +373,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -417,6 +438,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -438,6 +485,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -463,10 +526,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -590,10 +674,34 @@ pub mod acl {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: super::vals::Write,
+                    read: super::vals::Read,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Read {
             #[doc = "Allow read instructions to region n."]
             ENABLE = 0x0,
@@ -623,7 +731,8 @@ pub mod acl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Write {
             #[doc = "Allow write and erase instructions to region n."]
             ENABLE = 0x0,
@@ -708,6 +817,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -731,6 +860,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -746,6 +895,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -773,6 +939,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -935,6 +1118,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Header (S0) mask."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -956,6 +1159,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Headermask {
                 Headermask(0)
+            }
+        }
+        impl core::fmt::Debug for Headermask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Headermask")
+                    .field("headermask", &self.headermask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Headermask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Headermask {
+                    headermask: u8,
+                }
+                let proxy = Headermask {
+                    headermask: self.headermask(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1003,6 +1226,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1026,6 +1275,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1047,6 +1316,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1096,6 +1385,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1117,6 +1432,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1142,10 +1477,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1179,7 +1535,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1211,7 +1568,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1241,7 +1599,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1271,7 +1630,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1301,7 +1661,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1504,6 +1865,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1525,6 +1902,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -1561,6 +1958,29 @@ pub mod clock {
                 Hfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO debounce time. The HFXO is started by triggering the TASKS_HFCLKSTART task."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1582,6 +2002,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfxodebounce {
                 Hfxodebounce(0)
+            }
+        }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxodebounce")
+                    .field("hfxodebounce", &self.hfxodebounce())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxodebounce {
+                    hfxodebounce: super::vals::Hfxodebounce,
+                }
+                let proxy = Hfxodebounce {
+                    hfxodebounce: self.hfxodebounce(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1662,6 +2102,41 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .field("ctstarted", &self.ctstarted())
+                    .field("ctstopped", &self.ctstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                    ctstarted: bool,
+                    ctstopped: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                    ctstarted: self.ctstarted(),
+                    ctstopped: self.ctstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1683,6 +2158,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -1730,6 +2225,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1751,6 +2272,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -1787,6 +2326,29 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LFXO debounce time. The LFXO is started by triggering the TASKS_LFCLKSTART task when the LFCLKSRC register is configured for Xtal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1810,10 +2372,31 @@ pub mod clock {
                 Lfxodebounce(0)
             }
         }
+        impl core::fmt::Debug for Lfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfxodebounce")
+                    .field("lfxodebounce", &self.lfxodebounce())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfxodebounce {
+                    lfxodebounce: super::vals::Lfxodebounce,
+                }
+                let proxy = Lfxodebounce {
+                    lfxodebounce: self.lfxodebounce(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -1859,6 +2442,25 @@ pub mod clock {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("DB256US"),
+                    0x40 => f.write_str("DB1024US"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "DB256US"),
+                    0x40 => defmt::write!(f, "DB1024US"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxodebounce {
             #[inline(always)]
             fn from(val: u8) -> Hfxodebounce {
@@ -1872,7 +2474,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator (LFRC)"]
             RC = 0x0,
@@ -1905,7 +2508,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfxodebounce {
             #[doc = "8192 32.768 kHz periods, or 0.25 s. Recommended for normal Operating Temperature conditions."]
             NORMAL = 0x0,
@@ -2150,6 +2754,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2173,6 +2797,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2194,6 +2838,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -2252,6 +2912,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2286,6 +2975,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2307,6 +3019,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -2332,6 +3060,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2353,6 +3101,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -2422,6 +3190,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2456,10 +3256,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2491,7 +3315,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -2529,7 +3354,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -2559,7 +3385,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -2589,7 +3416,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -2628,7 +3456,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -2667,7 +3496,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -2697,7 +3527,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -2819,6 +3650,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -2895,6 +3749,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -3145,6 +4056,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3166,6 +4093,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -3191,6 +4134,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3212,6 +4171,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -3237,6 +4212,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3258,6 +4249,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -3283,6 +4290,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3304,6 +4327,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -3329,6 +4368,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3350,6 +4405,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -3375,6 +4446,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3398,6 +4485,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3419,6 +4522,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -3445,6 +4568,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3467,6 +4610,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -3493,6 +4656,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Production test signature n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3515,6 +4694,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Prodtest {
                 Prodtest(0)
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prodtest")
+                    .field("prodtest", &self.prodtest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prodtest {
+                    prodtest: super::vals::Prodtest,
+                }
+                let proxy = Prodtest {
+                    prodtest: self.prodtest(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -3541,6 +4740,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T0"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3562,6 +4777,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T0 {
                 T0(0)
+            }
+        }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T1"]
@@ -3587,6 +4818,22 @@ pub mod ficr {
                 T1(0)
             }
         }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T2"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3608,6 +4855,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T2 {
                 T2(0)
+            }
+        }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T3"]
@@ -3633,6 +4896,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3654,6 +4933,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Build code (hardware version and production configuration)"]
@@ -3680,10 +4975,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -3737,6 +5053,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0x0400 => f.write_str("K1024"),
+                    0x0800 => f.write_str("K2048"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0x0400 => defmt::write!(f, "K1024"),
+                    0x0800 => defmt::write!(f, "K2048"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -3764,6 +5107,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2007 => f.write_str("QD"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2007 => defmt::write!(f, "QD"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -3799,6 +5161,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2820 => f.write_str("N52820"),
+                    0x0005_2833 => f.write_str("N52833"),
+                    0x0005_2840 => f.write_str("N52840"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2820 => defmt::write!(f, "N52820"),
+                    0x0005_2833 => defmt::write!(f, "N52833"),
+                    0x0005_2840 => defmt::write!(f, "N52840"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -3826,6 +5211,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xbb42_319f => f.write_str("DONE"),
+                    0xffff_ffff => f.write_str("NOT_DONE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xbb42_319f => defmt::write!(f, "DONE"),
+                    0xffff_ffff => defmt::write!(f, "NOT_DONE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Prodtest {
@@ -3865,6 +5269,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -3900,6 +5331,33 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4243 => f.write_str("AABC"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    0x4141_4331 => f.write_str("AAC1"),
+                    0x4141_4430 => f.write_str("AAD0"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4243 => defmt::write!(f, "AABC"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    0x4141_4331 => defmt::write!(f, "AAC1"),
+                    0x4141_4430 => defmt::write!(f, "AAD0"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -4012,6 +5470,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4037,6 +5515,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -4066,6 +5633,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4091,6 +5747,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -4120,6 +5865,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4145,6 +5979,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -4174,6 +6097,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4201,6 +6213,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4226,6 +6327,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -4296,10 +6486,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -4329,7 +6552,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -4359,7 +6583,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -4401,7 +6626,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -4431,7 +6657,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -4464,7 +6691,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -4620,6 +6848,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4658,10 +6915,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -4694,7 +6996,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -4724,7 +7027,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -4853,6 +7157,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4874,6 +7194,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -4899,6 +7239,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4920,6 +7280,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -4945,6 +7325,26 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4968,10 +7368,31 @@ pub mod nvmc {
                 Readynext(0)
             }
         }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5184,6 +7605,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5207,6 +7648,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5228,6 +7689,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -5308,6 +7789,41 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .field("usbdetected", &self.usbdetected())
+                    .field("usbremoved", &self.usbremoved())
+                    .field("usbpwrrdy", &self.usbpwrrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                    usbdetected: bool,
+                    usbremoved: bool,
+                    usbpwrrdy: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                    usbdetected: self.usbdetected(),
+                    usbremoved: self.usbremoved(),
+                    usbpwrrdy: self.usbpwrrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Main supply status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5329,6 +7845,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Mainregstatus {
                 Mainregstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Mainregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mainregstatus")
+                    .field("mainregstatus", &self.mainregstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mainregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mainregstatus {
+                    mainregstatus: super::vals::Mainregstatus,
+                }
+                let proxy = Mainregstatus {
+                    mainregstatus: self.mainregstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power-fail comparator configuration"]
@@ -5376,6 +7912,32 @@ pub mod power {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("thresholdvddh", &self.thresholdvddh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    thresholdvddh: super::vals::Thresholdvddh,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    thresholdvddh: self.thresholdvddh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAMn power control register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5418,6 +7980,32 @@ pub mod power {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("s_power", &[self.s_power(0usize), self.s_power(1usize)])
+                    .field(
+                        "s_retention",
+                        &[self.s_retention(0usize), self.s_retention(1usize)],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 2usize],
+                    s_retention: [bool; 2usize],
+                }
+                let proxy = Power {
+                    s_power: [self.s_power(0usize), self.s_power(1usize)],
+                    s_retention: [self.s_retention(0usize), self.s_retention(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Deprecated register - RAM status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5450,6 +8038,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Ramstatus {
                 Ramstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ramstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramstatus")
+                    .field("ramblock0", &self.ramblock0())
+                    .field("ramblock1", &self.ramblock1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramstatus {
+                    ramblock0: bool,
+                    ramblock1: bool,
+                }
+                let proxy = Ramstatus {
+                    ramblock0: self.ramblock0(),
+                    ramblock1: self.ramblock1(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -5541,6 +8152,44 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .field("vbus", &self.vbus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    dif: bool,
+                    vbus: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    dif: self.dif(),
+                    vbus: self.vbus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5562,6 +8211,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "USB supply status"]
@@ -5598,10 +8267,34 @@ pub mod power {
                 Usbregstatus(0)
             }
         }
+        impl core::fmt::Debug for Usbregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbregstatus")
+                    .field("vbusdetect", &self.vbusdetect())
+                    .field("outputrdy", &self.outputrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbregstatus {
+                    vbusdetect: bool,
+                    outputrdy: bool,
+                }
+                let proxy = Usbregstatus {
+                    vbusdetect: self.vbusdetect(),
+                    outputrdy: self.outputrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mainregstatus {
             #[doc = "Normal voltage mode. Voltage supplied on VDD."]
             NORMAL = 0x0,
@@ -5631,7 +8324,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -5685,7 +8379,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Thresholdvddh {
             #[doc = "Set threshold to 2.7 V"]
             V27 = 0x0,
@@ -5905,6 +8600,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5930,6 +8714,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -6133,6 +9006,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6154,6 +9047,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -6179,6 +9092,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6200,6 +9133,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -6269,6 +9222,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6290,6 +9275,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -6315,6 +9320,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6338,6 +9363,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6359,6 +9404,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6450,10 +9515,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -6483,7 +9587,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -6534,7 +9639,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -7126,6 +10232,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7182,6 +10308,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear the GPIO pattern array for antenna control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7203,6 +10358,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC configuration"]
@@ -7239,6 +10414,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7261,6 +10459,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -7287,6 +10505,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7308,6 +10546,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -7412,6 +10670,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7455,6 +10754,32 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ctestatus {
                 Ctestatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -7645,6 +10970,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7666,6 +11056,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -7691,6 +11097,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7712,6 +11134,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -7818,6 +11260,47 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("repeatpattern", &self.repeatpattern())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    repeatpattern: super::vals::Repeatpattern,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    repeatpattern: self.repeatpattern(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7852,6 +11335,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7873,6 +11379,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -7909,6 +11435,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect loop count"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7933,6 +11482,26 @@ pub mod radio {
                 Edcnt(0)
             }
         }
+        impl core::fmt::Debug for Edcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edcnt")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edcnt {
+                    edcnt: u32,
+                }
+                let proxy = Edcnt {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect level"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7954,6 +11523,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edsample {
                 Edsample(0)
+            }
+        }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -7988,6 +11577,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -8266,6 +11878,95 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("framestart", &self.framestart())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("phyend", &self.phyend())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    framestart: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    txready: bool,
+                    rxready: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    phyend: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    framestart: self.framestart(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    phyend: self.phyend(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8289,6 +11990,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8310,6 +12031,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -8344,6 +12081,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -8449,6 +12209,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8517,6 +12318,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8551,6 +12384,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8572,6 +12428,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -8630,6 +12506,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8686,6 +12591,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8707,6 +12641,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -8809,6 +12763,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8831,6 +12826,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -8856,6 +12871,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8877,6 +12912,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -9100,6 +13151,80 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9121,6 +13246,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -9146,6 +13291,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9167,6 +13332,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmit address select"]
@@ -9192,6 +13373,26 @@ pub mod radio {
                 Txaddress(0)
             }
         }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output power"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9215,10 +13416,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -9257,7 +13479,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -9289,7 +13512,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -9319,7 +13543,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -9349,7 +13574,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -9389,7 +13615,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -9429,7 +13656,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8 us unit (default) Set to 20 if parsed CTETime is larger than 20"]
             _20 = 0x0,
@@ -9462,7 +13690,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -9492,7 +13721,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -9525,7 +13755,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -9558,7 +13789,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -9588,7 +13820,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -9622,7 +13855,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHz and 2500 MHz"]
             DEFAULT = 0x0,
@@ -9652,7 +13886,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -9701,7 +13936,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -9731,7 +13967,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -9765,7 +14002,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Repeatpattern {
             #[doc = "Do not repeat (1 time in total)"]
             NO_REPEAT = 0x0,
@@ -9808,7 +14046,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -9838,7 +14077,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -9868,7 +14108,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -9898,7 +14139,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -9928,7 +14170,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -9961,7 +14204,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -10012,7 +14256,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -10052,7 +14297,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10092,7 +14338,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10132,7 +14379,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10169,7 +14417,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -10549,6 +14798,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10570,6 +14839,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -10595,6 +14884,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10616,6 +14925,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10740,6 +15069,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10762,6 +15111,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -10813,6 +15182,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10862,6 +15270,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10883,6 +15330,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10924,10 +15391,34 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -11103,6 +15594,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11124,6 +15641,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -11150,6 +15687,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11171,6 +15728,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -11196,6 +15771,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11219,10 +15810,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -11252,7 +15860,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -11282,7 +15891,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -11352,6 +15962,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -11365,7 +16004,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -11665,6 +16305,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11686,6 +16352,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -11710,6 +16396,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -11779,6 +16485,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11800,6 +16538,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -11825,6 +16579,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11846,6 +16620,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -11871,6 +16663,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11892,6 +16704,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -11917,6 +16749,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11938,6 +16790,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes in transmit buffer"]
@@ -11963,10 +16833,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -11996,7 +16887,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -12026,7 +16918,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -12096,6 +16989,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -12109,7 +17031,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -12139,7 +17062,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -12171,7 +17095,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -12468,6 +17393,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12491,6 +17442,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12512,6 +17479,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -12559,6 +17546,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12580,6 +17593,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -12605,6 +17634,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12626,6 +17675,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -12651,6 +17718,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12674,6 +17761,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12695,6 +17802,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -12731,6 +17858,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12752,6 +17902,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -12777,6 +17947,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12800,10 +17988,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -12833,7 +18042,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -12863,7 +18073,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -12907,7 +18118,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -12937,7 +18149,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -12969,7 +18182,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -13003,7 +18217,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13150,6 +18365,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -13267,6 +18502,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13294,6 +18549,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13317,6 +18609,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13338,6 +18646,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13382,10 +18710,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -13419,7 +18805,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -13627,6 +19014,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13648,6 +19055,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -13695,6 +19122,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13717,6 +19170,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -13797,6 +19270,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13818,6 +19326,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13854,6 +19378,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13877,10 +19424,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -13940,6 +19504,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -14214,6 +19799,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14235,6 +19840,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14282,6 +19907,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14304,6 +19955,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14395,6 +20066,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14416,6 +20125,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14441,6 +20170,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14462,6 +20209,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14542,6 +20309,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14563,6 +20365,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14588,6 +20410,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14611,10 +20451,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -14676,6 +20537,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -14689,7 +20571,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14725,7 +20608,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15029,6 +20913,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15063,6 +20967,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15084,6 +21011,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -15129,6 +21076,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15209,6 +21182,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15230,6 +21238,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -15255,6 +21283,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15276,6 +21320,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15301,6 +21365,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15322,6 +21404,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15358,6 +21460,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15379,6 +21504,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15404,6 +21549,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15427,10 +21590,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -15474,7 +21658,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15506,7 +21691,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15724,6 +21910,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15780,6 +21986,35 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15801,6 +22036,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -15857,6 +22112,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -15937,6 +22221,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15958,6 +22277,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15994,6 +22329,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16015,6 +22373,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16068,6 +22442,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -16081,7 +22506,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -16117,7 +22543,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -16161,7 +22588,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -16191,7 +22619,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -16501,6 +22930,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16557,6 +23006,35 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16578,6 +23056,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -16634,6 +23132,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16769,6 +23296,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16792,6 +23369,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16813,6 +23410,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16849,6 +23466,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16872,6 +23512,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16893,6 +23553,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16946,6 +23626,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -16959,7 +23690,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -16995,7 +23727,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -17039,7 +23772,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -17069,7 +23803,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -17184,6 +23919,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Processor debug control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17205,6 +23958,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Debugctrl {
                 Debugctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Debugctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Debugctrl")
+                    .field("cpufpben", &self.cpufpben())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Debugctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Debugctrl {
+                    cpufpben: super::vals::Cpufpben,
+                }
+                let proxy = Debugctrl {
+                    cpufpben: self.cpufpben(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output voltage from REG0 regulator stage. The maximum output voltage from this stage is given as VDDH - V_VDDH-VDD."]
@@ -17230,6 +24003,24 @@ pub mod uicr {
                 Regout0(0)
             }
         }
+        impl core::fmt::Debug for Regout0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regout0")
+                    .field("vout", &self.vout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regout0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regout0 {
+                    vout: super::vals::Vout,
+                }
+                let proxy = Regout0 { vout: self.vout() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -17247,6 +24038,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Cpufpben {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0xff => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpufpben {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0xff => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Cpufpben {
@@ -17280,6 +24090,27 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Pall {
             #[inline(always)]
             fn from(val: u8) -> Pall {
@@ -17293,7 +24124,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Vout {
             #[doc = "1.8 V"]
             _1V8 = 0x0,
@@ -17865,6 +24697,32 @@ pub mod usbd {
                 Bmrequesttype(0)
             }
         }
+        impl core::fmt::Debug for Bmrequesttype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bmrequesttype")
+                    .field("recipient", &self.recipient())
+                    .field("type_", &self.type_())
+                    .field("direction", &self.direction())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bmrequesttype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bmrequesttype {
+                    recipient: super::vals::Recipient,
+                    type_: super::vals::Type,
+                    direction: super::vals::Io,
+                }
+                let proxy = Bmrequesttype {
+                    recipient: self.recipient(),
+                    type_: self.type_(),
+                    direction: self.direction(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 1, bRequest"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17888,6 +24746,26 @@ pub mod usbd {
                 Brequest(0)
             }
         }
+        impl core::fmt::Debug for Brequest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Brequest")
+                    .field("brequest", &self.brequest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Brequest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Brequest {
+                    brequest: super::vals::Brequest,
+                }
+                let proxy = Brequest {
+                    brequest: self.brequest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State D+ and D- lines will be forced into by the DPDMDRIVE task. The DPDMNODRIVE task reverts the control of the lines to MAC IP (no forcing)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17909,6 +24787,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Dpdmvalue {
                 Dpdmvalue(0)
+            }
+        }
+        impl core::fmt::Debug for Dpdmvalue {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpdmvalue")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpdmvalue {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpdmvalue {
+                    state: super::vals::State,
+                }
+                let proxy = Dpdmvalue {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data toggle control and status"]
@@ -17956,6 +24854,32 @@ pub mod usbd {
                 Dtoggle(0)
             }
         }
+        impl core::fmt::Debug for Dtoggle {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dtoggle")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dtoggle {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dtoggle {
+                    ep: u8,
+                    io: super::vals::Io,
+                    value: super::vals::Value,
+                }
+                let proxy = Dtoggle {
+                    ep: self.ep(),
+                    io: self.io(),
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable USB"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17977,6 +24901,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Provides information on which endpoint(s) an acknowledged data transfer has occurred (EPDATA event)"]
@@ -18021,6 +24965,67 @@ pub mod usbd {
                 Epdatastatus(0)
             }
         }
+        impl core::fmt::Debug for Epdatastatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epdatastatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epdatastatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epdatastatus {
+                    epin: [bool; 7usize],
+                    epout: [bool; 7usize],
+                }
+                let proxy = Epdatastatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: IN endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18043,6 +25048,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epin {
                 Epin(0)
+            }
+        }
+        impl core::fmt::Debug for Epin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epin")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epin {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = Epin {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
@@ -18068,6 +25093,26 @@ pub mod usbd {
                 EpinAmount(0)
             }
         }
+        impl core::fmt::Debug for EpinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinAmount {
+                    amount: u8,
+                }
+                let proxy = EpinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18089,6 +25134,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpinMaxcnt {
                 EpinMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint IN enable"]
@@ -18129,6 +25194,50 @@ pub mod usbd {
                 Epinen(0)
             }
         }
+        impl core::fmt::Debug for Epinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epinen")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("isoin", &self.isoin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epinen {
+                    in_: [bool; 8usize],
+                    isoin: bool,
+                }
+                let proxy = Epinen {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    isoin: self.isoin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18152,6 +25261,26 @@ pub mod usbd {
                 EpoutAmount(0)
             }
         }
+        impl core::fmt::Debug for EpoutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutAmount {
+                    amount: u8,
+                }
+                let proxy = EpoutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18173,6 +25302,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpoutMaxcnt {
                 EpoutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpoutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpoutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint OUT enable"]
@@ -18211,6 +25360,50 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epouten {
                 Epouten(0)
+            }
+        }
+        impl core::fmt::Debug for Epouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epouten")
+                    .field(
+                        "out",
+                        &[
+                            self.out(0usize),
+                            self.out(1usize),
+                            self.out(2usize),
+                            self.out(3usize),
+                            self.out(4usize),
+                            self.out(5usize),
+                            self.out(6usize),
+                            self.out(7usize),
+                        ],
+                    )
+                    .field("isoout", &self.isoout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epouten {
+                    out: [bool; 8usize],
+                    isoout: bool,
+                }
+                let proxy = Epouten {
+                    out: [
+                        self.out(0usize),
+                        self.out(1usize),
+                        self.out(2usize),
+                        self.out(3usize),
+                        self.out(4usize),
+                        self.out(5usize),
+                        self.out(6usize),
+                        self.out(7usize),
+                    ],
+                    isoout: self.isoout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "STALL endpoints"]
@@ -18258,6 +25451,32 @@ pub mod usbd {
                 Epstall(0)
             }
         }
+        impl core::fmt::Debug for Epstall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstall")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("stall", &self.stall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstall {
+                    ep: u8,
+                    io: super::vals::Io,
+                    stall: bool,
+                }
+                let proxy = Epstall {
+                    ep: self.ep(),
+                    io: self.io(),
+                    stall: self.stall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Provides information on which endpoint's EasyDMA registers have been captured"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18298,6 +25517,75 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epstatus {
                 Epstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Epstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                            self.epin(7usize),
+                            self.epin(8usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                            self.epout(7usize),
+                            self.epout(8usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstatus {
+                    epin: [bool; 9usize],
+                    epout: [bool; 9usize],
+                }
+                let proxy = Epstatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                        self.epin(7usize),
+                        self.epin(8usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                        self.epout(7usize),
+                        self.epout(8usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Details on what caused the USBEVENT event"]
@@ -18367,6 +25655,38 @@ pub mod usbd {
                 Eventcause(0)
             }
         }
+        impl core::fmt::Debug for Eventcause {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eventcause")
+                    .field("isooutcrc", &self.isooutcrc())
+                    .field("suspend", &self.suspend())
+                    .field("resume", &self.resume())
+                    .field("usbwuallowed", &self.usbwuallowed())
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eventcause {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eventcause {
+                    isooutcrc: bool,
+                    suspend: bool,
+                    resume: bool,
+                    usbwuallowed: bool,
+                    ready: bool,
+                }
+                let proxy = Eventcause {
+                    isooutcrc: self.isooutcrc(),
+                    suspend: self.suspend(),
+                    resume: self.resume(),
+                    usbwuallowed: self.usbwuallowed(),
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Returns the current value of the start of frame counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18388,6 +25708,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Framecntr {
                 Framecntr(0)
+            }
+        }
+        impl core::fmt::Debug for Framecntr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framecntr")
+                    .field("framecntr", &self.framecntr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framecntr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framecntr {
+                    framecntr: u16,
+                }
+                let proxy = Framecntr {
+                    framecntr: self.framecntr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: OUT endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
@@ -18412,6 +25752,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> HaltedEpout {
                 HaltedEpout(0)
+            }
+        }
+        impl core::fmt::Debug for HaltedEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HaltedEpout")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HaltedEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HaltedEpout {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = HaltedEpout {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -18555,6 +25915,98 @@ pub mod usbd {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("usbreset", &self.usbreset())
+                    .field("started", &self.started())
+                    .field(
+                        "endepin",
+                        &[
+                            self.endepin(0usize),
+                            self.endepin(1usize),
+                            self.endepin(2usize),
+                            self.endepin(3usize),
+                            self.endepin(4usize),
+                            self.endepin(5usize),
+                            self.endepin(6usize),
+                            self.endepin(7usize),
+                        ],
+                    )
+                    .field("ep0datadone", &self.ep0datadone())
+                    .field("endisoin", &self.endisoin())
+                    .field(
+                        "endepout",
+                        &[
+                            self.endepout(0usize),
+                            self.endepout(1usize),
+                            self.endepout(2usize),
+                            self.endepout(3usize),
+                            self.endepout(4usize),
+                            self.endepout(5usize),
+                            self.endepout(6usize),
+                            self.endepout(7usize),
+                        ],
+                    )
+                    .field("endisoout", &self.endisoout())
+                    .field("sof", &self.sof())
+                    .field("usbevent", &self.usbevent())
+                    .field("ep0setup", &self.ep0setup())
+                    .field("epdata", &self.epdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    usbreset: bool,
+                    started: bool,
+                    endepin: [bool; 8usize],
+                    ep0datadone: bool,
+                    endisoin: bool,
+                    endepout: [bool; 8usize],
+                    endisoout: bool,
+                    sof: bool,
+                    usbevent: bool,
+                    ep0setup: bool,
+                    epdata: bool,
+                }
+                let proxy = Int {
+                    usbreset: self.usbreset(),
+                    started: self.started(),
+                    endepin: [
+                        self.endepin(0usize),
+                        self.endepin(1usize),
+                        self.endepin(2usize),
+                        self.endepin(3usize),
+                        self.endepin(4usize),
+                        self.endepin(5usize),
+                        self.endepin(6usize),
+                        self.endepin(7usize),
+                    ],
+                    ep0datadone: self.ep0datadone(),
+                    endisoin: self.endisoin(),
+                    endepout: [
+                        self.endepout(0usize),
+                        self.endepout(1usize),
+                        self.endepout(2usize),
+                        self.endepout(3usize),
+                        self.endepout(4usize),
+                        self.endepout(5usize),
+                        self.endepout(6usize),
+                        self.endepout(7usize),
+                    ],
+                    endisoout: self.endisoout(),
+                    sof: self.sof(),
+                    usbevent: self.usbevent(),
+                    ep0setup: self.ep0setup(),
+                    epdata: self.epdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18576,6 +26028,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsoinAmount {
                 IsoinAmount(0)
+            }
+        }
+        impl core::fmt::Debug for IsoinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinAmount {
+                    amount: u16,
+                }
+                let proxy = IsoinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -18601,6 +26073,26 @@ pub mod usbd {
                 IsoinMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for IsoinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsoinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the response of the ISO IN endpoint to an IN token when no data is ready to be sent"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18622,6 +26114,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Isoinconfig {
                 Isoinconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Isoinconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoinconfig")
+                    .field("response", &self.response())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoinconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoinconfig {
+                    response: super::vals::Response,
+                }
+                let proxy = Isoinconfig {
+                    response: self.response(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received last on this ISO OUT data endpoint"]
@@ -18659,6 +26171,29 @@ pub mod usbd {
                 Isoout(0)
             }
         }
+        impl core::fmt::Debug for Isoout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoout")
+                    .field("size", &self.size())
+                    .field("zero", &self.zero())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoout {
+                    size: u16,
+                    zero: super::vals::Zero,
+                }
+                let proxy = Isoout {
+                    size: self.size(),
+                    zero: self.zero(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18682,6 +26217,26 @@ pub mod usbd {
                 IsooutAmount(0)
             }
         }
+        impl core::fmt::Debug for IsooutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutAmount {
+                    amount: u16,
+                }
+                let proxy = IsooutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18703,6 +26258,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsooutMaxcnt {
                 IsooutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for IsooutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsooutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the split of ISO buffers"]
@@ -18729,6 +26304,26 @@ pub mod usbd {
                 Isosplit(0)
             }
         }
+        impl core::fmt::Debug for Isosplit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isosplit")
+                    .field("split", &self.split())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isosplit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isosplit {
+                    split: super::vals::Split,
+                }
+                let proxy = Isosplit {
+                    split: self.split(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls USBD peripheral low power mode during USB suspend"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18750,6 +26345,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Lowpower {
                 Lowpower(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpower")
+                    .field("lowpower", &self.lowpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpower {
+                    lowpower: super::vals::Lowpower,
+                }
+                let proxy = Lowpower {
+                    lowpower: self.lowpower(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -18819,6 +26434,38 @@ pub mod usbd {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ep0datadone_startepin0", &self.ep0datadone_startepin0())
+                    .field("ep0datadone_startepout0", &self.ep0datadone_startepout0())
+                    .field("ep0datadone_ep0status", &self.ep0datadone_ep0status())
+                    .field("endepout0_ep0status", &self.endepout0_ep0status())
+                    .field("endepout0_ep0rcvout", &self.endepout0_ep0rcvout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ep0datadone_startepin0: bool,
+                    ep0datadone_startepout0: bool,
+                    ep0datadone_ep0status: bool,
+                    endepout0_ep0status: bool,
+                    endepout0_ep0rcvout: bool,
+                }
+                let proxy = Shorts {
+                    ep0datadone_startepin0: self.ep0datadone_startepin0(),
+                    ep0datadone_startepout0: self.ep0datadone_startepout0(),
+                    ep0datadone_ep0status: self.ep0datadone_ep0status(),
+                    endepout0_ep0status: self.endepout0_ep0status(),
+                    endepout0_ep0rcvout: self.endepout0_ep0rcvout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Number of bytes received last in the data stage of this OUT endpoint"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18840,6 +26487,24 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> SizeEpout {
                 SizeEpout(0)
+            }
+        }
+        impl core::fmt::Debug for SizeEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SizeEpout")
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SizeEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SizeEpout {
+                    size: u8,
+                }
+                let proxy = SizeEpout { size: self.size() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device USB address"]
@@ -18865,6 +26530,24 @@ pub mod usbd {
                 Usbaddr(0)
             }
         }
+        impl core::fmt::Debug for Usbaddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbaddr")
+                    .field("addr", &self.addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbaddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbaddr {
+                    addr: u8,
+                }
+                let proxy = Usbaddr { addr: self.addr() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control of the USB pull-up"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18886,6 +26569,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Usbpullup {
                 Usbpullup(0)
+            }
+        }
+        impl core::fmt::Debug for Usbpullup {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbpullup")
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbpullup {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbpullup {
+                    connect: bool,
+                }
+                let proxy = Usbpullup {
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 5, MSB of wIndex"]
@@ -18911,6 +26614,26 @@ pub mod usbd {
                 Windexh(0)
             }
         }
+        impl core::fmt::Debug for Windexh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexh")
+                    .field("windexh", &self.windexh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexh {
+                    windexh: u8,
+                }
+                let proxy = Windexh {
+                    windexh: self.windexh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 4, LSB of wIndex"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18932,6 +26655,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Windexl {
                 Windexl(0)
+            }
+        }
+        impl core::fmt::Debug for Windexl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexl")
+                    .field("windexl", &self.windexl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexl {
+                    windexl: u8,
+                }
+                let proxy = Windexl {
+                    windexl: self.windexl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 7, MSB of wLength"]
@@ -18957,6 +26700,26 @@ pub mod usbd {
                 Wlengthh(0)
             }
         }
+        impl core::fmt::Debug for Wlengthh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthh")
+                    .field("wlengthh", &self.wlengthh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthh {
+                    wlengthh: u8,
+                }
+                let proxy = Wlengthh {
+                    wlengthh: self.wlengthh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 6, LSB of wLength"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18978,6 +26741,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Wlengthl {
                 Wlengthl(0)
+            }
+        }
+        impl core::fmt::Debug for Wlengthl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthl")
+                    .field("wlengthl", &self.wlengthl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthl {
+                    wlengthl: u8,
+                }
+                let proxy = Wlengthl {
+                    wlengthl: self.wlengthl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 3, MSB of wValue"]
@@ -19003,6 +26786,26 @@ pub mod usbd {
                 Wvalueh(0)
             }
         }
+        impl core::fmt::Debug for Wvalueh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvalueh")
+                    .field("wvalueh", &self.wvalueh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvalueh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvalueh {
+                    wvalueh: u8,
+                }
+                let proxy = Wvalueh {
+                    wvalueh: self.wvalueh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 2, LSB of wValue"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19026,10 +26829,31 @@ pub mod usbd {
                 Wvaluel(0)
             }
         }
+        impl core::fmt::Debug for Wvaluel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvaluel")
+                    .field("wvaluel", &self.wvaluel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvaluel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvaluel {
+                    wvaluel: u8,
+                }
+                let proxy = Wvaluel {
+                    wvaluel: self.wvaluel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Brequest {
             #[doc = "Standard request GET_STATUS"]
             STD_GET_STATUS = 0x0,
@@ -19338,6 +27162,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Getstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("NOT_HALTED"),
+                    0x01 => f.write_str("HALTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Getstatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "NOT_HALTED"),
+                    0x01 => defmt::write!(f, "HALTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Getstatus {
             #[inline(always)]
             fn from(val: u16) -> Getstatus {
@@ -19351,7 +27194,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Io {
             #[doc = "Selects OUT endpoint"]
             OUT = 0x0,
@@ -19381,7 +27225,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lowpower {
             #[doc = "Software must write this value to exit low power mode and before performing a remote wake-up"]
             FORCE_NORMAL = 0x0,
@@ -19431,6 +27276,29 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Recipient {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DEVICE"),
+                    0x01 => f.write_str("INTERFACE"),
+                    0x02 => f.write_str("ENDPOINT"),
+                    0x03 => f.write_str("OTHER"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Recipient {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DEVICE"),
+                    0x01 => defmt::write!(f, "INTERFACE"),
+                    0x02 => defmt::write!(f, "ENDPOINT"),
+                    0x03 => defmt::write!(f, "OTHER"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Recipient {
             #[inline(always)]
             fn from(val: u8) -> Recipient {
@@ -19444,7 +27312,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Response {
             #[doc = "Endpoint does not respond in that case"]
             NO_RESP = 0x0,
@@ -19490,6 +27359,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Split {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ONE_DIR"),
+                    0x80 => f.write_str("HALF_IN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Split {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ONE_DIR"),
+                    0x80 => defmt::write!(f, "HALF_IN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Split {
             #[inline(always)]
             fn from(val: u16) -> Split {
@@ -19521,6 +27409,27 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("RESUME"),
+                    0x02 => f.write_str("J"),
+                    0x04 => f.write_str("K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "RESUME"),
+                    0x02 => defmt::write!(f, "J"),
+                    0x04 => defmt::write!(f, "K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for State {
             #[inline(always)]
             fn from(val: u8) -> State {
@@ -19534,7 +27443,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Type {
             #[doc = "Standard"]
             STANDARD = 0x0,
@@ -19567,7 +27477,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Value {
             #[doc = "No action on data toggle when writing the register with this value"]
             NOP = 0x0,
@@ -19600,7 +27511,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Zero {
             #[doc = "No zero-length data received, use value in SIZE"]
             NORMAL = 0x0,
@@ -19735,6 +27647,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19756,6 +27691,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -19785,6 +27740,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19807,6 +27803,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -19836,6 +27848,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19859,10 +27912,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -19906,6 +27980,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -19919,7 +28010,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52832/pac.rs
+++ b/src/chips/nrf52832/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -434,6 +435,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -479,6 +500,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -500,6 +547,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -525,10 +588,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -615,6 +699,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset. This register can only be written once."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -638,6 +742,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -653,6 +777,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -680,6 +821,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -1106,6 +1264,119 @@ pub mod bprot {
                 Config0(0)
             }
         }
+        impl core::fmt::Debug for Config0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config0")
+                    .field("region0", &self.region0())
+                    .field("region1", &self.region1())
+                    .field("region2", &self.region2())
+                    .field("region3", &self.region3())
+                    .field("region4", &self.region4())
+                    .field("region5", &self.region5())
+                    .field("region6", &self.region6())
+                    .field("region7", &self.region7())
+                    .field("region8", &self.region8())
+                    .field("region9", &self.region9())
+                    .field("region10", &self.region10())
+                    .field("region11", &self.region11())
+                    .field("region12", &self.region12())
+                    .field("region13", &self.region13())
+                    .field("region14", &self.region14())
+                    .field("region15", &self.region15())
+                    .field("region16", &self.region16())
+                    .field("region17", &self.region17())
+                    .field("region18", &self.region18())
+                    .field("region19", &self.region19())
+                    .field("region20", &self.region20())
+                    .field("region21", &self.region21())
+                    .field("region22", &self.region22())
+                    .field("region23", &self.region23())
+                    .field("region24", &self.region24())
+                    .field("region25", &self.region25())
+                    .field("region26", &self.region26())
+                    .field("region27", &self.region27())
+                    .field("region28", &self.region28())
+                    .field("region29", &self.region29())
+                    .field("region30", &self.region30())
+                    .field("region31", &self.region31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config0 {
+                    region0: bool,
+                    region1: bool,
+                    region2: bool,
+                    region3: bool,
+                    region4: bool,
+                    region5: bool,
+                    region6: bool,
+                    region7: bool,
+                    region8: bool,
+                    region9: bool,
+                    region10: bool,
+                    region11: bool,
+                    region12: bool,
+                    region13: bool,
+                    region14: bool,
+                    region15: bool,
+                    region16: bool,
+                    region17: bool,
+                    region18: bool,
+                    region19: bool,
+                    region20: bool,
+                    region21: bool,
+                    region22: bool,
+                    region23: bool,
+                    region24: bool,
+                    region25: bool,
+                    region26: bool,
+                    region27: bool,
+                    region28: bool,
+                    region29: bool,
+                    region30: bool,
+                    region31: bool,
+                }
+                let proxy = Config0 {
+                    region0: self.region0(),
+                    region1: self.region1(),
+                    region2: self.region2(),
+                    region3: self.region3(),
+                    region4: self.region4(),
+                    region5: self.region5(),
+                    region6: self.region6(),
+                    region7: self.region7(),
+                    region8: self.region8(),
+                    region9: self.region9(),
+                    region10: self.region10(),
+                    region11: self.region11(),
+                    region12: self.region12(),
+                    region13: self.region13(),
+                    region14: self.region14(),
+                    region15: self.region15(),
+                    region16: self.region16(),
+                    region17: self.region17(),
+                    region18: self.region18(),
+                    region19: self.region19(),
+                    region20: self.region20(),
+                    region21: self.region21(),
+                    region22: self.region22(),
+                    region23: self.region23(),
+                    region24: self.region24(),
+                    region25: self.region25(),
+                    region26: self.region26(),
+                    region27: self.region27(),
+                    region28: self.region28(),
+                    region29: self.region29(),
+                    region30: self.region30(),
+                    region31: self.region31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Block protect configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1468,6 +1739,119 @@ pub mod bprot {
             #[inline(always)]
             fn default() -> Config1 {
                 Config1(0)
+            }
+        }
+        impl core::fmt::Debug for Config1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config1")
+                    .field("region32", &self.region32())
+                    .field("region33", &self.region33())
+                    .field("region34", &self.region34())
+                    .field("region35", &self.region35())
+                    .field("region36", &self.region36())
+                    .field("region37", &self.region37())
+                    .field("region38", &self.region38())
+                    .field("region39", &self.region39())
+                    .field("region40", &self.region40())
+                    .field("region41", &self.region41())
+                    .field("region42", &self.region42())
+                    .field("region43", &self.region43())
+                    .field("region44", &self.region44())
+                    .field("region45", &self.region45())
+                    .field("region46", &self.region46())
+                    .field("region47", &self.region47())
+                    .field("region48", &self.region48())
+                    .field("region49", &self.region49())
+                    .field("region50", &self.region50())
+                    .field("region51", &self.region51())
+                    .field("region52", &self.region52())
+                    .field("region53", &self.region53())
+                    .field("region54", &self.region54())
+                    .field("region55", &self.region55())
+                    .field("region56", &self.region56())
+                    .field("region57", &self.region57())
+                    .field("region58", &self.region58())
+                    .field("region59", &self.region59())
+                    .field("region60", &self.region60())
+                    .field("region61", &self.region61())
+                    .field("region62", &self.region62())
+                    .field("region63", &self.region63())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config1 {
+                    region32: bool,
+                    region33: bool,
+                    region34: bool,
+                    region35: bool,
+                    region36: bool,
+                    region37: bool,
+                    region38: bool,
+                    region39: bool,
+                    region40: bool,
+                    region41: bool,
+                    region42: bool,
+                    region43: bool,
+                    region44: bool,
+                    region45: bool,
+                    region46: bool,
+                    region47: bool,
+                    region48: bool,
+                    region49: bool,
+                    region50: bool,
+                    region51: bool,
+                    region52: bool,
+                    region53: bool,
+                    region54: bool,
+                    region55: bool,
+                    region56: bool,
+                    region57: bool,
+                    region58: bool,
+                    region59: bool,
+                    region60: bool,
+                    region61: bool,
+                    region62: bool,
+                    region63: bool,
+                }
+                let proxy = Config1 {
+                    region32: self.region32(),
+                    region33: self.region33(),
+                    region34: self.region34(),
+                    region35: self.region35(),
+                    region36: self.region36(),
+                    region37: self.region37(),
+                    region38: self.region38(),
+                    region39: self.region39(),
+                    region40: self.region40(),
+                    region41: self.region41(),
+                    region42: self.region42(),
+                    region43: self.region43(),
+                    region44: self.region44(),
+                    region45: self.region45(),
+                    region46: self.region46(),
+                    region47: self.region47(),
+                    region48: self.region48(),
+                    region49: self.region49(),
+                    region50: self.region50(),
+                    region51: self.region51(),
+                    region52: self.region52(),
+                    region53: self.region53(),
+                    region54: self.region54(),
+                    region55: self.region55(),
+                    region56: self.region56(),
+                    region57: self.region57(),
+                    region58: self.region58(),
+                    region59: self.region59(),
+                    region60: self.region60(),
+                    region61: self.region61(),
+                    region62: self.region62(),
+                    region63: self.region63(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Block protect configuration register 2"]
@@ -1834,6 +2218,119 @@ pub mod bprot {
                 Config2(0)
             }
         }
+        impl core::fmt::Debug for Config2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config2")
+                    .field("region64", &self.region64())
+                    .field("region65", &self.region65())
+                    .field("region66", &self.region66())
+                    .field("region67", &self.region67())
+                    .field("region68", &self.region68())
+                    .field("region69", &self.region69())
+                    .field("region70", &self.region70())
+                    .field("region71", &self.region71())
+                    .field("region72", &self.region72())
+                    .field("region73", &self.region73())
+                    .field("region74", &self.region74())
+                    .field("region75", &self.region75())
+                    .field("region76", &self.region76())
+                    .field("region77", &self.region77())
+                    .field("region78", &self.region78())
+                    .field("region79", &self.region79())
+                    .field("region80", &self.region80())
+                    .field("region81", &self.region81())
+                    .field("region82", &self.region82())
+                    .field("region83", &self.region83())
+                    .field("region84", &self.region84())
+                    .field("region85", &self.region85())
+                    .field("region86", &self.region86())
+                    .field("region87", &self.region87())
+                    .field("region88", &self.region88())
+                    .field("region89", &self.region89())
+                    .field("region90", &self.region90())
+                    .field("region91", &self.region91())
+                    .field("region92", &self.region92())
+                    .field("region93", &self.region93())
+                    .field("region94", &self.region94())
+                    .field("region95", &self.region95())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config2 {
+                    region64: bool,
+                    region65: bool,
+                    region66: bool,
+                    region67: bool,
+                    region68: bool,
+                    region69: bool,
+                    region70: bool,
+                    region71: bool,
+                    region72: bool,
+                    region73: bool,
+                    region74: bool,
+                    region75: bool,
+                    region76: bool,
+                    region77: bool,
+                    region78: bool,
+                    region79: bool,
+                    region80: bool,
+                    region81: bool,
+                    region82: bool,
+                    region83: bool,
+                    region84: bool,
+                    region85: bool,
+                    region86: bool,
+                    region87: bool,
+                    region88: bool,
+                    region89: bool,
+                    region90: bool,
+                    region91: bool,
+                    region92: bool,
+                    region93: bool,
+                    region94: bool,
+                    region95: bool,
+                }
+                let proxy = Config2 {
+                    region64: self.region64(),
+                    region65: self.region65(),
+                    region66: self.region66(),
+                    region67: self.region67(),
+                    region68: self.region68(),
+                    region69: self.region69(),
+                    region70: self.region70(),
+                    region71: self.region71(),
+                    region72: self.region72(),
+                    region73: self.region73(),
+                    region74: self.region74(),
+                    region75: self.region75(),
+                    region76: self.region76(),
+                    region77: self.region77(),
+                    region78: self.region78(),
+                    region79: self.region79(),
+                    region80: self.region80(),
+                    region81: self.region81(),
+                    region82: self.region82(),
+                    region83: self.region83(),
+                    region84: self.region84(),
+                    region85: self.region85(),
+                    region86: self.region86(),
+                    region87: self.region87(),
+                    region88: self.region88(),
+                    region89: self.region89(),
+                    region90: self.region90(),
+                    region91: self.region91(),
+                    region92: self.region92(),
+                    region93: self.region93(),
+                    region94: self.region94(),
+                    region95: self.region95(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Block protect configuration register 3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2198,6 +2695,119 @@ pub mod bprot {
                 Config3(0)
             }
         }
+        impl core::fmt::Debug for Config3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config3")
+                    .field("region96", &self.region96())
+                    .field("region97", &self.region97())
+                    .field("region98", &self.region98())
+                    .field("region99", &self.region99())
+                    .field("region100", &self.region100())
+                    .field("region101", &self.region101())
+                    .field("region102", &self.region102())
+                    .field("region103", &self.region103())
+                    .field("region104", &self.region104())
+                    .field("region105", &self.region105())
+                    .field("region106", &self.region106())
+                    .field("region107", &self.region107())
+                    .field("region108", &self.region108())
+                    .field("region109", &self.region109())
+                    .field("region110", &self.region110())
+                    .field("region111", &self.region111())
+                    .field("region112", &self.region112())
+                    .field("region113", &self.region113())
+                    .field("region114", &self.region114())
+                    .field("region115", &self.region115())
+                    .field("region116", &self.region116())
+                    .field("region117", &self.region117())
+                    .field("region118", &self.region118())
+                    .field("region119", &self.region119())
+                    .field("region120", &self.region120())
+                    .field("region121", &self.region121())
+                    .field("region122", &self.region122())
+                    .field("region123", &self.region123())
+                    .field("region124", &self.region124())
+                    .field("region125", &self.region125())
+                    .field("region126", &self.region126())
+                    .field("region127", &self.region127())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config3 {
+                    region96: bool,
+                    region97: bool,
+                    region98: bool,
+                    region99: bool,
+                    region100: bool,
+                    region101: bool,
+                    region102: bool,
+                    region103: bool,
+                    region104: bool,
+                    region105: bool,
+                    region106: bool,
+                    region107: bool,
+                    region108: bool,
+                    region109: bool,
+                    region110: bool,
+                    region111: bool,
+                    region112: bool,
+                    region113: bool,
+                    region114: bool,
+                    region115: bool,
+                    region116: bool,
+                    region117: bool,
+                    region118: bool,
+                    region119: bool,
+                    region120: bool,
+                    region121: bool,
+                    region122: bool,
+                    region123: bool,
+                    region124: bool,
+                    region125: bool,
+                    region126: bool,
+                    region127: bool,
+                }
+                let proxy = Config3 {
+                    region96: self.region96(),
+                    region97: self.region97(),
+                    region98: self.region98(),
+                    region99: self.region99(),
+                    region100: self.region100(),
+                    region101: self.region101(),
+                    region102: self.region102(),
+                    region103: self.region103(),
+                    region104: self.region104(),
+                    region105: self.region105(),
+                    region106: self.region106(),
+                    region107: self.region107(),
+                    region108: self.region108(),
+                    region109: self.region109(),
+                    region110: self.region110(),
+                    region111: self.region111(),
+                    region112: self.region112(),
+                    region113: self.region113(),
+                    region114: self.region114(),
+                    region115: self.region115(),
+                    region116: self.region116(),
+                    region117: self.region117(),
+                    region118: self.region118(),
+                    region119: self.region119(),
+                    region120: self.region120(),
+                    region121: self.region121(),
+                    region122: self.region122(),
+                    region123: self.region123(),
+                    region124: self.region124(),
+                    region125: self.region125(),
+                    region126: self.region126(),
+                    region127: self.region127(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable protection mechanism in debug interface mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2221,10 +2831,31 @@ pub mod bprot {
                 Disableindebug(0)
             }
         }
+        impl core::fmt::Debug for Disableindebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disableindebug")
+                    .field("disableindebug", &self.disableindebug())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disableindebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disableindebug {
+                    disableindebug: super::vals::Disableindebug,
+                }
+                let proxy = Disableindebug {
+                    disableindebug: self.disableindebug(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Disableindebug {
             #[doc = "Enable in debug"]
             ENABLED = 0x0,
@@ -2377,6 +3008,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2422,6 +3073,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2443,6 +3120,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -2492,6 +3189,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2515,10 +3238,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "In synch with 1 Mbit data rate"]
             _1MBIT = 0x0,
@@ -2548,7 +3292,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2580,7 +3325,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field is 5-bit"]
             DEFAULT = 0x0,
@@ -2610,7 +3356,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -2640,7 +3387,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -2820,6 +3568,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2841,6 +3605,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -2875,6 +3659,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -2933,6 +3740,35 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2954,6 +3790,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -3001,6 +3857,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3022,6 +3904,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -3056,6 +3956,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkstat {
                 Lfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clocking options for the Trace Port debug interface"]
@@ -3093,10 +4016,34 @@ pub mod clock {
                 Traceconfig(0)
             }
         }
+        impl core::fmt::Debug for Traceconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceconfig")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .field("tracemux", &self.tracemux())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceconfig {
+                    traceportspeed: super::vals::Traceportspeed,
+                    tracemux: super::vals::Tracemux,
+                }
+                let proxy = Traceconfig {
+                    traceportspeed: self.traceportspeed(),
+                    tracemux: self.tracemux(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -3126,7 +4073,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             RC = 0x0,
@@ -3159,7 +4107,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tracemux {
             #[doc = "GPIOs multiplexed onto all trace-pins"]
             GPIO = 0x0,
@@ -3192,7 +4141,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "32 MHz Trace Port clock (TRACECLK = 16 MHz)"]
             _32MHZ = 0x0,
@@ -3446,6 +4396,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3469,6 +4439,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3490,6 +4480,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -3548,6 +4554,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current source select on analog input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3569,6 +4604,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Isource {
                 Isource(0)
+            }
+        }
+        impl core::fmt::Debug for Isource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isource")
+                    .field("isource", &self.isource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isource {
+                    isource: super::vals::Isource,
+                }
+                let proxy = Isource {
+                    isource: self.isource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mode configuration"]
@@ -3605,6 +4660,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3626,6 +4704,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -3651,6 +4745,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3672,6 +4786,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -3741,6 +4875,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3775,10 +4941,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -3810,7 +5000,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -3852,7 +5043,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -3882,7 +5074,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Isource {
             #[doc = "Current source disabled"]
             OFF = 0x0,
@@ -3916,7 +5109,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -3946,7 +5140,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -3988,7 +5183,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -4027,7 +5223,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -4057,7 +5254,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -4179,6 +5377,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -4255,6 +5476,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4538,6 +5816,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4559,6 +5853,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2."]
@@ -4584,6 +5894,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4605,6 +5931,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4."]
@@ -4630,6 +5972,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4651,6 +6009,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "y-intercept B0."]
@@ -4676,6 +6050,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "y-intercept B1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4697,6 +6087,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "y-intercept B2."]
@@ -4722,6 +6128,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "y-intercept B3."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4743,6 +6165,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "y-intercept B4."]
@@ -4768,6 +6206,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "y-intercept B5."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4791,6 +6245,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4812,6 +6282,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -4838,6 +6328,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4860,6 +6370,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -4886,6 +6416,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4908,6 +6454,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Ram {
                 Ram(0)
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T0."]
@@ -4933,6 +6495,22 @@ pub mod ficr {
                 T0(0)
             }
         }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4954,6 +6532,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T1 {
                 T1(0)
+            }
+        }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T2."]
@@ -4979,6 +6573,22 @@ pub mod ficr {
                 T2(0)
             }
         }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T3."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5002,6 +6612,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5023,6 +6649,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -5081,6 +6723,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5135,6 +6806,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -5193,6 +6893,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5249,6 +6978,35 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part Variant, Hardware version and Production configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5273,10 +7031,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -5326,6 +7105,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -5361,6 +7163,31 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QF"),
+                    0x2001 => f.write_str("CH"),
+                    0x2002 => f.write_str("CI"),
+                    0x2005 => f.write_str("CK"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QF"),
+                    0x2001 => defmt::write!(f, "CH"),
+                    0x2002 => defmt::write!(f, "CI"),
+                    0x2005 => defmt::write!(f, "CK"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -5388,6 +7215,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2832 => f.write_str("N52832"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2832 => defmt::write!(f, "N52832"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Part {
@@ -5421,6 +7267,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -5472,6 +7341,47 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4143 => f.write_str("AAAC"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4241 => f.write_str("AABA"),
+                    0x4141_4242 => f.write_str("AABB"),
+                    0x4141_4530 => f.write_str("AAE0"),
+                    0x4141_4730 => f.write_str("AAG0"),
+                    0x4141_4742 => f.write_str("AAGB"),
+                    0x4142_4230 => f.write_str("ABB0"),
+                    0x4142_4530 => f.write_str("ABE0"),
+                    0x4142_4730 => f.write_str("ABG0"),
+                    0x4142_4742 => f.write_str("ABGB"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4143 => defmt::write!(f, "AAAC"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4241 => defmt::write!(f, "AABA"),
+                    0x4141_4242 => defmt::write!(f, "AABB"),
+                    0x4141_4530 => defmt::write!(f, "AAE0"),
+                    0x4141_4730 => defmt::write!(f, "AAG0"),
+                    0x4141_4742 => defmt::write!(f, "AAGB"),
+                    0x4142_4230 => defmt::write!(f, "ABB0"),
+                    0x4142_4530 => defmt::write!(f, "ABE0"),
+                    0x4142_4730 => defmt::write!(f, "ABG0"),
+                    0x4142_4742 => defmt::write!(f, "ABGB"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -5608,6 +7518,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5633,6 +7563,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -5662,6 +7681,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5687,6 +7795,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -5716,6 +7913,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5741,6 +8027,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -5770,6 +8145,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5797,6 +8261,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5822,6 +8375,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -5892,10 +8534,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -5925,7 +8600,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -5955,7 +8631,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -5997,7 +8674,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -6027,7 +8705,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -6060,7 +8739,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -6216,6 +8896,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6254,10 +8963,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -6290,7 +9044,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -6320,7 +9075,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -6648,6 +9404,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6669,6 +9445,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module."]
@@ -6694,6 +9490,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6715,6 +9531,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6762,6 +9598,32 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6785,6 +9647,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6806,6 +9688,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Master clock generator frequency."]
@@ -6832,6 +9734,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6853,6 +9775,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio."]
@@ -6878,6 +9816,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6899,6 +9857,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width."]
@@ -6924,6 +9898,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6947,10 +9941,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -6980,7 +9991,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -7013,7 +10025,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -7091,6 +10104,57 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    0x2800_0000 => f.write_str("_32MDIV6"),
+                    0x3000_0000 => f.write_str("_32MDIV5"),
+                    0x4000_0000 => f.write_str("_32MDIV4"),
+                    0x5000_0000 => f.write_str("_32MDIV3"),
+                    0x8000_0000 => f.write_str("_32MDIV2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    0x2800_0000 => defmt::write!(f, "_32MDIV6"),
+                    0x3000_0000 => defmt::write!(f, "_32MDIV5"),
+                    0x4000_0000 => defmt::write!(f, "_32MDIV4"),
+                    0x5000_0000 => defmt::write!(f, "_32MDIV3"),
+                    0x8000_0000 => defmt::write!(f, "_32MDIV2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -7104,7 +10168,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -7134,7 +10199,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -7185,7 +10251,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit."]
             _8BIT = 0x0,
@@ -7346,6 +10413,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7367,6 +10454,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -7392,6 +10499,26 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7413,6 +10540,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -7471,6 +10614,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7492,6 +10664,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference select"]
@@ -7517,6 +10705,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7538,6 +10746,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -7607,10 +10835,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -7643,7 +10904,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -7675,7 +10937,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -7705,7 +10968,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -7735,7 +10999,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -7777,7 +11042,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -7835,7 +11101,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)."]
             BELOW = 0x0,
@@ -8244,6 +11511,59 @@ pub mod mwu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Int {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8388,6 +11708,59 @@ pub mod mwu {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Nmi {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable/disable regions watch"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8460,6 +11833,61 @@ pub mod mwu {
                 Regionen(0)
             }
         }
+        impl core::fmt::Debug for Regionen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regionen")
+                    .field(
+                        "rgn_wa",
+                        &[
+                            self.rgn_wa(0usize),
+                            self.rgn_wa(1usize),
+                            self.rgn_wa(2usize),
+                            self.rgn_wa(3usize),
+                        ],
+                    )
+                    .field(
+                        "rgn_ra",
+                        &[
+                            self.rgn_ra(0usize),
+                            self.rgn_ra(1usize),
+                            self.rgn_ra(2usize),
+                            self.rgn_ra(3usize),
+                        ],
+                    )
+                    .field("prgn_wa", &[self.prgn_wa(0usize), self.prgn_wa(1usize)])
+                    .field("prgn_ra", &[self.prgn_ra(0usize), self.prgn_ra(1usize)])
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regionen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regionen {
+                    rgn_wa: [bool; 4usize],
+                    rgn_ra: [bool; 4usize],
+                    prgn_wa: [bool; 2usize],
+                    prgn_ra: [bool; 2usize],
+                }
+                let proxy = Regionen {
+                    rgn_wa: [
+                        self.rgn_wa(0usize),
+                        self.rgn_wa(1usize),
+                        self.rgn_wa(2usize),
+                        self.rgn_wa(3usize),
+                    ],
+                    rgn_ra: [
+                        self.rgn_ra(0usize),
+                        self.rgn_ra(1usize),
+                        self.rgn_ra(2usize),
+                        self.rgn_ra(3usize),
+                    ],
+                    prgn_wa: [self.prgn_wa(0usize), self.prgn_wa(1usize)],
+                    prgn_ra: [self.prgn_ra(0usize), self.prgn_ra(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Subregions of region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8485,6 +11913,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Subs {
                 Subs(0)
+            }
+        }
+        impl core::fmt::Debug for Subs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subs")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subs {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Subs {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Source of event/interrupt in region n, read access detected while corresponding subregion was enabled for watching"]
@@ -8514,6 +12031,95 @@ pub mod mwu {
                 Substatra(0)
             }
         }
+        impl core::fmt::Debug for Substatra {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatra")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatra {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatra {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatra {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Source of event/interrupt in region n, write access detected while corresponding subregion was enabled for watching"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8539,6 +12145,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Substatwa {
                 Substatwa(0)
+            }
+        }
+        impl core::fmt::Debug for Substatwa {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatwa")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatwa {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatwa {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatwa {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8889,6 +12584,26 @@ pub mod nfct {
                 Currentloadctrl(0)
             }
         }
+        impl core::fmt::Debug for Currentloadctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentloadctrl")
+                    .field("currentloadctrl", &self.currentloadctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentloadctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentloadctrl {
+                    currentloadctrl: u8,
+                }
+                let proxy = Currentloadctrl {
+                    currentloadctrl: self.currentloadctrl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8934,6 +12649,32 @@ pub mod nfct {
                 Errorstatus(0)
             }
         }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .field("nfcfieldtoostrong", &self.nfcfieldtoostrong())
+                    .field("nfcfieldtooweak", &self.nfcfieldtooweak())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                    nfcfieldtoostrong: bool,
+                    nfcfieldtooweak: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                    nfcfieldtoostrong: self.nfcfieldtoostrong(),
+                    nfcfieldtooweak: self.nfcfieldtooweak(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates the presence or not of a valid field"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8968,6 +12709,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8989,6 +12753,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u16,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -9014,6 +12798,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9035,6 +12839,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -9214,6 +13038,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of allocated for TXD and RXD data storage buffer in Data RAM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9235,6 +13121,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Maxlen {
                 Maxlen(0)
+            }
+        }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
@@ -9282,6 +13188,32 @@ pub mod nfct {
                 Nfcid12ndLast(0)
             }
         }
+        impl core::fmt::Debug for Nfcid12ndLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid12ndLast")
+                    .field("nfcid1_v", &self.nfcid1_v())
+                    .field("nfcid1_u", &self.nfcid1_u())
+                    .field("nfcid1_t", &self.nfcid1_t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid12ndLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid12ndLast {
+                    nfcid1_v: u8,
+                    nfcid1_u: u8,
+                    nfcid1_t: u8,
+                }
+                let proxy = Nfcid12ndLast {
+                    nfcid1_v: self.nfcid1_v(),
+                    nfcid1_u: self.nfcid1_u(),
+                    nfcid1_t: self.nfcid1_t(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9325,6 +13257,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfcid13rdLast {
                 Nfcid13rdLast(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcid13rdLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid13rdLast")
+                    .field("nfcid1_s", &self.nfcid1_s())
+                    .field("nfcid1_r", &self.nfcid1_r())
+                    .field("nfcid1_q", &self.nfcid1_q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid13rdLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid13rdLast {
+                    nfcid1_s: u8,
+                    nfcid1_r: u8,
+                    nfcid1_q: u8,
+                }
+                let proxy = Nfcid13rdLast {
+                    nfcid1_s: self.nfcid1_s(),
+                    nfcid1_r: self.nfcid1_r(),
+                    nfcid1_q: self.nfcid1_q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
@@ -9383,6 +13341,35 @@ pub mod nfct {
                 Nfcid1Last(0)
             }
         }
+        impl core::fmt::Debug for Nfcid1Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid1Last")
+                    .field("nfcid1_z", &self.nfcid1_z())
+                    .field("nfcid1_y", &self.nfcid1_y())
+                    .field("nfcid1_x", &self.nfcid1_x())
+                    .field("nfcid1_w", &self.nfcid1_w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid1Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid1Last {
+                    nfcid1_z: u8,
+                    nfcid1_y: u8,
+                    nfcid1_x: u8,
+                    nfcid1_w: u8,
+                }
+                let proxy = Nfcid1Last {
+                    nfcid1_z: self.nfcid1_z(),
+                    nfcid1_y: self.nfcid1_y(),
+                    nfcid1_x: self.nfcid1_x(),
+                    nfcid1_w: self.nfcid1_w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Result of last incoming frames"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9428,6 +13415,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9460,6 +13473,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -9505,6 +13541,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdFrameconfig {
                 RxdFrameconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -9574,6 +13636,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: super::vals::Cascade,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9641,6 +13735,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9675,6 +13801,29 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of outgoing frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9707,6 +13856,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -9765,10 +13937,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -9832,7 +14034,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cascade {
             #[doc = "NFCID1 complete"]
             COMPLETE = 0x0,
@@ -9862,7 +14065,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits is discarded at end of frame"]
             DISCARD_END = 0x0,
@@ -9892,7 +14096,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -9926,7 +14131,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -10052,6 +14258,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10075,6 +14297,26 @@ pub mod nvmc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing User Information Configuration Registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10096,6 +14338,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-Code cache configuration register."]
@@ -10132,6 +14394,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10155,10 +14440,31 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -10363,6 +14669,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10386,6 +14712,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10407,6 +14753,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -10454,6 +14820,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10475,6 +14867,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -10511,6 +14923,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10535,10 +14970,29 @@ pub mod pdm {
                 Pdmclkctrl(0)
             }
         }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -10586,6 +15040,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -10617,6 +15092,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -10630,7 +15126,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (Left + Right) of 16bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -10821,6 +15318,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10844,6 +15361,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10865,6 +15402,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -10912,6 +15469,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power failure comparator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10944,6 +15527,29 @@ pub mod power {
             #[inline(always)]
             fn default() -> Pofcon {
                 Pofcon(0)
+            }
+        }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: RAMn power control register"]
@@ -10986,6 +15592,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("s_power", &[self.s_power(0usize), self.s_power(1usize)])
+                    .field(
+                        "s_retention",
+                        &[self.s_retention(0usize), self.s_retention(1usize)],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 2usize],
+                    s_retention: [bool; 2usize],
+                }
+                let proxy = Power {
+                    s_power: [self.s_power(0usize), self.s_power(1usize)],
+                    s_retention: [self.s_retention(0usize), self.s_retention(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Deprecated register - RAM on/off register (this register is retained)"]
@@ -11046,6 +15678,35 @@ pub mod power {
                 Ramon(0)
             }
         }
+        impl core::fmt::Debug for Ramon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramon")
+                    .field("onram0", &self.onram0())
+                    .field("onram1", &self.onram1())
+                    .field("offram0", &self.offram0())
+                    .field("offram1", &self.offram1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramon {
+                    onram0: super::vals::Onram0,
+                    onram1: super::vals::Onram1,
+                    offram0: super::vals::Offram0,
+                    offram1: super::vals::Offram1,
+                }
+                let proxy = Ramon {
+                    onram0: self.onram0(),
+                    onram1: self.onram1(),
+                    offram0: self.offram0(),
+                    offram1: self.offram1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Deprecated register - RAM on/off register (this register is retained)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11104,6 +15765,35 @@ pub mod power {
                 Ramonb(0)
             }
         }
+        impl core::fmt::Debug for Ramonb {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramonb")
+                    .field("onram2", &self.onram2())
+                    .field("onram3", &self.onram3())
+                    .field("offram2", &self.offram2())
+                    .field("offram3", &self.offram3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramonb {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramonb {
+                    onram2: super::vals::Onram2,
+                    onram3: super::vals::Onram3,
+                    offram2: super::vals::Offram2,
+                    offram3: super::vals::Offram3,
+                }
+                let proxy = Ramonb {
+                    onram2: self.onram2(),
+                    onram3: self.onram3(),
+                    offram2: self.offram2(),
+                    offram3: self.offram3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Deprecated register - RAM status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11158,6 +15848,35 @@ pub mod power {
             #[inline(always)]
             fn default() -> Ramstatus {
                 Ramstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ramstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramstatus")
+                    .field("ramblock0", &self.ramblock0())
+                    .field("ramblock1", &self.ramblock1())
+                    .field("ramblock2", &self.ramblock2())
+                    .field("ramblock3", &self.ramblock3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramstatus {
+                    ramblock0: bool,
+                    ramblock1: bool,
+                    ramblock2: bool,
+                    ramblock3: bool,
+                }
+                let proxy = Ramstatus {
+                    ramblock0: self.ramblock0(),
+                    ramblock1: self.ramblock1(),
+                    ramblock2: self.ramblock2(),
+                    ramblock3: self.ramblock3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -11260,6 +15979,47 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("nfc", &self.nfc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    nfc: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    nfc: self.nfc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11283,10 +16043,31 @@ pub mod power {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram0 {
             #[doc = "Off"]
             RAM0OFF = 0x0,
@@ -11316,7 +16097,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram1 {
             #[doc = "Off"]
             RAM1OFF = 0x0,
@@ -11346,7 +16128,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram2 {
             #[doc = "Off"]
             RAM2OFF = 0x0,
@@ -11376,7 +16159,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Offram3 {
             #[doc = "Off"]
             RAM3OFF = 0x0,
@@ -11406,7 +16190,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram0 {
             #[doc = "Off"]
             RAM0OFF = 0x0,
@@ -11436,7 +16221,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram1 {
             #[doc = "Off"]
             RAM1OFF = 0x0,
@@ -11466,7 +16252,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram2 {
             #[doc = "Off"]
             RAM2OFF = 0x0,
@@ -11496,7 +16283,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Onram3 {
             #[doc = "Off"]
             RAM3OFF = 0x0,
@@ -11526,7 +16314,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -11742,6 +16531,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11767,6 +16645,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11984,6 +16951,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12005,6 +16988,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -12041,6 +17044,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12062,6 +17088,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -12086,6 +17132,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -12177,6 +17241,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Amount of playback of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12199,6 +17301,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -12224,6 +17342,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12245,6 +17383,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Amount of additional PWM periods between samples loaded into compare register"]
@@ -12269,6 +17427,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12338,6 +17512,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -12355,6 +17561,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -12368,7 +17591,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -12416,6 +17640,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -12429,7 +17670,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -12459,7 +17701,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16MHz)"]
             DIV_1 = 0x0,
@@ -12515,6 +17758,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -12528,7 +17788,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter - edge aligned PWM duty-cycle"]
             UP = 0x0,
@@ -12758,6 +18019,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12779,6 +18060,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -12804,6 +18105,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12825,6 +18146,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -12894,6 +18235,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12915,6 +18288,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -12940,6 +18333,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12963,6 +18376,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12984,6 +18417,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13075,10 +18528,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -13108,7 +18600,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples / report"]
             _10SMPL = 0x0,
@@ -13159,7 +18652,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -13528,6 +19022,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13550,6 +19067,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -13576,6 +19113,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13597,6 +19154,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -13787,6 +19364,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13808,6 +19450,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -13833,6 +19491,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13854,6 +19528,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -13888,6 +19582,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14023,6 +19740,56 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14044,6 +19811,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -14078,6 +19861,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -14149,6 +19955,38 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("plen", &self.plen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    plen: super::vals::Plen,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    plen: self.plen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14217,6 +20055,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14238,6 +20108,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -14296,6 +20186,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14352,6 +20271,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14373,6 +20321,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -14475,6 +20443,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14499,6 +20508,26 @@ pub mod radio {
                 Rxcrc(0)
             }
         }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Received address"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14520,6 +20549,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxmatch {
                 Rxmatch(0)
+            }
+        }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14622,6 +20671,47 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14643,6 +20733,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Inter Frame Spacing in us"]
@@ -14668,6 +20778,22 @@ pub mod radio {
                 Tifs(0)
             }
         }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u8,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14689,6 +20815,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -14714,10 +20860,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -14747,7 +20914,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -14780,7 +20948,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least Significant bit on air first"]
             LITTLE = 0x0,
@@ -14810,7 +20979,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -14844,7 +21014,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -14874,7 +21045,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbit/s Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -14921,7 +21093,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -14951,7 +21124,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -14981,7 +21155,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -15011,7 +21186,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -15041,7 +21217,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -15092,7 +21269,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -15467,6 +21645,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15488,6 +21686,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15513,6 +21731,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15534,6 +21772,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -15658,6 +21916,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15680,6 +21958,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -15731,6 +22029,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15780,6 +22117,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)).Must be written when RTC is stopped"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15801,6 +22177,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16050,6 +22446,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16142,6 +22558,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16163,6 +22617,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16273,6 +22747,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16307,6 +22864,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last results is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16328,6 +22908,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last results is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -16353,6 +22953,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16374,6 +22994,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -16399,6 +23039,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16420,6 +23080,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -16445,6 +23125,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16466,6 +23166,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -16503,6 +23221,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16526,10 +23267,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -16559,7 +23321,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -16601,7 +23364,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -16652,7 +23416,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -16720,7 +23485,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -16750,7 +23516,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -16784,7 +23551,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -16818,7 +23586,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -16848,7 +23617,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -16878,7 +23648,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -16918,7 +23689,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -16994,10 +23766,34 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -17173,6 +23969,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17194,6 +24016,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency"]
@@ -17220,6 +24062,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17241,6 +24103,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -17266,6 +24146,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17289,10 +24185,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -17322,7 +24235,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -17352,7 +24266,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -17422,6 +24337,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -17435,7 +24379,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -17479,6 +24424,23 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pselmiso {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselmiso {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Pselmiso {
             #[inline(always)]
             fn from(val: u32) -> Pselmiso {
@@ -17506,6 +24468,23 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pselmosi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselmosi {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Pselmosi {
             #[inline(always)]
             fn from(val: u32) -> Pselmosi {
@@ -17531,6 +24510,23 @@ pub mod spi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pselsck {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselsck {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Pselsck {
@@ -17816,6 +24812,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17837,6 +24859,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -17861,6 +24903,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -17930,6 +24992,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case and over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17951,6 +25045,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -17976,6 +25086,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u8,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17997,6 +25127,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -18022,6 +25170,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18043,6 +25211,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -18068,6 +25256,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u8,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18089,6 +25297,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -18114,10 +25340,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -18147,7 +25394,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -18177,7 +25425,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -18247,6 +25496,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -18260,7 +25538,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -18290,7 +25569,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -18326,7 +25606,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -18617,6 +25898,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18640,6 +25947,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18661,6 +25984,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -18708,6 +26051,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18729,6 +26098,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -18754,6 +26139,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u8,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18775,6 +26180,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Semaphore status register"]
@@ -18800,6 +26225,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18821,6 +26266,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -18857,6 +26322,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18878,6 +26366,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u8,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -18903,10 +26411,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -18936,7 +26465,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -18966,7 +26496,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -19010,7 +26541,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -19040,7 +26572,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -19189,6 +26722,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -19306,6 +26859,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19333,6 +26906,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19356,6 +26966,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19377,6 +27003,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -19421,10 +27067,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -19458,7 +27162,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -19648,6 +27353,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19669,6 +27394,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -19716,6 +27461,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19738,6 +27509,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -19818,6 +27609,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19839,6 +27665,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -19875,6 +27717,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19898,10 +27763,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -19963,6 +27845,27 @@ pub mod twi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -19990,6 +27893,23 @@ pub mod twi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pselscl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselscl {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Pselscl {
             #[inline(always)]
             fn from(val: u32) -> Pselscl {
@@ -20015,6 +27935,23 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pselsda {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselsda {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Pselsda {
@@ -20289,6 +28226,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20310,6 +28267,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -20357,6 +28334,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20379,6 +28382,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -20470,6 +28493,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20491,6 +28552,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u8,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -20516,6 +28597,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20537,6 +28636,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -20606,6 +28725,38 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20627,6 +28778,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u8,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -20652,6 +28823,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20675,10 +28864,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -20740,6 +28950,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -20753,7 +28984,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -20789,7 +29021,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -21083,6 +29316,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21117,6 +29370,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21138,6 +29414,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -21183,6 +29479,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -21263,6 +29585,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21284,6 +29641,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -21309,6 +29686,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21332,6 +29725,26 @@ pub mod twis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u8,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21353,6 +29766,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -21389,6 +29822,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21410,6 +29866,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u8,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in TXD buffer"]
@@ -21435,10 +29911,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -21654,6 +30151,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21688,6 +30205,29 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21709,6 +30249,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -21765,6 +30325,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -21845,6 +30434,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21866,6 +30490,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -21902,6 +30542,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21923,6 +30586,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -21976,6 +30655,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -21989,7 +30719,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -22025,7 +30756,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -22083,6 +30815,23 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pselcts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselcts {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Pselcts {
             #[inline(always)]
             fn from(val: u32) -> Pselcts {
@@ -22108,6 +30857,23 @@ pub mod uart {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pselrts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselrts {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Pselrts {
@@ -22137,6 +30903,23 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pselrxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselrxd {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Pselrxd {
             #[inline(always)]
             fn from(val: u32) -> Pselrxd {
@@ -22162,6 +30945,23 @@ pub mod uart {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Pseltxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("DISCONNECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseltxd {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "DISCONNECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Pseltxd {
@@ -22457,6 +31257,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22491,6 +31311,29 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22512,6 +31355,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -22568,6 +31431,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -22703,6 +31595,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22726,6 +31668,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u8,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22747,6 +31709,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -22783,6 +31765,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22806,6 +31811,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u8,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22827,6 +31852,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -22880,6 +31925,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -22893,7 +31989,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -22929,7 +32026,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -23053,6 +32151,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Setting of pins dedicated to NFC functionality: NFC antenna or GPIO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23076,6 +32192,26 @@ pub mod uicr {
                 Nfcpins(0)
             }
         }
+        impl core::fmt::Debug for Nfcpins {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcpins")
+                    .field("protect", &self.protect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcpins {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcpins {
+                    protect: super::vals::Protect,
+                }
+                let proxy = Nfcpins {
+                    protect: self.protect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -23097,6 +32233,27 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Pall {
             #[inline(always)]
             fn from(val: u8) -> Pall {
@@ -23110,7 +32267,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protect {
             #[doc = "Operation as GPIO pins. Same protection as normal GPIO pins."]
             DISABLED = 0x0,
@@ -23245,6 +32403,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23266,6 +32447,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -23295,6 +32496,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23317,6 +32559,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -23346,6 +32604,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23369,10 +32668,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -23416,6 +32736,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -23429,7 +32766,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52833/pac.rs
+++ b/src/chips/nrf52833/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -465,6 +466,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -510,6 +531,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -531,6 +578,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -556,10 +619,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -683,10 +767,34 @@ pub mod acl {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: super::vals::Write,
+                    read: super::vals::Read,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Read {
             #[doc = "Allow read instructions to region n."]
             ENABLE = 0x0,
@@ -716,7 +824,8 @@ pub mod acl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Write {
             #[doc = "Allow write and erase instructions to region n."]
             ENABLE = 0x0,
@@ -801,6 +910,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -824,6 +953,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -839,6 +988,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -866,6 +1032,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -1028,6 +1211,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Header (S0) mask."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1049,6 +1252,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Headermask {
                 Headermask(0)
+            }
+        }
+        impl core::fmt::Debug for Headermask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Headermask")
+                    .field("headermask", &self.headermask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Headermask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Headermask {
+                    headermask: u8,
+                }
+                let proxy = Headermask {
+                    headermask: self.headermask(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1096,6 +1319,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1119,6 +1368,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1140,6 +1409,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1189,6 +1478,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1210,6 +1525,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1235,10 +1570,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1272,7 +1628,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1304,7 +1661,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1334,7 +1692,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1364,7 +1723,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1394,7 +1754,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1602,6 +1963,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1623,6 +2000,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -1659,6 +2056,29 @@ pub mod clock {
                 Hfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO debounce time. The HFXO is started by triggering the TASKS_HFCLKSTART task."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1680,6 +2100,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfxodebounce {
                 Hfxodebounce(0)
+            }
+        }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxodebounce")
+                    .field("hfxodebounce", &self.hfxodebounce())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxodebounce {
+                    hfxodebounce: super::vals::Hfxodebounce,
+                }
+                let proxy = Hfxodebounce {
+                    hfxodebounce: self.hfxodebounce(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1760,6 +2200,41 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .field("ctstarted", &self.ctstarted())
+                    .field("ctstopped", &self.ctstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                    ctstarted: bool,
+                    ctstopped: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                    ctstarted: self.ctstarted(),
+                    ctstopped: self.ctstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1781,6 +2256,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -1828,6 +2323,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1849,6 +2370,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -1885,6 +2424,29 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LFXO debounce time. The LFXO is started by triggering the TASKS_LFCLKSTART task when the LFCLKSRC register is configured for Xtal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1906,6 +2468,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfxodebounce {
                 Lfxodebounce(0)
+            }
+        }
+        impl core::fmt::Debug for Lfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfxodebounce")
+                    .field("lfxodebounce", &self.lfxodebounce())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfxodebounce {
+                    lfxodebounce: super::vals::Lfxodebounce,
+                }
+                let proxy = Lfxodebounce {
+                    lfxodebounce: self.lfxodebounce(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clocking options for the trace port debug interface"]
@@ -1943,10 +2525,34 @@ pub mod clock {
                 Traceconfig(0)
             }
         }
+        impl core::fmt::Debug for Traceconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceconfig")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .field("tracemux", &self.tracemux())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceconfig {
+                    traceportspeed: super::vals::Traceportspeed,
+                    tracemux: super::vals::Tracemux,
+                }
+                let proxy = Traceconfig {
+                    traceportspeed: self.traceportspeed(),
+                    tracemux: self.tracemux(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -1992,6 +2598,25 @@ pub mod clock {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("DB256US"),
+                    0x40 => f.write_str("DB1024US"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "DB256US"),
+                    0x40 => defmt::write!(f, "DB1024US"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxodebounce {
             #[inline(always)]
             fn from(val: u8) -> Hfxodebounce {
@@ -2005,7 +2630,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator (LFRC)"]
             RC = 0x0,
@@ -2038,7 +2664,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfxodebounce {
             #[doc = "8192 32.768 kHz periods, or 0.25 s. Recommended for normal Operating Temperature conditions."]
             NORMAL = 0x0,
@@ -2068,7 +2695,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tracemux {
             #[doc = "No trace signals routed to pins. All pins can be used as regular GPIOs."]
             GPIO = 0x0,
@@ -2101,7 +2729,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "32 MHz trace port clock (TRACECLK = 16 MHz)"]
             _32MHZ = 0x0,
@@ -2350,6 +2979,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2373,6 +3022,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2394,6 +3063,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -2452,6 +3137,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2486,6 +3200,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2507,6 +3244,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -2532,6 +3285,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2553,6 +3326,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -2622,6 +3415,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2656,10 +3481,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2691,7 +3540,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -2733,7 +3583,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -2763,7 +3614,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -2793,7 +3645,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -2835,7 +3688,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -2874,7 +3728,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -2904,7 +3759,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -3026,6 +3882,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -3102,6 +3981,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -3394,6 +4330,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3415,6 +4367,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -3440,6 +4408,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3461,6 +4445,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -3486,6 +4486,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3507,6 +4523,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -3532,6 +4564,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3553,6 +4601,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -3578,6 +4642,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3599,6 +4679,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -3624,6 +4720,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3647,6 +4759,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3668,6 +4796,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -3694,6 +4842,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3716,6 +4884,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -3742,6 +4930,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Production test signature n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3764,6 +4968,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Prodtest {
                 Prodtest(0)
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prodtest")
+                    .field("prodtest", &self.prodtest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prodtest {
+                    prodtest: super::vals::Prodtest,
+                }
+                let proxy = Prodtest {
+                    prodtest: self.prodtest(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -3790,6 +5014,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T0"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3811,6 +5051,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T0 {
                 T0(0)
+            }
+        }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T1"]
@@ -3836,6 +5092,22 @@ pub mod ficr {
                 T1(0)
             }
         }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T2"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3857,6 +5129,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T2 {
                 T2(0)
+            }
+        }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T3"]
@@ -3882,6 +5170,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3903,6 +5207,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
@@ -3961,6 +5281,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4015,6 +5364,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
@@ -4073,6 +5451,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4129,6 +5536,35 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Build code (hardware version and production configuration)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4153,10 +5589,31 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -4210,6 +5667,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0x0400 => f.write_str("K1024"),
+                    0x0800 => f.write_str("K2048"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0x0400 => defmt::write!(f, "K1024"),
+                    0x0800 => defmt::write!(f, "K2048"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -4241,6 +5725,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2004 => f.write_str("QI"),
+                    0x2007 => f.write_str("QD"),
+                    0x2008 => f.write_str("CJ"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2004 => defmt::write!(f, "QI"),
+                    0x2007 => defmt::write!(f, "QD"),
+                    0x2008 => defmt::write!(f, "CJ"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -4276,6 +5783,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2820 => f.write_str("N52820"),
+                    0x0005_2833 => f.write_str("N52833"),
+                    0x0005_2840 => f.write_str("N52840"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2820 => defmt::write!(f, "N52820"),
+                    0x0005_2833 => defmt::write!(f, "N52833"),
+                    0x0005_2840 => defmt::write!(f, "N52840"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -4303,6 +5833,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xbb42_319f => f.write_str("DONE"),
+                    0xffff_ffff => f.write_str("NOT_DONE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xbb42_319f => defmt::write!(f, "DONE"),
+                    0xffff_ffff => defmt::write!(f, "NOT_DONE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Prodtest {
@@ -4342,6 +5891,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -4377,6 +5953,33 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4131 => f.write_str("AAA1"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4142 => f.write_str("AAAB"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4131 => defmt::write!(f, "AAA1"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4142 => defmt::write!(f, "AAAB"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -4513,6 +6116,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4538,6 +6161,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -4567,6 +6279,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4592,6 +6393,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -4621,6 +6511,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4646,6 +6625,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -4675,6 +6743,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4702,6 +6859,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4727,6 +6973,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -4797,10 +7132,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -4830,7 +7198,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -4860,7 +7229,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -4902,7 +7272,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -4932,7 +7303,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -4965,7 +7337,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -5132,6 +7505,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: bool,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5170,10 +7575,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -5206,7 +7656,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -5236,7 +7687,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -5564,6 +8016,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5585,6 +8057,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module."]
@@ -5610,6 +8102,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5631,6 +8143,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5678,6 +8210,32 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5701,6 +8259,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5722,6 +8300,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Master clock generator frequency."]
@@ -5748,6 +8346,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5769,6 +8387,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio."]
@@ -5794,6 +8428,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5815,6 +8469,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width."]
@@ -5840,6 +8510,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5863,10 +8553,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -5896,7 +8603,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -5929,7 +8637,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -5997,6 +8706,47 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -6010,7 +8760,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -6040,7 +8791,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -6091,7 +8843,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit."]
             _8BIT = 0x0,
@@ -6252,6 +9005,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6273,6 +9046,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -6298,6 +9091,26 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6319,6 +9132,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: bool,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -6377,6 +9206,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6398,6 +9256,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference select"]
@@ -6423,6 +9297,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6444,6 +9338,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6513,10 +9427,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -6549,7 +9496,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -6581,7 +9529,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -6611,7 +9560,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -6653,7 +9603,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -6711,7 +9662,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -7120,6 +10072,59 @@ pub mod mwu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Int {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7264,6 +10269,59 @@ pub mod mwu {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Nmi {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable/disable regions watch"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7336,6 +10394,61 @@ pub mod mwu {
                 Regionen(0)
             }
         }
+        impl core::fmt::Debug for Regionen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regionen")
+                    .field(
+                        "rgn_wa",
+                        &[
+                            self.rgn_wa(0usize),
+                            self.rgn_wa(1usize),
+                            self.rgn_wa(2usize),
+                            self.rgn_wa(3usize),
+                        ],
+                    )
+                    .field(
+                        "rgn_ra",
+                        &[
+                            self.rgn_ra(0usize),
+                            self.rgn_ra(1usize),
+                            self.rgn_ra(2usize),
+                            self.rgn_ra(3usize),
+                        ],
+                    )
+                    .field("prgn_wa", &[self.prgn_wa(0usize), self.prgn_wa(1usize)])
+                    .field("prgn_ra", &[self.prgn_ra(0usize), self.prgn_ra(1usize)])
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regionen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regionen {
+                    rgn_wa: [bool; 4usize],
+                    rgn_ra: [bool; 4usize],
+                    prgn_wa: [bool; 2usize],
+                    prgn_ra: [bool; 2usize],
+                }
+                let proxy = Regionen {
+                    rgn_wa: [
+                        self.rgn_wa(0usize),
+                        self.rgn_wa(1usize),
+                        self.rgn_wa(2usize),
+                        self.rgn_wa(3usize),
+                    ],
+                    rgn_ra: [
+                        self.rgn_ra(0usize),
+                        self.rgn_ra(1usize),
+                        self.rgn_ra(2usize),
+                        self.rgn_ra(3usize),
+                    ],
+                    prgn_wa: [self.prgn_wa(0usize), self.prgn_wa(1usize)],
+                    prgn_ra: [self.prgn_ra(0usize), self.prgn_ra(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Subregions of region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7361,6 +10474,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Subs {
                 Subs(0)
+            }
+        }
+        impl core::fmt::Debug for Subs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subs")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subs {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Subs {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Source of event/interrupt in region n, read access detected while corresponding subregion was enabled for watching"]
@@ -7390,6 +10592,95 @@ pub mod mwu {
                 Substatra(0)
             }
         }
+        impl core::fmt::Debug for Substatra {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatra")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatra {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatra {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatra {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Source of event/interrupt in region n, write access detected while corresponding subregion was enabled for watching"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7415,6 +10706,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Substatwa {
                 Substatwa(0)
+            }
+        }
+        impl core::fmt::Debug for Substatwa {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatwa")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatwa {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatwa {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatwa {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7789,6 +11169,24 @@ pub mod nfct {
                 Autocolresconfig(0)
             }
         }
+        impl core::fmt::Debug for Autocolresconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Autocolresconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Autocolresconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Autocolresconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Autocolresconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7810,6 +11208,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the presence or not of a valid field"]
@@ -7846,6 +11264,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7868,6 +11309,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u32,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -7893,6 +11354,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7914,6 +11395,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -8093,6 +11594,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of the RAM buffer allocated to TXD and RXD data storage each"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8116,6 +11679,26 @@ pub mod nfct {
                 Maxlen(0)
             }
         }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables the modulation output to a GPIO pin which can be connected to a second external antenna."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8137,6 +11720,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Modulationctrl {
                 Modulationctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Modulationctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationctrl")
+                    .field("modulationctrl", &self.modulationctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationctrl {
+                    modulationctrl: super::vals::Modulationctrl,
+                }
+                let proxy = Modulationctrl {
+                    modulationctrl: self.modulationctrl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Pin select for Modulation control."]
@@ -8185,6 +11788,32 @@ pub mod nfct {
                 Modulationpsel(0)
             }
         }
+        impl core::fmt::Debug for Modulationpsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationpsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationpsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationpsel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::super::shared::vals::Connect,
+                }
+                let proxy = Modulationpsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8230,6 +11859,32 @@ pub mod nfct {
                 Nfcid12ndLast(0)
             }
         }
+        impl core::fmt::Debug for Nfcid12ndLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid12ndLast")
+                    .field("nfcid1_v", &self.nfcid1_v())
+                    .field("nfcid1_u", &self.nfcid1_u())
+                    .field("nfcid1_t", &self.nfcid1_t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid12ndLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid12ndLast {
+                    nfcid1_v: u8,
+                    nfcid1_u: u8,
+                    nfcid1_t: u8,
+                }
+                let proxy = Nfcid12ndLast {
+                    nfcid1_v: self.nfcid1_v(),
+                    nfcid1_u: self.nfcid1_u(),
+                    nfcid1_t: self.nfcid1_t(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8273,6 +11928,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfcid13rdLast {
                 Nfcid13rdLast(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcid13rdLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid13rdLast")
+                    .field("nfcid1_s", &self.nfcid1_s())
+                    .field("nfcid1_r", &self.nfcid1_r())
+                    .field("nfcid1_q", &self.nfcid1_q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid13rdLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid13rdLast {
+                    nfcid1_s: u8,
+                    nfcid1_r: u8,
+                    nfcid1_q: u8,
+                }
+                let proxy = Nfcid13rdLast {
+                    nfcid1_s: self.nfcid1_s(),
+                    nfcid1_r: self.nfcid1_r(),
+                    nfcid1_q: self.nfcid1_q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
@@ -8331,6 +12012,35 @@ pub mod nfct {
                 Nfcid1Last(0)
             }
         }
+        impl core::fmt::Debug for Nfcid1Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid1Last")
+                    .field("nfcid1_z", &self.nfcid1_z())
+                    .field("nfcid1_y", &self.nfcid1_y())
+                    .field("nfcid1_x", &self.nfcid1_x())
+                    .field("nfcid1_w", &self.nfcid1_w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid1Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid1Last {
+                    nfcid1_z: u8,
+                    nfcid1_y: u8,
+                    nfcid1_x: u8,
+                    nfcid1_w: u8,
+                }
+                let proxy = Nfcid1Last {
+                    nfcid1_z: self.nfcid1_z(),
+                    nfcid1_y: self.nfcid1_y(),
+                    nfcid1_x: self.nfcid1_x(),
+                    nfcid1_w: self.nfcid1_w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NfcTag state register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8352,6 +12062,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfctagstate {
                 Nfctagstate(0)
+            }
+        }
+        impl core::fmt::Debug for Nfctagstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfctagstate")
+                    .field("nfctagstate", &self.nfctagstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfctagstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfctagstate {
+                    nfctagstate: super::vals::Nfctagstate,
+                }
+                let proxy = Nfctagstate {
+                    nfctagstate: self.nfctagstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of last incoming frame"]
@@ -8399,6 +12129,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8431,6 +12187,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -8476,6 +12255,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdFrameconfig {
                 RxdFrameconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -8545,6 +12350,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: bool,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8612,6 +12449,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8657,6 +12526,32 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .field("txframeend_enablerxdata", &self.txframeend_enablerxdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                    txframeend_enablerxdata: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                    txframeend_enablerxdata: self.txframeend_enablerxdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sleep state during automatic collision resolution"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8678,6 +12573,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Sleepstate {
                 Sleepstate(0)
+            }
+        }
+        impl core::fmt::Debug for Sleepstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sleepstate")
+                    .field("sleepstate", &self.sleepstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sleepstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sleepstate {
+                    sleepstate: super::vals::Sleepstate,
+                }
+                let proxy = Sleepstate {
+                    sleepstate: self.sleepstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Size of outgoing frame"]
@@ -8712,6 +12627,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -8770,10 +12708,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -8837,7 +12805,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits are discarded at end of frame (EoF)"]
             DISCARD_END = 0x0,
@@ -8867,7 +12836,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -8901,7 +12871,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Auto collision resolution enabled"]
             ENABLED = 0x0,
@@ -8931,7 +12902,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Modulationctrl {
             #[doc = "Invalid, defaults to same behaviour as for Internal"]
             INVALID = 0x0,
@@ -8965,7 +12937,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -8998,7 +12971,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfctagstate {
             #[doc = "Disabled or sense"]
             DISABLED = 0x0,
@@ -9038,7 +13012,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleepstate {
             #[doc = "State is IDLE."]
             IDLE = 0x0,
@@ -9178,6 +13153,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9199,6 +13190,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -9224,6 +13235,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9245,6 +13276,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-code cache configuration register"]
@@ -9281,6 +13332,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9302,6 +13376,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Ready {
                 Ready(0)
+            }
+        }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -9327,10 +13421,31 @@ pub mod nvmc {
                 Readynext(0)
             }
         }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -9540,6 +13655,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9563,6 +13698,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9584,6 +13739,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -9631,6 +13806,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9652,6 +13853,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -9688,6 +13909,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9710,6 +13954,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Pdmclkctrl {
                 Pdmclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the ratio between PDM_CLK and output sample rate. Change PDMCLKCTRL accordingly."]
@@ -9735,10 +13997,31 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -9792,6 +14075,33 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    0x0980_0000 => f.write_str("_1231K"),
+                    0x0a00_0000 => f.write_str("_1280K"),
+                    0x0a80_0000 => f.write_str("_1333K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    0x0980_0000 => defmt::write!(f, "_1231K"),
+                    0x0a00_0000 => defmt::write!(f, "_1280K"),
+                    0x0a80_0000 => defmt::write!(f, "_1333K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -9823,6 +14133,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -9836,7 +14167,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -9866,7 +14198,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 64"]
             RATIO64 = 0x0,
@@ -10076,6 +14409,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10099,6 +14452,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10120,6 +14493,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -10200,6 +14593,41 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .field("usbdetected", &self.usbdetected())
+                    .field("usbremoved", &self.usbremoved())
+                    .field("usbpwrrdy", &self.usbpwrrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                    usbdetected: bool,
+                    usbremoved: bool,
+                    usbpwrrdy: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                    usbdetected: self.usbdetected(),
+                    usbremoved: self.usbremoved(),
+                    usbpwrrdy: self.usbpwrrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Main supply status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10221,6 +14649,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Mainregstatus {
                 Mainregstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Mainregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mainregstatus")
+                    .field("mainregstatus", &self.mainregstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mainregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mainregstatus {
+                    mainregstatus: super::vals::Mainregstatus,
+                }
+                let proxy = Mainregstatus {
+                    mainregstatus: self.mainregstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power-fail comparator configuration"]
@@ -10268,6 +14716,32 @@ pub mod power {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("thresholdvddh", &self.thresholdvddh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    thresholdvddh: super::vals::Thresholdvddh,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    thresholdvddh: self.thresholdvddh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAMn power control register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10308,6 +14782,103 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "s_power",
+                        &[
+                            self.s_power(0usize),
+                            self.s_power(1usize),
+                            self.s_power(2usize),
+                            self.s_power(3usize),
+                            self.s_power(4usize),
+                            self.s_power(5usize),
+                            self.s_power(6usize),
+                            self.s_power(7usize),
+                            self.s_power(8usize),
+                            self.s_power(9usize),
+                            self.s_power(10usize),
+                            self.s_power(11usize),
+                            self.s_power(12usize),
+                            self.s_power(13usize),
+                            self.s_power(14usize),
+                            self.s_power(15usize),
+                        ],
+                    )
+                    .field(
+                        "s_retention",
+                        &[
+                            self.s_retention(0usize),
+                            self.s_retention(1usize),
+                            self.s_retention(2usize),
+                            self.s_retention(3usize),
+                            self.s_retention(4usize),
+                            self.s_retention(5usize),
+                            self.s_retention(6usize),
+                            self.s_retention(7usize),
+                            self.s_retention(8usize),
+                            self.s_retention(9usize),
+                            self.s_retention(10usize),
+                            self.s_retention(11usize),
+                            self.s_retention(12usize),
+                            self.s_retention(13usize),
+                            self.s_retention(14usize),
+                            self.s_retention(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 16usize],
+                    s_retention: [bool; 16usize],
+                }
+                let proxy = Power {
+                    s_power: [
+                        self.s_power(0usize),
+                        self.s_power(1usize),
+                        self.s_power(2usize),
+                        self.s_power(3usize),
+                        self.s_power(4usize),
+                        self.s_power(5usize),
+                        self.s_power(6usize),
+                        self.s_power(7usize),
+                        self.s_power(8usize),
+                        self.s_power(9usize),
+                        self.s_power(10usize),
+                        self.s_power(11usize),
+                        self.s_power(12usize),
+                        self.s_power(13usize),
+                        self.s_power(14usize),
+                        self.s_power(15usize),
+                    ],
+                    s_retention: [
+                        self.s_retention(0usize),
+                        self.s_retention(1usize),
+                        self.s_retention(2usize),
+                        self.s_retention(3usize),
+                        self.s_retention(4usize),
+                        self.s_retention(5usize),
+                        self.s_retention(6usize),
+                        self.s_retention(7usize),
+                        self.s_retention(8usize),
+                        self.s_retention(9usize),
+                        self.s_retention(10usize),
+                        self.s_retention(11usize),
+                        self.s_retention(12usize),
+                        self.s_retention(13usize),
+                        self.s_retention(14usize),
+                        self.s_retention(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Deprecated register - RAM status register"]
@@ -10364,6 +14935,35 @@ pub mod power {
             #[inline(always)]
             fn default() -> Ramstatus {
                 Ramstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ramstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramstatus")
+                    .field("ramblock0", &self.ramblock0())
+                    .field("ramblock1", &self.ramblock1())
+                    .field("ramblock2", &self.ramblock2())
+                    .field("ramblock3", &self.ramblock3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramstatus {
+                    ramblock0: bool,
+                    ramblock1: bool,
+                    ramblock2: bool,
+                    ramblock3: bool,
+                }
+                let proxy = Ramstatus {
+                    ramblock0: self.ramblock0(),
+                    ramblock1: self.ramblock1(),
+                    ramblock2: self.ramblock2(),
+                    ramblock3: self.ramblock3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -10477,6 +15077,50 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("nfc", &self.nfc())
+                    .field("vbus", &self.vbus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    nfc: bool,
+                    vbus: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    nfc: self.nfc(),
+                    vbus: self.vbus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10498,6 +15142,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "USB supply status"]
@@ -10534,10 +15198,34 @@ pub mod power {
                 Usbregstatus(0)
             }
         }
+        impl core::fmt::Debug for Usbregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbregstatus")
+                    .field("vbusdetect", &self.vbusdetect())
+                    .field("outputrdy", &self.outputrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbregstatus {
+                    vbusdetect: bool,
+                    outputrdy: bool,
+                }
+                let proxy = Usbregstatus {
+                    vbusdetect: self.vbusdetect(),
+                    outputrdy: self.outputrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mainregstatus {
             #[doc = "Normal voltage mode. Voltage supplied on VDD."]
             NORMAL = 0x0,
@@ -10567,7 +15255,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -10621,7 +15310,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Thresholdvddh {
             #[doc = "Set threshold to 2.7 V"]
             V27 = 0x0,
@@ -10841,6 +15531,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10866,6 +15645,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11083,6 +15951,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11104,6 +15988,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -11140,6 +16044,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11161,6 +16088,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -11185,6 +16132,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -11276,6 +16241,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11298,6 +16301,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -11323,6 +16342,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11344,6 +16383,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -11368,6 +16427,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -11437,6 +16512,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -11454,6 +16561,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -11467,7 +16591,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -11515,6 +16640,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -11528,7 +16670,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -11558,7 +16701,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -11614,6 +16758,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -11627,7 +16788,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -11857,6 +17019,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11878,6 +17060,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -11903,6 +17105,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11924,6 +17146,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -11993,6 +17235,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12014,6 +17288,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -12039,6 +17333,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12062,6 +17376,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12083,6 +17417,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12174,10 +17528,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -12207,7 +17600,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -12258,7 +17652,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -12850,6 +18245,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12906,6 +18321,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear the GPIO pattern array for antenna control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12927,6 +18371,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC configuration"]
@@ -12963,6 +18427,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12985,6 +18472,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -13011,6 +18518,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13032,6 +18559,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -13136,6 +18683,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13179,6 +18767,32 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ctestatus {
                 Ctestatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -13369,6 +18983,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13390,6 +19069,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -13415,6 +19110,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13436,6 +19147,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -13542,6 +19273,47 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("repeatpattern", &self.repeatpattern())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    repeatpattern: super::vals::Repeatpattern,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    repeatpattern: self.repeatpattern(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13576,6 +19348,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13597,6 +19392,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -13633,6 +19448,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect loop count"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13657,6 +19495,26 @@ pub mod radio {
                 Edcnt(0)
             }
         }
+        impl core::fmt::Debug for Edcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edcnt")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edcnt {
+                    edcnt: u32,
+                }
+                let proxy = Edcnt {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect level"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13678,6 +19536,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edsample {
                 Edsample(0)
+            }
+        }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -13712,6 +19590,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -13990,6 +19891,95 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("framestart", &self.framestart())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("phyend", &self.phyend())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    framestart: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    txready: bool,
+                    rxready: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    phyend: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    framestart: self.framestart(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    phyend: self.phyend(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14013,6 +20003,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14034,6 +20044,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -14068,6 +20094,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -14173,6 +20222,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14241,6 +20331,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14275,6 +20397,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14296,6 +20441,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -14354,6 +20519,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14410,6 +20604,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14431,6 +20654,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -14533,6 +20776,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14555,6 +20839,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -14580,6 +20884,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14601,6 +20925,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14824,6 +21164,80 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14845,6 +21259,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -14870,6 +21304,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14891,6 +21345,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmit address select"]
@@ -14916,6 +21386,26 @@ pub mod radio {
                 Txaddress(0)
             }
         }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output power"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14939,10 +21429,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -14981,7 +21492,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -15013,7 +21525,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -15043,7 +21556,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -15073,7 +21587,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -15113,7 +21628,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -15153,7 +21669,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8 us unit (default) Set to 20 if parsed CTETime is larger than 20"]
             _20 = 0x0,
@@ -15186,7 +21703,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -15216,7 +21734,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -15249,7 +21768,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -15282,7 +21802,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -15312,7 +21833,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -15346,7 +21868,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -15376,7 +21899,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -15425,7 +21949,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -15455,7 +21980,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -15489,7 +22015,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Repeatpattern {
             #[doc = "Do not repeat (1 time in total)"]
             NO_REPEAT = 0x0,
@@ -15532,7 +22059,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -15562,7 +22090,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -15592,7 +22121,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -15622,7 +22152,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -15652,7 +22183,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -15685,7 +22217,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -15736,7 +22269,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -15776,7 +22310,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -15816,7 +22351,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -15856,7 +22392,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -15893,7 +22430,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -16273,6 +22811,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16294,6 +22852,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16319,6 +22897,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16340,6 +22938,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16464,6 +23082,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16486,6 +23124,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -16537,6 +23195,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16586,6 +23283,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16607,6 +23343,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -16856,6 +23612,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16948,6 +23724,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable SAADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16969,6 +23783,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17079,6 +23913,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring of a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17113,6 +24030,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last result is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17134,6 +24074,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last result is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -17159,6 +24119,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of 16-bit samples to be written to output RAM buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17180,6 +24160,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -17205,6 +24205,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17226,6 +24246,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -17251,6 +24291,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17272,6 +24332,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -17309,6 +24387,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17332,10 +24433,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single-ended, PSELN will be ignored, negative input to SAADC shorted to GND"]
             SE = 0x0,
@@ -17365,7 +24487,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -17407,7 +24530,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -17458,7 +24582,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -17527,7 +24652,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -17557,7 +24683,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -17591,7 +24718,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -17625,7 +24753,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -17655,7 +24784,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "SAADC is ready. No on-going conversions."]
             READY = 0x0,
@@ -17685,7 +24815,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -17725,7 +24856,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bits"]
             _8BIT = 0x0,
@@ -17812,10 +24944,37 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -17991,6 +25150,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18012,6 +25197,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -18038,6 +25243,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18059,6 +25284,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register"]
@@ -18084,6 +25327,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18107,10 +25366,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -18140,7 +25416,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -18170,7 +25447,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -18240,6 +25518,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -18253,7 +25560,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -18612,6 +25920,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Minimum duration between edge of CSN and edge of SCK and minimum duration CSN must stay high between transactions"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18633,6 +25967,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csndur {
                 Csndur(0)
+            }
+        }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Polarity of CSN output"]
@@ -18658,6 +26012,26 @@ pub mod spim {
                 Csnpol(0)
             }
         }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol", &self.csnpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol: super::vals::Csnpol,
+                }
+                let proxy = Csnpol {
+                    csnpol: self.csnpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DCX configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18679,6 +26053,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Dcxcnt {
                 Dcxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable SPIM"]
@@ -18704,6 +26098,26 @@ pub mod spim {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18726,6 +26140,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -18795,6 +26229,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18816,6 +26282,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -18841,6 +26323,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18862,6 +26364,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -18887,6 +26407,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample delay for input serial data on MISO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18910,6 +26450,26 @@ pub mod spim {
                 Rxdelay(0)
             }
         }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18931,6 +26491,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Stall status for EasyDMA RAM accesses. The fields in this register are set to STALL by hardware whenever a stall occurs and can be cleared (set to NOSTALL) by the CPU."]
@@ -18967,6 +26547,29 @@ pub mod spim {
                 Stallstat(0)
             }
         }
+        impl core::fmt::Debug for Stallstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Stallstat")
+                    .field("tx", &self.tx())
+                    .field("rx", &self.rx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Stallstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Stallstat {
+                    tx: bool,
+                    rx: bool,
+                }
+                let proxy = Stallstat {
+                    tx: self.tx(),
+                    rx: self.rx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18988,6 +26591,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -19013,6 +26636,24 @@ pub mod spim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19036,10 +26677,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -19069,7 +26731,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -19099,7 +26762,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -19129,7 +26793,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -19203,6 +26868,39 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x0a00_0000 => f.write_str("M16"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x1400_0000 => f.write_str("M32"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x0a00_0000 => defmt::write!(f, "M16"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x1400_0000 => defmt::write!(f, "M32"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -19216,7 +26914,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -19246,7 +26945,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -19278,7 +26978,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -19575,6 +27276,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19598,6 +27325,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19619,6 +27362,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -19666,6 +27429,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19687,6 +27476,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -19712,6 +27517,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19733,6 +27558,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -19758,6 +27601,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19781,6 +27644,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19802,6 +27685,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -19838,6 +27741,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19859,6 +27785,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -19884,6 +27830,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19907,10 +27871,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -19940,7 +27925,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -19970,7 +27956,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -20014,7 +28001,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -20044,7 +28032,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -20076,7 +28065,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -20110,7 +28100,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -20257,6 +28248,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -20374,6 +28385,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20401,6 +28432,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20424,6 +28492,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20445,6 +28529,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -20489,10 +28593,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -20526,7 +28688,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -20734,6 +28897,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20755,6 +28938,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -20802,6 +29005,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20824,6 +29053,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -20904,6 +29153,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20925,6 +29209,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -20961,6 +29261,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20984,10 +29307,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -21047,6 +29387,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -21321,6 +29682,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21342,6 +29723,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -21389,6 +29790,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21411,6 +29838,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -21502,6 +29949,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21523,6 +30008,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -21548,6 +30053,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21569,6 +30092,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -21649,6 +30192,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21670,6 +30248,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -21695,6 +30293,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21718,10 +30334,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -21783,6 +30420,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -21796,7 +30454,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -21832,7 +30491,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -22136,6 +30796,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22170,6 +30850,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22191,6 +30894,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -22236,6 +30959,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -22316,6 +31065,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22337,6 +31121,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -22362,6 +31166,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22383,6 +31203,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -22408,6 +31248,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22429,6 +31287,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -22465,6 +31343,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22486,6 +31387,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -22511,6 +31432,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22534,10 +31473,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -22581,7 +31541,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -22613,7 +31574,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -22831,6 +31793,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22887,6 +31869,35 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22908,6 +31919,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -22964,6 +31995,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -23044,6 +32104,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23065,6 +32160,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -23101,6 +32212,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23122,6 +32256,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -23175,6 +32325,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -23188,7 +32389,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -23224,7 +32426,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -23268,7 +32471,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -23298,7 +32502,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -23608,6 +32813,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23664,6 +32889,35 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23685,6 +32939,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -23741,6 +33015,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -23876,6 +33179,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23899,6 +33252,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23920,6 +33293,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -23956,6 +33349,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23979,6 +33395,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24000,6 +33436,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -24053,6 +33509,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -24066,7 +33573,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -24102,7 +33610,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -24146,7 +33655,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -24176,7 +33686,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -24296,6 +33807,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Processor debug control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24330,6 +33859,29 @@ pub mod uicr {
                 Debugctrl(0)
             }
         }
+        impl core::fmt::Debug for Debugctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Debugctrl")
+                    .field("cpuniden", &self.cpuniden())
+                    .field("cpufpben", &self.cpufpben())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Debugctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Debugctrl {
+                    cpuniden: super::vals::Cpuniden,
+                    cpufpben: super::vals::Cpufpben,
+                }
+                let proxy = Debugctrl {
+                    cpuniden: self.cpuniden(),
+                    cpufpben: self.cpufpben(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Setting of pins dedicated to NFC functionality: NFC antenna or GPIO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24351,6 +33903,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Nfcpins {
                 Nfcpins(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcpins {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcpins")
+                    .field("protect", &self.protect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcpins {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcpins {
+                    protect: super::vals::Protect,
+                }
+                let proxy = Nfcpins {
+                    protect: self.protect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output voltage from REG0 regulator stage. The maximum output voltage from this stage is given as VDDH - V_VDDH-VDD."]
@@ -24376,6 +33948,24 @@ pub mod uicr {
                 Regout0(0)
             }
         }
+        impl core::fmt::Debug for Regout0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regout0")
+                    .field("vout", &self.vout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regout0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regout0 {
+                    vout: super::vals::Vout,
+                }
+                let proxy = Regout0 { vout: self.vout() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -24393,6 +33983,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Cpufpben {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0xff => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpufpben {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0xff => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Cpufpben {
@@ -24422,6 +34031,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Cpuniden {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0xff => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpuniden {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0xff => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Cpuniden {
@@ -24455,6 +34083,27 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Pall {
             #[inline(always)]
             fn from(val: u8) -> Pall {
@@ -24468,7 +34117,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protect {
             #[doc = "Operation as GPIO pins. Same protection as normal GPIO pins."]
             DISABLED = 0x0,
@@ -24498,7 +34148,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Vout {
             #[doc = "1.8 V"]
             _1V8 = 0x0,
@@ -25070,6 +34721,32 @@ pub mod usbd {
                 Bmrequesttype(0)
             }
         }
+        impl core::fmt::Debug for Bmrequesttype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bmrequesttype")
+                    .field("recipient", &self.recipient())
+                    .field("type_", &self.type_())
+                    .field("direction", &self.direction())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bmrequesttype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bmrequesttype {
+                    recipient: super::vals::Recipient,
+                    type_: super::vals::Type,
+                    direction: super::vals::Io,
+                }
+                let proxy = Bmrequesttype {
+                    recipient: self.recipient(),
+                    type_: self.type_(),
+                    direction: self.direction(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 1, bRequest"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25093,6 +34770,26 @@ pub mod usbd {
                 Brequest(0)
             }
         }
+        impl core::fmt::Debug for Brequest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Brequest")
+                    .field("brequest", &self.brequest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Brequest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Brequest {
+                    brequest: super::vals::Brequest,
+                }
+                let proxy = Brequest {
+                    brequest: self.brequest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State D+ and D- lines will be forced into by the DPDMDRIVE task. The DPDMNODRIVE task reverts the control of the lines to MAC IP (no forcing)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25114,6 +34811,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Dpdmvalue {
                 Dpdmvalue(0)
+            }
+        }
+        impl core::fmt::Debug for Dpdmvalue {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpdmvalue")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpdmvalue {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpdmvalue {
+                    state: super::vals::State,
+                }
+                let proxy = Dpdmvalue {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data toggle control and status"]
@@ -25161,6 +34878,32 @@ pub mod usbd {
                 Dtoggle(0)
             }
         }
+        impl core::fmt::Debug for Dtoggle {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dtoggle")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dtoggle {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dtoggle {
+                    ep: u8,
+                    io: super::vals::Io,
+                    value: super::vals::Value,
+                }
+                let proxy = Dtoggle {
+                    ep: self.ep(),
+                    io: self.io(),
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable USB"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25182,6 +34925,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Provides information on which endpoint(s) an acknowledged data transfer has occurred (EPDATA event)"]
@@ -25226,6 +34989,67 @@ pub mod usbd {
                 Epdatastatus(0)
             }
         }
+        impl core::fmt::Debug for Epdatastatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epdatastatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epdatastatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epdatastatus {
+                    epin: [bool; 7usize],
+                    epout: [bool; 7usize],
+                }
+                let proxy = Epdatastatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: IN endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25248,6 +35072,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epin {
                 Epin(0)
+            }
+        }
+        impl core::fmt::Debug for Epin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epin")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epin {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = Epin {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
@@ -25273,6 +35117,26 @@ pub mod usbd {
                 EpinAmount(0)
             }
         }
+        impl core::fmt::Debug for EpinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinAmount {
+                    amount: u8,
+                }
+                let proxy = EpinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25294,6 +35158,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpinMaxcnt {
                 EpinMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint IN enable"]
@@ -25334,6 +35218,50 @@ pub mod usbd {
                 Epinen(0)
             }
         }
+        impl core::fmt::Debug for Epinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epinen")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("isoin", &self.isoin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epinen {
+                    in_: [bool; 8usize],
+                    isoin: bool,
+                }
+                let proxy = Epinen {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    isoin: self.isoin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25357,6 +35285,26 @@ pub mod usbd {
                 EpoutAmount(0)
             }
         }
+        impl core::fmt::Debug for EpoutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutAmount {
+                    amount: u8,
+                }
+                let proxy = EpoutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25378,6 +35326,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpoutMaxcnt {
                 EpoutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpoutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpoutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint OUT enable"]
@@ -25416,6 +35384,50 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epouten {
                 Epouten(0)
+            }
+        }
+        impl core::fmt::Debug for Epouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epouten")
+                    .field(
+                        "out",
+                        &[
+                            self.out(0usize),
+                            self.out(1usize),
+                            self.out(2usize),
+                            self.out(3usize),
+                            self.out(4usize),
+                            self.out(5usize),
+                            self.out(6usize),
+                            self.out(7usize),
+                        ],
+                    )
+                    .field("isoout", &self.isoout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epouten {
+                    out: [bool; 8usize],
+                    isoout: bool,
+                }
+                let proxy = Epouten {
+                    out: [
+                        self.out(0usize),
+                        self.out(1usize),
+                        self.out(2usize),
+                        self.out(3usize),
+                        self.out(4usize),
+                        self.out(5usize),
+                        self.out(6usize),
+                        self.out(7usize),
+                    ],
+                    isoout: self.isoout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "STALL endpoints"]
@@ -25463,6 +35475,32 @@ pub mod usbd {
                 Epstall(0)
             }
         }
+        impl core::fmt::Debug for Epstall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstall")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("stall", &self.stall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstall {
+                    ep: u8,
+                    io: super::vals::Io,
+                    stall: bool,
+                }
+                let proxy = Epstall {
+                    ep: self.ep(),
+                    io: self.io(),
+                    stall: self.stall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Provides information on which endpoint's EasyDMA registers have been captured"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25503,6 +35541,75 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epstatus {
                 Epstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Epstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                            self.epin(7usize),
+                            self.epin(8usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                            self.epout(7usize),
+                            self.epout(8usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstatus {
+                    epin: [bool; 9usize],
+                    epout: [bool; 9usize],
+                }
+                let proxy = Epstatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                        self.epin(7usize),
+                        self.epin(8usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                        self.epout(7usize),
+                        self.epout(8usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Details on what caused the USBEVENT event"]
@@ -25572,6 +35679,38 @@ pub mod usbd {
                 Eventcause(0)
             }
         }
+        impl core::fmt::Debug for Eventcause {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eventcause")
+                    .field("isooutcrc", &self.isooutcrc())
+                    .field("suspend", &self.suspend())
+                    .field("resume", &self.resume())
+                    .field("usbwuallowed", &self.usbwuallowed())
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eventcause {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eventcause {
+                    isooutcrc: bool,
+                    suspend: bool,
+                    resume: bool,
+                    usbwuallowed: bool,
+                    ready: bool,
+                }
+                let proxy = Eventcause {
+                    isooutcrc: self.isooutcrc(),
+                    suspend: self.suspend(),
+                    resume: self.resume(),
+                    usbwuallowed: self.usbwuallowed(),
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Returns the current value of the start of frame counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25593,6 +35732,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Framecntr {
                 Framecntr(0)
+            }
+        }
+        impl core::fmt::Debug for Framecntr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framecntr")
+                    .field("framecntr", &self.framecntr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framecntr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framecntr {
+                    framecntr: u16,
+                }
+                let proxy = Framecntr {
+                    framecntr: self.framecntr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: OUT endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
@@ -25617,6 +35776,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> HaltedEpout {
                 HaltedEpout(0)
+            }
+        }
+        impl core::fmt::Debug for HaltedEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HaltedEpout")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HaltedEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HaltedEpout {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = HaltedEpout {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -25760,6 +35939,98 @@ pub mod usbd {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("usbreset", &self.usbreset())
+                    .field("started", &self.started())
+                    .field(
+                        "endepin",
+                        &[
+                            self.endepin(0usize),
+                            self.endepin(1usize),
+                            self.endepin(2usize),
+                            self.endepin(3usize),
+                            self.endepin(4usize),
+                            self.endepin(5usize),
+                            self.endepin(6usize),
+                            self.endepin(7usize),
+                        ],
+                    )
+                    .field("ep0datadone", &self.ep0datadone())
+                    .field("endisoin", &self.endisoin())
+                    .field(
+                        "endepout",
+                        &[
+                            self.endepout(0usize),
+                            self.endepout(1usize),
+                            self.endepout(2usize),
+                            self.endepout(3usize),
+                            self.endepout(4usize),
+                            self.endepout(5usize),
+                            self.endepout(6usize),
+                            self.endepout(7usize),
+                        ],
+                    )
+                    .field("endisoout", &self.endisoout())
+                    .field("sof", &self.sof())
+                    .field("usbevent", &self.usbevent())
+                    .field("ep0setup", &self.ep0setup())
+                    .field("epdata", &self.epdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    usbreset: bool,
+                    started: bool,
+                    endepin: [bool; 8usize],
+                    ep0datadone: bool,
+                    endisoin: bool,
+                    endepout: [bool; 8usize],
+                    endisoout: bool,
+                    sof: bool,
+                    usbevent: bool,
+                    ep0setup: bool,
+                    epdata: bool,
+                }
+                let proxy = Int {
+                    usbreset: self.usbreset(),
+                    started: self.started(),
+                    endepin: [
+                        self.endepin(0usize),
+                        self.endepin(1usize),
+                        self.endepin(2usize),
+                        self.endepin(3usize),
+                        self.endepin(4usize),
+                        self.endepin(5usize),
+                        self.endepin(6usize),
+                        self.endepin(7usize),
+                    ],
+                    ep0datadone: self.ep0datadone(),
+                    endisoin: self.endisoin(),
+                    endepout: [
+                        self.endepout(0usize),
+                        self.endepout(1usize),
+                        self.endepout(2usize),
+                        self.endepout(3usize),
+                        self.endepout(4usize),
+                        self.endepout(5usize),
+                        self.endepout(6usize),
+                        self.endepout(7usize),
+                    ],
+                    endisoout: self.endisoout(),
+                    sof: self.sof(),
+                    usbevent: self.usbevent(),
+                    ep0setup: self.ep0setup(),
+                    epdata: self.epdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25781,6 +36052,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsoinAmount {
                 IsoinAmount(0)
+            }
+        }
+        impl core::fmt::Debug for IsoinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinAmount {
+                    amount: u16,
+                }
+                let proxy = IsoinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -25806,6 +36097,26 @@ pub mod usbd {
                 IsoinMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for IsoinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsoinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the response of the ISO IN endpoint to an IN token when no data is ready to be sent"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25827,6 +36138,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Isoinconfig {
                 Isoinconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Isoinconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoinconfig")
+                    .field("response", &self.response())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoinconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoinconfig {
+                    response: super::vals::Response,
+                }
+                let proxy = Isoinconfig {
+                    response: self.response(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received last on this ISO OUT data endpoint"]
@@ -25864,6 +36195,29 @@ pub mod usbd {
                 Isoout(0)
             }
         }
+        impl core::fmt::Debug for Isoout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoout")
+                    .field("size", &self.size())
+                    .field("zero", &self.zero())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoout {
+                    size: u16,
+                    zero: super::vals::Zero,
+                }
+                let proxy = Isoout {
+                    size: self.size(),
+                    zero: self.zero(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25887,6 +36241,26 @@ pub mod usbd {
                 IsooutAmount(0)
             }
         }
+        impl core::fmt::Debug for IsooutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutAmount {
+                    amount: u16,
+                }
+                let proxy = IsooutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25908,6 +36282,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsooutMaxcnt {
                 IsooutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for IsooutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsooutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the split of ISO buffers"]
@@ -25934,6 +36328,26 @@ pub mod usbd {
                 Isosplit(0)
             }
         }
+        impl core::fmt::Debug for Isosplit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isosplit")
+                    .field("split", &self.split())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isosplit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isosplit {
+                    split: super::vals::Split,
+                }
+                let proxy = Isosplit {
+                    split: self.split(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls USBD peripheral low power mode during USB suspend"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25955,6 +36369,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Lowpower {
                 Lowpower(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpower")
+                    .field("lowpower", &self.lowpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpower {
+                    lowpower: super::vals::Lowpower,
+                }
+                let proxy = Lowpower {
+                    lowpower: self.lowpower(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -26024,6 +36458,38 @@ pub mod usbd {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ep0datadone_startepin0", &self.ep0datadone_startepin0())
+                    .field("ep0datadone_startepout0", &self.ep0datadone_startepout0())
+                    .field("ep0datadone_ep0status", &self.ep0datadone_ep0status())
+                    .field("endepout0_ep0status", &self.endepout0_ep0status())
+                    .field("endepout0_ep0rcvout", &self.endepout0_ep0rcvout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ep0datadone_startepin0: bool,
+                    ep0datadone_startepout0: bool,
+                    ep0datadone_ep0status: bool,
+                    endepout0_ep0status: bool,
+                    endepout0_ep0rcvout: bool,
+                }
+                let proxy = Shorts {
+                    ep0datadone_startepin0: self.ep0datadone_startepin0(),
+                    ep0datadone_startepout0: self.ep0datadone_startepout0(),
+                    ep0datadone_ep0status: self.ep0datadone_ep0status(),
+                    endepout0_ep0status: self.endepout0_ep0status(),
+                    endepout0_ep0rcvout: self.endepout0_ep0rcvout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Number of bytes received last in the data stage of this OUT endpoint"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26045,6 +36511,24 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> SizeEpout {
                 SizeEpout(0)
+            }
+        }
+        impl core::fmt::Debug for SizeEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SizeEpout")
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SizeEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SizeEpout {
+                    size: u8,
+                }
+                let proxy = SizeEpout { size: self.size() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device USB address"]
@@ -26070,6 +36554,24 @@ pub mod usbd {
                 Usbaddr(0)
             }
         }
+        impl core::fmt::Debug for Usbaddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbaddr")
+                    .field("addr", &self.addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbaddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbaddr {
+                    addr: u8,
+                }
+                let proxy = Usbaddr { addr: self.addr() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control of the USB pull-up"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26091,6 +36593,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Usbpullup {
                 Usbpullup(0)
+            }
+        }
+        impl core::fmt::Debug for Usbpullup {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbpullup")
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbpullup {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbpullup {
+                    connect: bool,
+                }
+                let proxy = Usbpullup {
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 5, MSB of wIndex"]
@@ -26116,6 +36638,26 @@ pub mod usbd {
                 Windexh(0)
             }
         }
+        impl core::fmt::Debug for Windexh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexh")
+                    .field("windexh", &self.windexh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexh {
+                    windexh: u8,
+                }
+                let proxy = Windexh {
+                    windexh: self.windexh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 4, LSB of wIndex"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26137,6 +36679,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Windexl {
                 Windexl(0)
+            }
+        }
+        impl core::fmt::Debug for Windexl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexl")
+                    .field("windexl", &self.windexl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexl {
+                    windexl: u8,
+                }
+                let proxy = Windexl {
+                    windexl: self.windexl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 7, MSB of wLength"]
@@ -26162,6 +36724,26 @@ pub mod usbd {
                 Wlengthh(0)
             }
         }
+        impl core::fmt::Debug for Wlengthh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthh")
+                    .field("wlengthh", &self.wlengthh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthh {
+                    wlengthh: u8,
+                }
+                let proxy = Wlengthh {
+                    wlengthh: self.wlengthh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 6, LSB of wLength"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26183,6 +36765,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Wlengthl {
                 Wlengthl(0)
+            }
+        }
+        impl core::fmt::Debug for Wlengthl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthl")
+                    .field("wlengthl", &self.wlengthl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthl {
+                    wlengthl: u8,
+                }
+                let proxy = Wlengthl {
+                    wlengthl: self.wlengthl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 3, MSB of wValue"]
@@ -26208,6 +36810,26 @@ pub mod usbd {
                 Wvalueh(0)
             }
         }
+        impl core::fmt::Debug for Wvalueh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvalueh")
+                    .field("wvalueh", &self.wvalueh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvalueh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvalueh {
+                    wvalueh: u8,
+                }
+                let proxy = Wvalueh {
+                    wvalueh: self.wvalueh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 2, LSB of wValue"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26231,10 +36853,31 @@ pub mod usbd {
                 Wvaluel(0)
             }
         }
+        impl core::fmt::Debug for Wvaluel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvaluel")
+                    .field("wvaluel", &self.wvaluel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvaluel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvaluel {
+                    wvaluel: u8,
+                }
+                let proxy = Wvaluel {
+                    wvaluel: self.wvaluel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Brequest {
             #[doc = "Standard request GET_STATUS"]
             STD_GET_STATUS = 0x0,
@@ -26543,6 +37186,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Getstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("NOT_HALTED"),
+                    0x01 => f.write_str("HALTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Getstatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "NOT_HALTED"),
+                    0x01 => defmt::write!(f, "HALTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Getstatus {
             #[inline(always)]
             fn from(val: u16) -> Getstatus {
@@ -26556,7 +37218,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Io {
             #[doc = "Selects OUT endpoint"]
             OUT = 0x0,
@@ -26586,7 +37249,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lowpower {
             #[doc = "Software must write this value to exit low power mode and before performing a remote wake-up"]
             FORCE_NORMAL = 0x0,
@@ -26636,6 +37300,29 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Recipient {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DEVICE"),
+                    0x01 => f.write_str("INTERFACE"),
+                    0x02 => f.write_str("ENDPOINT"),
+                    0x03 => f.write_str("OTHER"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Recipient {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DEVICE"),
+                    0x01 => defmt::write!(f, "INTERFACE"),
+                    0x02 => defmt::write!(f, "ENDPOINT"),
+                    0x03 => defmt::write!(f, "OTHER"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Recipient {
             #[inline(always)]
             fn from(val: u8) -> Recipient {
@@ -26649,7 +37336,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Response {
             #[doc = "Endpoint does not respond in that case"]
             NO_RESP = 0x0,
@@ -26695,6 +37383,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Split {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ONE_DIR"),
+                    0x80 => f.write_str("HALF_IN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Split {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ONE_DIR"),
+                    0x80 => defmt::write!(f, "HALF_IN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Split {
             #[inline(always)]
             fn from(val: u16) -> Split {
@@ -26726,6 +37433,27 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("RESUME"),
+                    0x02 => f.write_str("J"),
+                    0x04 => f.write_str("K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "RESUME"),
+                    0x02 => defmt::write!(f, "J"),
+                    0x04 => defmt::write!(f, "K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for State {
             #[inline(always)]
             fn from(val: u8) -> State {
@@ -26739,7 +37467,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Type {
             #[doc = "Standard"]
             STANDARD = 0x0,
@@ -26772,7 +37501,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Value {
             #[doc = "No action on data toggle when writing the register with this value"]
             NOP = 0x0,
@@ -26805,7 +37535,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Zero {
             #[doc = "No zero-length data received, use value in SIZE"]
             NORMAL = 0x0,
@@ -26940,6 +37671,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26961,6 +37715,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -26990,6 +37764,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27012,6 +37827,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -27041,6 +37872,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27064,10 +37936,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -27111,6 +38004,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -27124,7 +38034,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf52840/pac.rs
+++ b/src/chips/nrf52840/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - CLOCK_POWER"]
     CLOCK_POWER = 0,
@@ -503,6 +504,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -548,6 +569,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -569,6 +616,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -594,10 +657,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -721,10 +805,34 @@ pub mod acl {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: super::vals::Write,
+                    read: super::vals::Read,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Read {
             #[doc = "Allow read instructions to region n."]
             ENABLE = 0x0,
@@ -754,7 +862,8 @@ pub mod acl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Write {
             #[doc = "Allow write and erase instructions to region n."]
             ENABLE = 0x0,
@@ -839,6 +948,26 @@ pub mod approtect {
                 Disable(0)
             }
         }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Disable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Disable {
+                    disable: super::vals::Disable,
+                }
+                let proxy = Disable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force enable APPROTECT mechanism until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -862,6 +991,26 @@ pub mod approtect {
                 Forceprotect(0)
             }
         }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceprotect {
+                    forceprotect: super::vals::Forceprotect,
+                }
+                let proxy = Forceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -877,6 +1026,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Disable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_DISABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Disable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_DISABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Disable {
@@ -904,6 +1070,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Forceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("FORCE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "FORCE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Forceprotect {
@@ -1031,6 +1214,26 @@ pub mod cc_aes {
                 AesBusy(0)
             }
         }
+        impl core::fmt::Debug for AesBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesBusy {
+                    status: super::vals::Status,
+                }
+                let proxy = AesBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Writing to this address triggers the AES engine to generate K1 and K2 for AES-CMAC operations."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1054,6 +1257,26 @@ pub mod cc_aes {
                 AesCmacInit(0)
             }
         }
+        impl core::fmt::Debug for AesCmacInit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesCmacInit")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesCmacInit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesCmacInit {
+                    enable: bool,
+                }
+                let proxy = AesCmacInit {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Writing to this address triggers the AES engine to perform a CMAC operation with size 0. The CMAC result can be read from the AES_IV_0 register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1075,6 +1298,26 @@ pub mod cc_aes {
             #[inline(always)]
             fn default() -> AesCmacSize0Kick {
                 AesCmacSize0Kick(0)
+            }
+        }
+        impl core::fmt::Debug for AesCmacSize0Kick {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesCmacSize0Kick")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesCmacSize0Kick {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesCmacSize0Kick {
+                    enable: bool,
+                }
+                let proxy = AesCmacSize0Kick {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control the AES engine behavior."]
@@ -1145,6 +1388,38 @@ pub mod cc_aes {
                 AesControl(0)
             }
         }
+        impl core::fmt::Debug for AesControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesControl")
+                    .field("dec_key0", &self.dec_key0())
+                    .field("mode_key0", &self.mode_key0())
+                    .field("nk_key0", &self.nk_key0())
+                    .field("aes_xor_cryptokey", &self.aes_xor_cryptokey())
+                    .field("direct_access", &self.direct_access())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesControl {
+                    dec_key0: super::vals::DecKey0,
+                    mode_key0: super::vals::ModeKey0,
+                    nk_key0: super::vals::NkKey0,
+                    aes_xor_cryptokey: bool,
+                    direct_access: bool,
+                }
+                let proxy = AesControl {
+                    dec_key0: self.dec_key0(),
+                    mode_key0: self.mode_key0(),
+                    nk_key0: self.nk_key0(),
+                    aes_xor_cryptokey: self.aes_xor_cryptokey(),
+                    direct_access: self.direct_access(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register enables the AES CTR no increment mode in which the counter mode is not incremented between two blocks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1166,6 +1441,26 @@ pub mod cc_aes {
             #[inline(always)]
             fn default() -> AesCtrNoIncrement {
                 AesCtrNoIncrement(0)
+            }
+        }
+        impl core::fmt::Debug for AesCtrNoIncrement {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesCtrNoIncrement")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesCtrNoIncrement {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesCtrNoIncrement {
+                    enable: bool,
+                }
+                let proxy = AesCtrNoIncrement {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration of the AES engine. Reset value holds the supported features."]
@@ -1301,6 +1596,56 @@ pub mod cc_aes {
                 AesHwFlags(0)
             }
         }
+        impl core::fmt::Debug for AesHwFlags {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesHwFlags")
+                    .field("support_256_192_key", &self.support_256_192_key())
+                    .field("aes_large_rkek", &self.aes_large_rkek())
+                    .field("dpa_cntrmsr_exist", &self.dpa_cntrmsr_exist())
+                    .field("ctr_exist", &self.ctr_exist())
+                    .field("only_encrypt", &self.only_encrypt())
+                    .field("use_sbox_table", &self.use_sbox_table())
+                    .field("use_5_sboxes", &self.use_5_sboxes())
+                    .field("aes_support_prev_iv", &self.aes_support_prev_iv())
+                    .field("aes_tunnel_exist", &self.aes_tunnel_exist())
+                    .field("second_regs_set_exist", &self.second_regs_set_exist())
+                    .field("dfa_cntrmsr_exist", &self.dfa_cntrmsr_exist())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesHwFlags {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesHwFlags {
+                    support_256_192_key: bool,
+                    aes_large_rkek: bool,
+                    dpa_cntrmsr_exist: bool,
+                    ctr_exist: bool,
+                    only_encrypt: bool,
+                    use_sbox_table: bool,
+                    use_5_sboxes: bool,
+                    aes_support_prev_iv: bool,
+                    aes_tunnel_exist: bool,
+                    second_regs_set_exist: bool,
+                    dfa_cntrmsr_exist: bool,
+                }
+                let proxy = AesHwFlags {
+                    support_256_192_key: self.support_256_192_key(),
+                    aes_large_rkek: self.aes_large_rkek(),
+                    dpa_cntrmsr_exist: self.dpa_cntrmsr_exist(),
+                    ctr_exist: self.ctr_exist(),
+                    only_encrypt: self.only_encrypt(),
+                    use_sbox_table: self.use_sbox_table(),
+                    use_5_sboxes: self.use_5_sboxes(),
+                    aes_support_prev_iv: self.aes_support_prev_iv(),
+                    aes_tunnel_exist: self.aes_tunnel_exist(),
+                    second_regs_set_exist: self.second_regs_set_exist(),
+                    dfa_cntrmsr_exist: self.dfa_cntrmsr_exist(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Writing to this address trigger sampling of the HW key to the AES_KEY_0 register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1322,6 +1667,26 @@ pub mod cc_aes {
             #[inline(always)]
             fn default() -> AesSk {
                 AesSk(0)
+            }
+        }
+        impl core::fmt::Debug for AesSk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesSk")
+                    .field("aes_sk", &self.aes_sk())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesSk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesSk {
+                    aes_sk: bool,
+                }
+                let proxy = AesSk {
+                    aes_sk: self.aes_sk(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset the AES engine."]
@@ -1347,10 +1712,31 @@ pub mod cc_aes {
                 AesSwReset(0)
             }
         }
+        impl core::fmt::Debug for AesSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesSwReset {
+                    reset: bool,
+                }
+                let proxy = AesSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DecKey0 {
             #[doc = "Perform AES encryption"]
             ENCRYPT = 0x0,
@@ -1380,7 +1766,8 @@ pub mod cc_aes {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ModeKey0 {
             #[doc = "Electronic codebook mode"]
             ECB = 0x0,
@@ -1419,7 +1806,8 @@ pub mod cc_aes {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NkKey0 {
             #[doc = "128 bits key length"]
             _128BITS = 0x0,
@@ -1450,7 +1838,8 @@ pub mod cc_aes {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "AES engine is idle"]
             IDLE = 0x0,
@@ -1597,6 +1986,26 @@ pub mod cc_chacha {
                 ChachaBusy(0)
             }
         }
+        impl core::fmt::Debug for ChachaBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaBusy {
+                    status: super::vals::Status,
+                }
+                let proxy = ChachaBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control the CHACHA engine behavior."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1686,6 +2095,44 @@ pub mod cc_chacha {
                 ChachaControl(0)
             }
         }
+        impl core::fmt::Debug for ChachaControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaControl")
+                    .field("chacha_or_salsa", &self.chacha_or_salsa())
+                    .field("init", &self.init())
+                    .field("gen_key_poly1305", &self.gen_key_poly1305())
+                    .field("key_len", &self.key_len())
+                    .field("num_of_rounds", &self.num_of_rounds())
+                    .field("reset_block_cnt", &self.reset_block_cnt())
+                    .field("use_iv_96bit", &self.use_iv_96bit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaControl {
+                    chacha_or_salsa: super::vals::ChachaOrSalsa,
+                    init: bool,
+                    gen_key_poly1305: bool,
+                    key_len: super::vals::KeyLen,
+                    num_of_rounds: super::vals::NumOfRounds,
+                    reset_block_cnt: bool,
+                    use_iv_96bit: bool,
+                }
+                let proxy = ChachaControl {
+                    chacha_or_salsa: self.chacha_or_salsa(),
+                    init: self.init(),
+                    gen_key_poly1305: self.gen_key_poly1305(),
+                    key_len: self.key_len(),
+                    num_of_rounds: self.num_of_rounds(),
+                    reset_block_cnt: self.reset_block_cnt(),
+                    use_iv_96bit: self.use_iv_96bit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Debug register for the CHACHA engine"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1707,6 +2154,26 @@ pub mod cc_chacha {
             #[inline(always)]
             fn default() -> ChachaDebug {
                 ChachaDebug(0)
+            }
+        }
+        impl core::fmt::Debug for ChachaDebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaDebug")
+                    .field("fsm_state", &self.fsm_state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaDebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaDebug {
+                    fsm_state: super::vals::FsmState,
+                }
+                let proxy = ChachaDebug {
+                    fsm_state: self.fsm_state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CHACHA engine data order configuration."]
@@ -1781,6 +2248,41 @@ pub mod cc_chacha {
                 ChachaEndianness(0)
             }
         }
+        impl core::fmt::Debug for ChachaEndianness {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaEndianness")
+                    .field("chacha_din_word_order", &self.chacha_din_word_order())
+                    .field("chacha_din_byte_order", &self.chacha_din_byte_order())
+                    .field(
+                        "chacha_core_matrix_lbe_order",
+                        &self.chacha_core_matrix_lbe_order(),
+                    )
+                    .field("chacha_dout_word_order", &self.chacha_dout_word_order())
+                    .field("chacha_dout_byte_order", &self.chacha_dout_byte_order())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaEndianness {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaEndianness {
+                    chacha_din_word_order: super::vals::ChachaDinWordOrder,
+                    chacha_din_byte_order: super::vals::ChachaDinByteOrder,
+                    chacha_core_matrix_lbe_order: super::vals::ChachaCoreMatrixLbeOrder,
+                    chacha_dout_word_order: super::vals::ChachaDoutWordOrder,
+                    chacha_dout_byte_order: super::vals::ChachaDoutByteOrder,
+                }
+                let proxy = ChachaEndianness {
+                    chacha_din_word_order: self.chacha_din_word_order(),
+                    chacha_din_byte_order: self.chacha_din_byte_order(),
+                    chacha_core_matrix_lbe_order: self.chacha_core_matrix_lbe_order(),
+                    chacha_dout_word_order: self.chacha_dout_word_order(),
+                    chacha_dout_byte_order: self.chacha_dout_byte_order(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hardware configuration of the CHACHA engine. Reset value holds the supported features."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1826,6 +2328,32 @@ pub mod cc_chacha {
                 ChachaHwFlags(0)
             }
         }
+        impl core::fmt::Debug for ChachaHwFlags {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaHwFlags")
+                    .field("chacha_exists", &self.chacha_exists())
+                    .field("salsa_exists", &self.salsa_exists())
+                    .field("fast_chacha", &self.fast_chacha())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaHwFlags {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaHwFlags {
+                    chacha_exists: bool,
+                    salsa_exists: bool,
+                    fast_chacha: bool,
+                }
+                let proxy = ChachaHwFlags {
+                    chacha_exists: self.chacha_exists(),
+                    salsa_exists: self.salsa_exists(),
+                    fast_chacha: self.fast_chacha(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the CHACHA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1849,10 +2377,31 @@ pub mod cc_chacha {
                 ChachaSwReset(0)
             }
         }
+        impl core::fmt::Debug for ChachaSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaSwReset {
+                    reset: bool,
+                }
+                let proxy = ChachaSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaCoreMatrixLbeOrder {
             #[doc = "Use default quarter of matrix order, where quarters are ordered as follows: q0, q1, q2, q3. Each quarter represents a 128-bits section of the matrix."]
             DEFAULT = 0x0,
@@ -1882,7 +2431,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaDinByteOrder {
             #[doc = "Use default byte order within each input word, where bytes are ordered as follows: B0, B1, B2, B3."]
             DEFAULT = 0x0,
@@ -1912,7 +2462,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaDinWordOrder {
             #[doc = "Use default word order for 128-bits input, where words are ordered as follows: w0, w1, w2, w3."]
             DEFAULT = 0x0,
@@ -1942,7 +2493,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaDoutByteOrder {
             #[doc = "Use default byte order within each output word, where bytes are ordered as follows: B0, B1, B2, B3."]
             DEFAULT = 0x0,
@@ -1972,7 +2524,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaDoutWordOrder {
             #[doc = "Uses default word order for 128-bits output, where words are ordered as follows: w0, w1, w2, w3."]
             DEFAULT = 0x0,
@@ -2002,7 +2555,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ChachaOrSalsa {
             #[doc = "Run engine in ChaCha mode"]
             CHA_CHA = 0x0,
@@ -2032,7 +2586,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum FsmState {
             #[doc = "CHACHA FSM is in idle state"]
             IDLE_STATE = 0x0,
@@ -2066,7 +2621,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum KeyLen {
             #[doc = "Use 256 bits key length"]
             _256BITS = 0x0,
@@ -2096,7 +2652,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NumOfRounds {
             #[doc = "Use 20 rounds of rotation (default)"]
             DEFAULT = 0x0,
@@ -2129,7 +2686,8 @@ pub mod cc_chacha {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "CHACHA engine is idle"]
             IDLE = 0x0,
@@ -2222,6 +2780,26 @@ pub mod cc_ctl {
                 ContextId(0)
             }
         }
+        impl core::fmt::Debug for ContextId {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ContextId")
+                    .field("context_id", &self.context_id())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ContextId {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ContextId {
+                    context_id: u8,
+                }
+                let proxy = ContextId {
+                    context_id: self.context_id(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for cryptographic cores engine activity."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2243,6 +2821,26 @@ pub mod cc_ctl {
             #[inline(always)]
             fn default() -> CryptoBusy {
                 CryptoBusy(0)
+            }
+        }
+        impl core::fmt::Debug for CryptoBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptoBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptoBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptoBusy {
+                    status: super::vals::CryptoBusyStatus,
+                }
+                let proxy = CryptoBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the cryptographic flow."]
@@ -2268,6 +2866,24 @@ pub mod cc_ctl {
                 CryptoCtl(0)
             }
         }
+        impl core::fmt::Debug for CryptoCtl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptoCtl")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptoCtl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptoCtl {
+                    mode: super::vals::Mode,
+                }
+                let proxy = CryptoCtl { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for HASH engine activity."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2291,10 +2907,31 @@ pub mod cc_ctl {
                 HashBusy(0)
             }
         }
+        impl core::fmt::Debug for HashBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashBusy {
+                    status: super::vals::HashBusyStatus,
+                }
+                let proxy = HashBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CryptoBusyStatus {
             #[doc = "Cryptographic core engines are idle"]
             IDLE = 0x0,
@@ -2324,7 +2961,8 @@ pub mod cc_ctl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HashBusyStatus {
             #[doc = "HASH engine is idle"]
             IDLE = 0x0,
@@ -2354,7 +2992,8 @@ pub mod cc_ctl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Bypass cryptographic engine"]
             BYPASS = 0x0,
@@ -2540,6 +3179,24 @@ pub mod cc_din {
                 DinCpuData(0)
             }
         }
+        impl core::fmt::Debug for DinCpuData {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinCpuData")
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinCpuData {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinCpuData {
+                    size: u16,
+                }
+                let proxy = DinCpuData { size: self.size() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for DIN DMA engine activity when accessing memory."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2561,6 +3218,26 @@ pub mod cc_din {
             #[inline(always)]
             fn default() -> DinDmaMemBusy {
                 DinDmaMemBusy(0)
+            }
+        }
+        impl core::fmt::Debug for DinDmaMemBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinDmaMemBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinDmaMemBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinDmaMemBusy {
+                    status: super::vals::DinDmaMemBusyStatus,
+                }
+                let proxy = DinDmaMemBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register for DIN DMA engine activity when accessing RNG SRAM."]
@@ -2586,6 +3263,26 @@ pub mod cc_din {
                 DinDmaSramBusy(0)
             }
         }
+        impl core::fmt::Debug for DinDmaSramBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinDmaSramBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinDmaSramBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinDmaSramBusy {
+                    status: super::vals::DinDmaSramBusyStatus,
+                }
+                let proxy = DinDmaSramBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure the endianness of DIN DMA transactions towards RNG SRAM."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2607,6 +3304,26 @@ pub mod cc_din {
             #[inline(always)]
             fn default() -> DinDmaSramEndianness {
                 DinDmaSramEndianness(0)
+            }
+        }
+        impl core::fmt::Debug for DinDmaSramEndianness {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinDmaSramEndianness")
+                    .field("endian", &self.endian())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinDmaSramEndianness {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinDmaSramEndianness {
+                    endian: super::vals::Endian,
+                }
+                let proxy = DinDmaSramEndianness {
+                    endian: self.endian(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register indicating if DIN FIFO is empty and if more data can be accepted."]
@@ -2632,6 +3349,26 @@ pub mod cc_din {
                 DinFifoEmpty(0)
             }
         }
+        impl core::fmt::Debug for DinFifoEmpty {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinFifoEmpty")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinFifoEmpty {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinFifoEmpty {
+                    status: bool,
+                }
+                let proxy = DinFifoEmpty {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the DIN FIFO, effectively clearing the FIFO for new data."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2653,6 +3390,26 @@ pub mod cc_din {
             #[inline(always)]
             fn default() -> DinFifoReset {
                 DinFifoReset(0)
+            }
+        }
+        impl core::fmt::Debug for DinFifoReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinFifoReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinFifoReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinFifoReset {
+                    reset: bool,
+                }
+                let proxy = DinFifoReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset the DIN DMA engine."]
@@ -2678,6 +3435,26 @@ pub mod cc_din {
                 DinSwReset(0)
             }
         }
+        impl core::fmt::Debug for DinSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinSwReset {
+                    reset: bool,
+                }
+                let proxy = DinSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that the next CPU write to the DIN_BUFFER is the last in the sequence. This is needed only when the data size is NOT modulo 4 (e.g. HASH padding)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2699,6 +3476,24 @@ pub mod cc_din {
             #[inline(always)]
             fn default() -> DinWriteAlign {
                 DinWriteAlign(0)
+            }
+        }
+        impl core::fmt::Debug for DinWriteAlign {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DinWriteAlign")
+                    .field("last", &self.last())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DinWriteAlign {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DinWriteAlign {
+                    last: bool,
+                }
+                let proxy = DinWriteAlign { last: self.last() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The number of bytes to be read from memory. Writing to this register triggers the DMA operation."]
@@ -2747,10 +3542,37 @@ pub mod cc_din {
                 SrcMemSize(0)
             }
         }
+        impl core::fmt::Debug for SrcMemSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SrcMemSize")
+                    .field("size", &self.size())
+                    .field("first", &self.first())
+                    .field("last", &self.last())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SrcMemSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SrcMemSize {
+                    size: u32,
+                    first: bool,
+                    last: bool,
+                }
+                let proxy = SrcMemSize {
+                    size: self.size(),
+                    first: self.first(),
+                    last: self.last(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DinDmaMemBusyStatus {
             #[doc = "DIN memory DMA engine is idle"]
             IDLE = 0x0,
@@ -2780,7 +3602,8 @@ pub mod cc_din {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DinDmaSramBusyStatus {
             #[doc = "DIN RNG SRAM DMA engine is idle"]
             IDLE = 0x0,
@@ -2810,7 +3633,8 @@ pub mod cc_din {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Use little-endian format for RNG SRAM DMA transactions"]
             LITTLE_ENDIAN = 0x0,
@@ -2950,6 +3774,26 @@ pub mod cc_dout {
                 DoutDmaMemBusy(0)
             }
         }
+        impl core::fmt::Debug for DoutDmaMemBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutDmaMemBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutDmaMemBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutDmaMemBusy {
+                    status: super::vals::DoutDmaMemBusyStatus,
+                }
+                let proxy = DoutDmaMemBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for DOUT DMA engine activity when accessing RNG SRAM."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2971,6 +3815,26 @@ pub mod cc_dout {
             #[inline(always)]
             fn default() -> DoutDmaSramBusy {
                 DoutDmaSramBusy(0)
+            }
+        }
+        impl core::fmt::Debug for DoutDmaSramBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutDmaSramBusy")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutDmaSramBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutDmaSramBusy {
+                    status: super::vals::DoutDmaSramBusyStatus,
+                }
+                let proxy = DoutDmaSramBusy {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configure the endianness of DOUT DMA transactions towards RNG SRAM."]
@@ -2996,6 +3860,26 @@ pub mod cc_dout {
                 DoutDmaSramEndianness(0)
             }
         }
+        impl core::fmt::Debug for DoutDmaSramEndianness {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutDmaSramEndianness")
+                    .field("endian", &self.endian())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutDmaSramEndianness {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutDmaSramEndianness {
+                    endian: super::vals::Endian,
+                }
+                let proxy = DoutDmaSramEndianness {
+                    endian: self.endian(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register indicating if DOUT FIFO is empty or if more data will come."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3017,6 +3901,26 @@ pub mod cc_dout {
             #[inline(always)]
             fn default() -> DoutFifoEmpty {
                 DoutFifoEmpty(0)
+            }
+        }
+        impl core::fmt::Debug for DoutFifoEmpty {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutFifoEmpty")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutFifoEmpty {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutFifoEmpty {
+                    status: bool,
+                }
+                let proxy = DoutFifoEmpty {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indication that the next CPU read from the DOUT_BUFFER is the last in the sequence. This is needed only when the data size is NOT modulo 4 (e.g. HASH padding)."]
@@ -3042,6 +3946,24 @@ pub mod cc_dout {
                 DoutReadAlign(0)
             }
         }
+        impl core::fmt::Debug for DoutReadAlign {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutReadAlign")
+                    .field("last", &self.last())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutReadAlign {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutReadAlign {
+                    last: bool,
+                }
+                let proxy = DoutReadAlign { last: self.last() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the DOUT DMA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3063,6 +3985,26 @@ pub mod cc_dout {
             #[inline(always)]
             fn default() -> DoutSwReset {
                 DoutSwReset(0)
+            }
+        }
+        impl core::fmt::Debug for DoutSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DoutSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DoutSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DoutSwReset {
+                    reset: bool,
+                }
+                let proxy = DoutSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The number of bytes to be written to memory."]
@@ -3111,10 +4053,37 @@ pub mod cc_dout {
                 DstMemSize(0)
             }
         }
+        impl core::fmt::Debug for DstMemSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DstMemSize")
+                    .field("size", &self.size())
+                    .field("first", &self.first())
+                    .field("last", &self.last())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DstMemSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DstMemSize {
+                    size: u32,
+                    first: bool,
+                    last: bool,
+                }
+                let proxy = DstMemSize {
+                    size: self.size(),
+                    first: self.first(),
+                    last: self.last(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutDmaMemBusyStatus {
             #[doc = "DOUT memory DMA engine is idle"]
             IDLE = 0x0,
@@ -3144,7 +4113,8 @@ pub mod cc_dout {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutDmaSramBusyStatus {
             #[doc = "DOUT RNG SRAM DMA engine is idle"]
             IDLE = 0x0,
@@ -3174,7 +4144,8 @@ pub mod cc_dout {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Use little-endian format for RNG SRAM DMA transactions"]
             LITTLE_ENDIAN = 0x0,
@@ -3322,6 +4293,24 @@ pub mod cc_hash {
                 HashControl(0)
             }
         }
+        impl core::fmt::Debug for HashControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashControl")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashControl {
+                    mode: super::vals::Mode,
+                }
+                let proxy = HashControl { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure the endianness of HASH data and padding generation."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3343,6 +4332,26 @@ pub mod cc_hash {
             #[inline(always)]
             fn default() -> HashEndianness {
                 HashEndianness(0)
+            }
+        }
+        impl core::fmt::Debug for HashEndianness {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashEndianness")
+                    .field("endian", &self.endian())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashEndianness {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashEndianness {
+                    endian: super::vals::Endian,
+                }
+                let proxy = HashEndianness {
+                    endian: self.endian(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration of the HASH engine. Reset value holds the supported features."]
@@ -3467,6 +4476,53 @@ pub mod cc_hash {
                 HashHwFlags(0)
             }
         }
+        impl core::fmt::Debug for HashHwFlags {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashHwFlags")
+                    .field("cw", &self.cw())
+                    .field("ch", &self.ch())
+                    .field("dw", &self.dw())
+                    .field("sha_512_exists", &self.sha_512_exists())
+                    .field("pad_exists", &self.pad_exists())
+                    .field("md5_exists", &self.md5_exists())
+                    .field("hmac_exists", &self.hmac_exists())
+                    .field("sha_256_exists", &self.sha_256_exists())
+                    .field("hash_compare_exists", &self.hash_compare_exists())
+                    .field("dump_hash_to_dout_exists", &self.dump_hash_to_dout_exists())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashHwFlags {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashHwFlags {
+                    cw: super::vals::Cw,
+                    ch: super::vals::Ch,
+                    dw: super::vals::Dw,
+                    sha_512_exists: bool,
+                    pad_exists: bool,
+                    md5_exists: bool,
+                    hmac_exists: bool,
+                    sha_256_exists: bool,
+                    hash_compare_exists: bool,
+                    dump_hash_to_dout_exists: bool,
+                }
+                let proxy = HashHwFlags {
+                    cw: self.cw(),
+                    ch: self.ch(),
+                    dw: self.dw(),
+                    sha_512_exists: self.sha_512_exists(),
+                    pad_exists: self.pad_exists(),
+                    md5_exists: self.md5_exists(),
+                    hmac_exists: self.hmac_exists(),
+                    sha_256_exists: self.sha_256_exists(),
+                    hash_compare_exists: self.hash_compare_exists(),
+                    dump_hash_to_dout_exists: self.dump_hash_to_dout_exists(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure HASH engine initial state registers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3488,6 +4544,24 @@ pub mod cc_hash {
             #[inline(always)]
             fn default() -> HashInitState {
                 HashInitState(0)
+            }
+        }
+        impl core::fmt::Debug for HashInitState {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashInitState")
+                    .field("load", &self.load())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashInitState {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashInitState {
+                    load: bool,
+                }
+                let proxy = HashInitState { load: self.load() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable the hardware padding feature of the HASH engine."]
@@ -3513,6 +4587,26 @@ pub mod cc_hash {
                 HashPad(0)
             }
         }
+        impl core::fmt::Debug for HashPad {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashPad")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashPad {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashPad {
+                    enable: bool,
+                }
+                let proxy = HashPad {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure the HASH engine to automatically pad data at the end of the DMA transfer to complete the digest operation."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3534,6 +4628,26 @@ pub mod cc_hash {
             #[inline(always)]
             fn default() -> HashPadAuto {
                 HashPadAuto(0)
+            }
+        }
+        impl core::fmt::Debug for HashPadAuto {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashPadAuto")
+                    .field("hwpad", &self.hwpad())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashPadAuto {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashPadAuto {
+                    hwpad: bool,
+                }
+                let proxy = HashPadAuto {
+                    hwpad: self.hwpad(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Force the hardware padding operation to trigger if the input data length is zero bytes."]
@@ -3559,6 +4673,26 @@ pub mod cc_hash {
                 HashPadForce(0)
             }
         }
+        impl core::fmt::Debug for HashPadForce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashPadForce")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashPadForce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashPadForce {
+                    enable: bool,
+                }
+                let proxy = HashPadForce {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the HASH engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3580,6 +4714,26 @@ pub mod cc_hash {
             #[inline(always)]
             fn default() -> HashSwReset {
                 HashSwReset(0)
+            }
+        }
+        impl core::fmt::Debug for HashSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashSwReset {
+                    reset: bool,
+                }
+                let proxy = HashSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HASH engine HW version"]
@@ -3625,10 +4779,37 @@ pub mod cc_hash {
                 HashVersion(0)
             }
         }
+        impl core::fmt::Debug for HashVersion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashVersion")
+                    .field("patch", &self.patch())
+                    .field("minor_version_number", &self.minor_version_number())
+                    .field("major_version_number", &self.major_version_number())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashVersion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashVersion {
+                    patch: u8,
+                    minor_version_number: u8,
+                    major_version_number: u8,
+                }
+                let proxy = HashVersion {
+                    patch: self.patch(),
+                    minor_version_number: self.minor_version_number(),
+                    major_version_number: self.major_version_number(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ch {
             #[doc = "One Hi value is updated at a time."]
             ONE = 0x0,
@@ -3672,7 +4853,8 @@ pub mod cc_hash {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cw {
             _RESERVED_0 = 0x0,
             #[doc = "One concurrent word used by hash during signature generation"]
@@ -3716,7 +4898,8 @@ pub mod cc_hash {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dw {
             #[doc = "32 bits word data."]
             _32BITS = 0x0,
@@ -3760,7 +4943,8 @@ pub mod cc_hash {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Use little-endian format for data and padding"]
             LITTLE_ENDIAN = 0x0,
@@ -3790,7 +4974,8 @@ pub mod cc_hash {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             _RESERVED_0 = 0x0,
             #[doc = "Select SHA1 mode"]
@@ -3982,6 +5167,35 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> Endianness {
                 Endianness(0)
+            }
+        }
+        impl core::fmt::Debug for Endianness {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Endianness")
+                    .field("dout_wr_bg", &self.dout_wr_bg())
+                    .field("din_rd_bg", &self.din_rd_bg())
+                    .field("dout_wr_wbg", &self.dout_wr_wbg())
+                    .field("din_rd_wbg", &self.din_rd_wbg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Endianness {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Endianness {
+                    dout_wr_bg: super::vals::DoutWrBg,
+                    din_rd_bg: super::vals::DinRdBg,
+                    dout_wr_wbg: super::vals::DoutWrWbg,
+                    din_rd_wbg: super::vals::DinRdWbg,
+                }
+                let proxy = Endianness {
+                    dout_wr_bg: self.dout_wr_bg(),
+                    din_rd_bg: self.din_rd_bg(),
+                    dout_wr_wbg: self.dout_wr_wbg(),
+                    din_rd_wbg: self.din_rd_wbg(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration of the CRYPTOCELL subsystem. Reset value holds the supported features."]
@@ -4304,6 +5518,119 @@ pub mod cc_host_rgf {
                 HostBoot(0)
             }
         }
+        impl core::fmt::Debug for HostBoot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostBoot")
+                    .field(
+                        "power_gating_exists_local",
+                        &self.power_gating_exists_local(),
+                    )
+                    .field("large_rkek_local", &self.large_rkek_local())
+                    .field("hash_in_fuses_local", &self.hash_in_fuses_local())
+                    .field("ext_mem_secured_local", &self.ext_mem_secured_local())
+                    .field("rkek_ecc_exists_local_n", &self.rkek_ecc_exists_local_n())
+                    .field("sram_size_local", &self.sram_size_local())
+                    .field("dscrptr_exists_local", &self.dscrptr_exists_local())
+                    .field("pau_exists_local", &self.pau_exists_local())
+                    .field("rng_exists_local", &self.rng_exists_local())
+                    .field("pka_exists_local", &self.pka_exists_local())
+                    .field("rc4_exists_local", &self.rc4_exists_local())
+                    .field("sha_512_prsnt_local", &self.sha_512_prsnt_local())
+                    .field("sha_256_prsnt_local", &self.sha_256_prsnt_local())
+                    .field("md5_prsnt_local", &self.md5_prsnt_local())
+                    .field("hash_exists_local", &self.hash_exists_local())
+                    .field("c2_exists_local", &self.c2_exists_local())
+                    .field("des_exists_local", &self.des_exists_local())
+                    .field(
+                        "aes_xcbc_mac_exists_local",
+                        &self.aes_xcbc_mac_exists_local(),
+                    )
+                    .field("aes_cmac_exists_local", &self.aes_cmac_exists_local())
+                    .field("aes_ccm_exists_local", &self.aes_ccm_exists_local())
+                    .field("aes_xex_hw_t_calc_local", &self.aes_xex_hw_t_calc_local())
+                    .field("aes_xex_exists_local", &self.aes_xex_exists_local())
+                    .field("ctr_exists_local", &self.ctr_exists_local())
+                    .field(
+                        "aes_din_byte_resolution_local",
+                        &self.aes_din_byte_resolution_local(),
+                    )
+                    .field("tunneling_enb_local", &self.tunneling_enb_local())
+                    .field(
+                        "support_256_192_key_local",
+                        &self.support_256_192_key_local(),
+                    )
+                    .field("only_encrypt_local", &self.only_encrypt_local())
+                    .field("aes_exists_local", &self.aes_exists_local())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostBoot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostBoot {
+                    power_gating_exists_local: bool,
+                    large_rkek_local: bool,
+                    hash_in_fuses_local: bool,
+                    ext_mem_secured_local: bool,
+                    rkek_ecc_exists_local_n: bool,
+                    sram_size_local: u8,
+                    dscrptr_exists_local: bool,
+                    pau_exists_local: bool,
+                    rng_exists_local: bool,
+                    pka_exists_local: bool,
+                    rc4_exists_local: bool,
+                    sha_512_prsnt_local: bool,
+                    sha_256_prsnt_local: bool,
+                    md5_prsnt_local: bool,
+                    hash_exists_local: bool,
+                    c2_exists_local: bool,
+                    des_exists_local: bool,
+                    aes_xcbc_mac_exists_local: bool,
+                    aes_cmac_exists_local: bool,
+                    aes_ccm_exists_local: bool,
+                    aes_xex_hw_t_calc_local: bool,
+                    aes_xex_exists_local: bool,
+                    ctr_exists_local: bool,
+                    aes_din_byte_resolution_local: bool,
+                    tunneling_enb_local: bool,
+                    support_256_192_key_local: bool,
+                    only_encrypt_local: bool,
+                    aes_exists_local: bool,
+                }
+                let proxy = HostBoot {
+                    power_gating_exists_local: self.power_gating_exists_local(),
+                    large_rkek_local: self.large_rkek_local(),
+                    hash_in_fuses_local: self.hash_in_fuses_local(),
+                    ext_mem_secured_local: self.ext_mem_secured_local(),
+                    rkek_ecc_exists_local_n: self.rkek_ecc_exists_local_n(),
+                    sram_size_local: self.sram_size_local(),
+                    dscrptr_exists_local: self.dscrptr_exists_local(),
+                    pau_exists_local: self.pau_exists_local(),
+                    rng_exists_local: self.rng_exists_local(),
+                    pka_exists_local: self.pka_exists_local(),
+                    rc4_exists_local: self.rc4_exists_local(),
+                    sha_512_prsnt_local: self.sha_512_prsnt_local(),
+                    sha_256_prsnt_local: self.sha_256_prsnt_local(),
+                    md5_prsnt_local: self.md5_prsnt_local(),
+                    hash_exists_local: self.hash_exists_local(),
+                    c2_exists_local: self.c2_exists_local(),
+                    des_exists_local: self.des_exists_local(),
+                    aes_xcbc_mac_exists_local: self.aes_xcbc_mac_exists_local(),
+                    aes_cmac_exists_local: self.aes_cmac_exists_local(),
+                    aes_ccm_exists_local: self.aes_ccm_exists_local(),
+                    aes_xex_hw_t_calc_local: self.aes_xex_hw_t_calc_local(),
+                    aes_xex_exists_local: self.aes_xex_exists_local(),
+                    ctr_exists_local: self.ctr_exists_local(),
+                    aes_din_byte_resolution_local: self.aes_din_byte_resolution_local(),
+                    tunneling_enb_local: self.tunneling_enb_local(),
+                    support_256_192_key_local: self.support_256_192_key_local(),
+                    only_encrypt_local: self.only_encrypt_local(),
+                    aes_exists_local: self.aes_exists_local(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "AES hardware key select."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4325,6 +5652,26 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> HostCryptokeySel {
                 HostCryptokeySel(0)
+            }
+        }
+        impl core::fmt::Debug for HostCryptokeySel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostCryptokeySel")
+                    .field("host_cryptokey_sel", &self.host_cryptokey_sel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostCryptokeySel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostCryptokeySel {
+                    host_cryptokey_sel: super::vals::HostCryptokeySel,
+                }
+                let proxy = HostCryptokeySel {
+                    host_cryptokey_sel: self.host_cryptokey_sel(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This register holds bits 31:0 of K_DR. The value of this register is saved in the CRYPTOCELL AO power domain. Reading from this address returns the K_DR valid status indicating if K_DR is successfully retained."]
@@ -4351,6 +5698,26 @@ pub mod cc_host_rgf {
                 HostIotKdr0(0)
             }
         }
+        impl core::fmt::Debug for HostIotKdr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotKdr0")
+                    .field("host_iot_kdr0", &self.host_iot_kdr0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotKdr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotKdr0 {
+                    host_iot_kdr0: super::vals::HostIotKdr0,
+                }
+                let proxy = HostIotKdr0 {
+                    host_iot_kdr0: self.host_iot_kdr0(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This write-once register is the K_PRTL lock register. When this register is set, K_PRTL cannot be used and a zeroed key will be used instead. The value of this register is saved in the CRYPTOCELL AO power domain."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4372,6 +5739,26 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> HostIotKprtlLock {
                 HostIotKprtlLock(0)
+            }
+        }
+        impl core::fmt::Debug for HostIotKprtlLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotKprtlLock")
+                    .field("host_iot_kprtl_lock", &self.host_iot_kprtl_lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotKprtlLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotKprtlLock {
+                    host_iot_kprtl_lock: bool,
+                }
+                let proxy = HostIotKprtlLock {
+                    host_iot_kprtl_lock: self.host_iot_kprtl_lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls life-cycle state (LCS) for CRYPTOCELL subsystem"]
@@ -4406,6 +5793,29 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> HostIotLcs {
                 HostIotLcs(0)
+            }
+        }
+        impl core::fmt::Debug for HostIotLcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotLcs")
+                    .field("lcs", &self.lcs())
+                    .field("lcs_is_valid", &self.lcs_is_valid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotLcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotLcs {
+                    lcs: super::vals::Lcs,
+                    lcs_is_valid: bool,
+                }
+                let proxy = HostIotLcs {
+                    lcs: self.lcs(),
+                    lcs_is_valid: self.lcs_is_valid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt clear register. Writing a 1 bit into a field in this register will clear the corresponding bit in IRR."]
@@ -4495,6 +5905,44 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> Icr {
                 Icr(0)
+            }
+        }
+        impl core::fmt::Debug for Icr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icr")
+                    .field("sram_to_din_clear", &self.sram_to_din_clear())
+                    .field("dout_to_sram_clear", &self.dout_to_sram_clear())
+                    .field("mem_to_din_clear", &self.mem_to_din_clear())
+                    .field("dout_to_mem_clear", &self.dout_to_mem_clear())
+                    .field("ahb_err_clear", &self.ahb_err_clear())
+                    .field("pka_clear", &self.pka_clear())
+                    .field("rng_clear", &self.rng_clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icr {
+                    sram_to_din_clear: bool,
+                    dout_to_sram_clear: bool,
+                    mem_to_din_clear: bool,
+                    dout_to_mem_clear: bool,
+                    ahb_err_clear: bool,
+                    pka_clear: bool,
+                    rng_clear: bool,
+                }
+                let proxy = Icr {
+                    sram_to_din_clear: self.sram_to_din_clear(),
+                    dout_to_sram_clear: self.dout_to_sram_clear(),
+                    mem_to_din_clear: self.mem_to_din_clear(),
+                    dout_to_mem_clear: self.dout_to_mem_clear(),
+                    ahb_err_clear: self.ahb_err_clear(),
+                    pka_clear: self.pka_clear(),
+                    rng_clear: self.rng_clear(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt mask register. Each bit of this register holds the mask of a single interrupt source."]
@@ -4587,6 +6035,44 @@ pub mod cc_host_rgf {
                 Imr(0)
             }
         }
+        impl core::fmt::Debug for Imr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Imr")
+                    .field("sram_to_din_mask", &self.sram_to_din_mask())
+                    .field("dout_to_sram_mask", &self.dout_to_sram_mask())
+                    .field("mem_to_din_mask", &self.mem_to_din_mask())
+                    .field("dout_to_mem_mask", &self.dout_to_mem_mask())
+                    .field("ahb_err_mask", &self.ahb_err_mask())
+                    .field("pka_mask", &self.pka_mask())
+                    .field("rng_mask", &self.rng_mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Imr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Imr {
+                    sram_to_din_mask: super::vals::SramToDinMask,
+                    dout_to_sram_mask: super::vals::DoutToSramMask,
+                    mem_to_din_mask: super::vals::MemToDinMask,
+                    dout_to_mem_mask: super::vals::DoutToMemMask,
+                    ahb_err_mask: super::vals::AhbErrMask,
+                    pka_mask: super::vals::PkaMask,
+                    rng_mask: super::vals::RngMask,
+                }
+                let proxy = Imr {
+                    sram_to_din_mask: self.sram_to_din_mask(),
+                    dout_to_sram_mask: self.dout_to_sram_mask(),
+                    mem_to_din_mask: self.mem_to_din_mask(),
+                    dout_to_mem_mask: self.dout_to_mem_mask(),
+                    ahb_err_mask: self.ahb_err_mask(),
+                    pka_mask: self.pka_mask(),
+                    rng_mask: self.rng_mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt request register. Each bit of this register holds the interrupt status of a single interrupt source. If corresponding IMR bit is unmasked, an interrupt is generated."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4676,10 +6162,49 @@ pub mod cc_host_rgf {
                 Irr(0)
             }
         }
+        impl core::fmt::Debug for Irr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Irr")
+                    .field("sram_to_din_int", &self.sram_to_din_int())
+                    .field("dout_to_sram_int", &self.dout_to_sram_int())
+                    .field("mem_to_din_int", &self.mem_to_din_int())
+                    .field("dout_to_mem_int", &self.dout_to_mem_int())
+                    .field("ahb_err_int", &self.ahb_err_int())
+                    .field("pka_int", &self.pka_int())
+                    .field("rng_int", &self.rng_int())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Irr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Irr {
+                    sram_to_din_int: bool,
+                    dout_to_sram_int: bool,
+                    mem_to_din_int: bool,
+                    dout_to_mem_int: bool,
+                    ahb_err_int: bool,
+                    pka_int: bool,
+                    rng_int: bool,
+                }
+                let proxy = Irr {
+                    sram_to_din_int: self.sram_to_din_int(),
+                    dout_to_sram_int: self.dout_to_sram_int(),
+                    mem_to_din_int: self.mem_to_din_int(),
+                    dout_to_mem_int: self.dout_to_mem_int(),
+                    ahb_err_int: self.ahb_err_int(),
+                    pka_int: self.pka_int(),
+                    rng_int: self.rng_int(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum AhbErrMask {
             #[doc = "Do not mask AHB error interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -4709,7 +6234,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DinRdBg {
             #[doc = "Configure DIN read as little-endian"]
             LITTLE_ENDIAN = 0x0,
@@ -4739,7 +6265,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DinRdWbg {
             #[doc = "Configure DIN read word as little-endian"]
             LITTLE_ENDIAN = 0x0,
@@ -4769,7 +6296,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutToMemMask {
             #[doc = "Do not mask DOUT to memory DMA done interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -4799,7 +6327,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutToSramMask {
             #[doc = "Do not mask DOUT to RNG SRAM DMA done interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -4829,7 +6358,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutWrBg {
             #[doc = "Configure DOUT write as little-endian"]
             LITTLE_ENDIAN = 0x0,
@@ -4859,7 +6389,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DoutWrWbg {
             #[doc = "Configure DOUT write word as little-endian"]
             LITTLE_ENDIAN = 0x0,
@@ -4889,7 +6420,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HostCryptokeySel {
             #[doc = "Use device root key K_DR from CRYPTOCELL AO power domain"]
             K_DR = 0x0,
@@ -4938,6 +6470,25 @@ pub mod cc_host_rgf {
                 self.0
             }
         }
+        impl core::fmt::Debug for HostIotKdr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("NOT_RETAINED"),
+                    0x01 => f.write_str("RETAINED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotKdr0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "NOT_RETAINED"),
+                    0x01 => defmt::write!(f, "RETAINED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for HostIotKdr0 {
             #[inline(always)]
             fn from(val: u32) -> HostIotKdr0 {
@@ -4951,7 +6502,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lcs {
             #[doc = "CC310 operates in debug mode"]
             DEBUG_ENABLE = 0x0,
@@ -4987,7 +6539,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum MemToDinMask {
             #[doc = "Do not mask memory to DIN DMA done interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -5017,7 +6570,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PkaMask {
             #[doc = "Do not mask PKA end of operation interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -5047,7 +6601,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RngMask {
             #[doc = "Do not mask RNG interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -5077,7 +6632,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SramToDinMask {
             #[doc = "Do not mask RNG SRAM to DIN DMA done interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -5180,6 +6736,26 @@ pub mod cc_misc {
                 AesClk(0)
             }
         }
+        impl core::fmt::Debug for AesClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AesClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AesClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AesClk {
+                    enable: bool,
+                }
+                let proxy = AesClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock control for the CHACHA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5201,6 +6777,26 @@ pub mod cc_misc {
             #[inline(always)]
             fn default() -> ChachaClk {
                 ChachaClk(0)
+            }
+        }
+        impl core::fmt::Debug for ChachaClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ChachaClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ChachaClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ChachaClk {
+                    enable: bool,
+                }
+                let proxy = ChachaClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRYPTOCELL clocks status register."]
@@ -5270,6 +6866,38 @@ pub mod cc_misc {
                 ClkStatus(0)
             }
         }
+        impl core::fmt::Debug for ClkStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ClkStatus")
+                    .field("aes_clk", &self.aes_clk())
+                    .field("hash_clk", &self.hash_clk())
+                    .field("pka_clk", &self.pka_clk())
+                    .field("chacha_clk", &self.chacha_clk())
+                    .field("dma_clk", &self.dma_clk())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ClkStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ClkStatus {
+                    aes_clk: bool,
+                    hash_clk: bool,
+                    pka_clk: bool,
+                    chacha_clk: bool,
+                    dma_clk: bool,
+                }
+                let proxy = ClkStatus {
+                    aes_clk: self.aes_clk(),
+                    hash_clk: self.hash_clk(),
+                    pka_clk: self.pka_clk(),
+                    chacha_clk: self.chacha_clk(),
+                    dma_clk: self.dma_clk(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock control for the DMA engines."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5291,6 +6919,26 @@ pub mod cc_misc {
             #[inline(always)]
             fn default() -> DmaClk {
                 DmaClk(0)
+            }
+        }
+        impl core::fmt::Debug for DmaClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DmaClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DmaClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DmaClk {
+                    enable: bool,
+                }
+                let proxy = DmaClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock control for the HASH engine."]
@@ -5316,6 +6964,26 @@ pub mod cc_misc {
                 HashClk(0)
             }
         }
+        impl core::fmt::Debug for HashClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HashClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HashClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HashClk {
+                    enable: bool,
+                }
+                let proxy = HashClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock control for the PKA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5337,6 +7005,26 @@ pub mod cc_misc {
             #[inline(always)]
             fn default() -> PkaClk {
                 PkaClk(0)
+            }
+        }
+        impl core::fmt::Debug for PkaClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaClk {
+                    enable: bool,
+                }
+                let proxy = PkaClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -5460,6 +7148,24 @@ pub mod cc_pka {
                 MemoryMap(0)
             }
         }
+        impl core::fmt::Debug for MemoryMap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MemoryMap")
+                    .field("addr", &self.addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MemoryMap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MemoryMap {
+                    addr: u16,
+                }
+                let proxy = MemoryMap { addr: self.addr() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register defines the N, Np, T0, and T1 virtual register index."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5514,6 +7220,35 @@ pub mod cc_pka {
             #[inline(always)]
             fn default() -> NNpT0T1Addr {
                 NNpT0T1Addr(0)
+            }
+        }
+        impl core::fmt::Debug for NNpT0T1Addr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NNpT0T1Addr")
+                    .field("n_virtual_addr", &self.n_virtual_addr())
+                    .field("np_virtual_addr", &self.np_virtual_addr())
+                    .field("t0_virtual_addr", &self.t0_virtual_addr())
+                    .field("t1_virtual_addr", &self.t1_virtual_addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NNpT0T1Addr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NNpT0T1Addr {
+                    n_virtual_addr: u8,
+                    np_virtual_addr: u8,
+                    t0_virtual_addr: u8,
+                    t1_virtual_addr: u8,
+                }
+                let proxy = NNpT0T1Addr {
+                    n_virtual_addr: self.n_virtual_addr(),
+                    np_virtual_addr: self.np_virtual_addr(),
+                    t0_virtual_addr: self.t0_virtual_addr(),
+                    t1_virtual_addr: self.t1_virtual_addr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation code to be executed by the PKA engine. Writing to this register triggers the PKA operation."]
@@ -5631,6 +7366,50 @@ pub mod cc_pka {
                 Opcode(0)
             }
         }
+        impl core::fmt::Debug for Opcode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Opcode")
+                    .field("tag", &self.tag())
+                    .field("reg_r", &self.reg_r())
+                    .field("discard_r", &self.discard_r())
+                    .field("reg_b", &self.reg_b())
+                    .field("const_b", &self.const_b())
+                    .field("reg_a", &self.reg_a())
+                    .field("const_a", &self.const_a())
+                    .field("len", &self.len())
+                    .field("opcode", &self.opcode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Opcode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Opcode {
+                    tag: u8,
+                    reg_r: u8,
+                    discard_r: super::vals::DiscardR,
+                    reg_b: u8,
+                    const_b: super::vals::ConstB,
+                    reg_a: u8,
+                    const_a: super::vals::ConstA,
+                    len: u8,
+                    opcode: super::vals::Opcode,
+                }
+                let proxy = Opcode {
+                    tag: self.tag(),
+                    reg_r: self.reg_r(),
+                    discard_r: self.discard_r(),
+                    reg_b: self.reg_b(),
+                    const_b: self.const_b(),
+                    reg_a: self.reg_a(),
+                    const_a: self.const_a(),
+                    len: self.len(),
+                    opcode: self.opcode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating if the PKA operation has been completed."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5652,6 +7431,26 @@ pub mod cc_pka {
             #[inline(always)]
             fn default() -> PkaDone {
                 PkaDone(0)
+            }
+        }
+        impl core::fmt::Debug for PkaDone {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaDone")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaDone {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaDone {
+                    status: super::vals::PkaDoneStatus,
+                }
+                let proxy = PkaDone {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: This register holds the operands bit size."]
@@ -5677,6 +7476,26 @@ pub mod cc_pka {
                 PkaL(0)
             }
         }
+        impl core::fmt::Debug for PkaL {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaL")
+                    .field("op_size", &self.op_size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaL {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaL {
+                    op_size: u16,
+                }
+                let proxy = PkaL {
+                    op_size: self.op_size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating if the PKA pipeline is ready to receive a new OPCODE."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5698,6 +7517,26 @@ pub mod cc_pka {
             #[inline(always)]
             fn default() -> PkaPipe {
                 PkaPipe(0)
+            }
+        }
+        impl core::fmt::Debug for PkaPipe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaPipe")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaPipe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaPipe {
+                    status: bool,
+                }
+                let proxy = PkaPipe {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This register holds the status for the PKA pipeline."]
@@ -5833,6 +7672,56 @@ pub mod cc_pka {
                 PkaStatus(0)
             }
         }
+        impl core::fmt::Debug for PkaStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaStatus")
+                    .field("alu_msb_4bits", &self.alu_msb_4bits())
+                    .field("alu_lsb_4bits", &self.alu_lsb_4bits())
+                    .field("alu_sign_out", &self.alu_sign_out())
+                    .field("alu_carry", &self.alu_carry())
+                    .field("alu_carry_mod", &self.alu_carry_mod())
+                    .field("alu_sub_is_zero", &self.alu_sub_is_zero())
+                    .field("alu_out_zero", &self.alu_out_zero())
+                    .field("alu_modovrflw", &self.alu_modovrflw())
+                    .field("div_by_zero", &self.div_by_zero())
+                    .field("modinv_of_zero", &self.modinv_of_zero())
+                    .field("opcode", &self.opcode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaStatus {
+                    alu_msb_4bits: u8,
+                    alu_lsb_4bits: u8,
+                    alu_sign_out: bool,
+                    alu_carry: bool,
+                    alu_carry_mod: bool,
+                    alu_sub_is_zero: bool,
+                    alu_out_zero: bool,
+                    alu_modovrflw: bool,
+                    div_by_zero: bool,
+                    modinv_of_zero: bool,
+                    opcode: u8,
+                }
+                let proxy = PkaStatus {
+                    alu_msb_4bits: self.alu_msb_4bits(),
+                    alu_lsb_4bits: self.alu_lsb_4bits(),
+                    alu_sign_out: self.alu_sign_out(),
+                    alu_carry: self.alu_carry(),
+                    alu_carry_mod: self.alu_carry_mod(),
+                    alu_sub_is_zero: self.alu_sub_is_zero(),
+                    alu_out_zero: self.alu_out_zero(),
+                    alu_modovrflw: self.alu_modovrflw(),
+                    div_by_zero: self.div_by_zero(),
+                    modinv_of_zero: self.modinv_of_zero(),
+                    opcode: self.opcode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the PKA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5856,10 +7745,31 @@ pub mod cc_pka {
                 PkaSwReset(0)
             }
         }
+        impl core::fmt::Debug for PkaSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkaSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkaSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkaSwReset {
+                    reset: bool,
+                }
+                let proxy = PkaSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConstA {
             #[doc = "REG_A is intepreted as a register index."]
             REGISTER = 0x0,
@@ -5889,7 +7799,8 @@ pub mod cc_pka {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConstB {
             #[doc = "REG_B is intepreted as a register index."]
             REGISTER = 0x0,
@@ -5919,7 +7830,8 @@ pub mod cc_pka {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DiscardR {
             #[doc = "REG_R is intepreted as a register index."]
             REGISTER = 0x0,
@@ -5949,7 +7861,8 @@ pub mod cc_pka {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Opcode {
             #[doc = "Terminate operation"]
             TERMINATE = 0x0,
@@ -6030,7 +7943,8 @@ pub mod cc_pka {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PkaDoneStatus {
             #[doc = "PKA operation is processing"]
             PROCESSING = 0x0,
@@ -6230,6 +8144,29 @@ pub mod cc_rng {
                 AutocorrStatistic(0)
             }
         }
+        impl core::fmt::Debug for AutocorrStatistic {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AutocorrStatistic")
+                    .field("autocorr_trys", &self.autocorr_trys())
+                    .field("autocorr_fails", &self.autocorr_fails())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AutocorrStatistic {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AutocorrStatistic {
+                    autocorr_trys: u16,
+                    autocorr_fails: u8,
+                }
+                let proxy = AutocorrStatistic {
+                    autocorr_trys: self.autocorr_trys(),
+                    autocorr_fails: self.autocorr_fails(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register controls the ring oscillator circuit used as a noise source."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6251,6 +8188,26 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> NoiseSource {
                 NoiseSource(0)
+            }
+        }
+        impl core::fmt::Debug for NoiseSource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NoiseSource")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NoiseSource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NoiseSource {
+                    enable: bool,
+                }
+                let proxy = NoiseSource {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register for RNG engine activity."]
@@ -6287,6 +8244,29 @@ pub mod cc_rng {
                 RngBusy(0)
             }
         }
+        impl core::fmt::Debug for RngBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngBusy")
+                    .field("status", &self.status())
+                    .field("trng_status", &self.trng_status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngBusy {
+                    status: super::vals::RngBusyStatus,
+                    trng_status: super::vals::TrngStatus,
+                }
+                let proxy = RngBusy {
+                    status: self.status(),
+                    trng_status: self.trng_status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control clock for the RNG engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6310,6 +8290,26 @@ pub mod cc_rng {
                 RngClk(0)
             }
         }
+        impl core::fmt::Debug for RngClk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngClk")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngClk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngClk {
+                    enable: bool,
+                }
+                let proxy = RngClk {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Writing to this register enables the RNG DMA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6329,6 +8329,26 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> RngDma {
                 RngDma(0)
+            }
+        }
+        impl core::fmt::Debug for RngDma {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngDma")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngDma {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngDma {
+                    enable: bool,
+                }
+                let proxy = RngDma {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register for RNG DMA engine activity."]
@@ -6374,6 +8394,32 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> RngDmaBusy {
                 RngDmaBusy(0)
+            }
+        }
+        impl core::fmt::Debug for RngDmaBusy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngDmaBusy")
+                    .field("status", &self.status())
+                    .field("rosc_len", &self.rosc_len())
+                    .field("num_of_samples", &self.num_of_samples())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngDmaBusy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngDmaBusy {
+                    status: super::vals::RngDmaBusyStatus,
+                    rosc_len: super::vals::RngDmaBusyRoscLen,
+                    num_of_samples: u8,
+                }
+                let proxy = RngDmaBusy {
+                    status: self.status(),
+                    rosc_len: self.rosc_len(),
+                    num_of_samples: self.num_of_samples(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This register defines which ring oscillator length configuration should be used when using the RNG DMA engine."]
@@ -6432,6 +8478,35 @@ pub mod cc_rng {
                 RngDmaRoscLen(0)
             }
         }
+        impl core::fmt::Debug for RngDmaRoscLen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngDmaRoscLen")
+                    .field("rosc1", &self.rosc1())
+                    .field("rosc2", &self.rosc2())
+                    .field("rosc3", &self.rosc3())
+                    .field("rosc4", &self.rosc4())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngDmaRoscLen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngDmaRoscLen {
+                    rosc1: bool,
+                    rosc2: bool,
+                    rosc3: bool,
+                    rosc4: bool,
+                }
+                let proxy = RngDmaRoscLen {
+                    rosc1: self.rosc1(),
+                    rosc2: self.rosc2(),
+                    rosc3: self.rosc3(),
+                    rosc4: self.rosc4(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register defines the number of 192-bits samples that the RNG DMA engine collects per run."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6455,6 +8530,26 @@ pub mod cc_rng {
                 RngDmaSamplesNum(0)
             }
         }
+        impl core::fmt::Debug for RngDmaSamplesNum {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngDmaSamplesNum")
+                    .field("rng_samples_num", &self.rng_samples_num())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngDmaSamplesNum {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngDmaSamplesNum {
+                    rng_samples_num: u8,
+                }
+                let proxy = RngDmaSamplesNum {
+                    rng_samples_num: self.rng_samples_num(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register defines the start address in TRNG SRAM for the TRNG data to be collected by the RNG DMA engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6476,6 +8571,26 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> RngDmaSramAddr {
                 RngDmaSramAddr(0)
+            }
+        }
+        impl core::fmt::Debug for RngDmaSramAddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngDmaSramAddr")
+                    .field("rng_sram_dma_addr", &self.rng_sram_dma_addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngDmaSramAddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngDmaSramAddr {
+                    rng_sram_dma_addr: u16,
+                }
+                let proxy = RngDmaSramAddr {
+                    rng_sram_dma_addr: self.rng_sram_dma_addr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration of RNG engine. Reset value holds the supported features."]
@@ -6576,6 +8691,47 @@ pub mod cc_rng {
                 RngHwFlags(0)
             }
         }
+        impl core::fmt::Debug for RngHwFlags {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngHwFlags")
+                    .field("ehr_width", &self.ehr_width())
+                    .field("crngt_exists", &self.crngt_exists())
+                    .field("autocorr_exists", &self.autocorr_exists())
+                    .field("bypass_exists", &self.bypass_exists())
+                    .field("prng_exists", &self.prng_exists())
+                    .field("kat_exists", &self.kat_exists())
+                    .field("reseeding_exists", &self.reseeding_exists())
+                    .field("rng_use_5_sboxes", &self.rng_use_5_sboxes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngHwFlags {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngHwFlags {
+                    ehr_width: super::vals::EhrWidth,
+                    crngt_exists: bool,
+                    autocorr_exists: bool,
+                    bypass_exists: bool,
+                    prng_exists: bool,
+                    kat_exists: bool,
+                    reseeding_exists: bool,
+                    rng_use_5_sboxes: bool,
+                }
+                let proxy = RngHwFlags {
+                    ehr_width: self.ehr_width(),
+                    crngt_exists: self.crngt_exists(),
+                    autocorr_exists: self.autocorr_exists(),
+                    bypass_exists: self.bypass_exists(),
+                    prng_exists: self.prng_exists(),
+                    kat_exists: self.kat_exists(),
+                    reseeding_exists: self.reseeding_exists(),
+                    rng_use_5_sboxes: self.rng_use_5_sboxes(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt clear register. Writing a 1 bit into a field in this register will clear the corresponding bit in RNG_ISR."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6652,6 +8808,41 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> RngIcr {
                 RngIcr(0)
+            }
+        }
+        impl core::fmt::Debug for RngIcr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngIcr")
+                    .field("ehr_valid_clear", &self.ehr_valid_clear())
+                    .field("autocorr_err_clear", &self.autocorr_err_clear())
+                    .field("crngt_err_clear", &self.crngt_err_clear())
+                    .field("vnc_err_clear", &self.vnc_err_clear())
+                    .field("watchdog_clear", &self.watchdog_clear())
+                    .field("dma_done_clear", &self.dma_done_clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngIcr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngIcr {
+                    ehr_valid_clear: bool,
+                    autocorr_err_clear: bool,
+                    crngt_err_clear: bool,
+                    vnc_err_clear: bool,
+                    watchdog_clear: bool,
+                    dma_done_clear: bool,
+                }
+                let proxy = RngIcr {
+                    ehr_valid_clear: self.ehr_valid_clear(),
+                    autocorr_err_clear: self.autocorr_err_clear(),
+                    crngt_err_clear: self.crngt_err_clear(),
+                    vnc_err_clear: self.vnc_err_clear(),
+                    watchdog_clear: self.watchdog_clear(),
+                    dma_done_clear: self.dma_done_clear(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interrupt mask register. Each bit of this register holds the mask of a single interrupt source."]
@@ -6732,6 +8923,41 @@ pub mod cc_rng {
                 RngImr(0)
             }
         }
+        impl core::fmt::Debug for RngImr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngImr")
+                    .field("ehr_valid_mask", &self.ehr_valid_mask())
+                    .field("autocorr_err_mask", &self.autocorr_err_mask())
+                    .field("crngt_err_mask", &self.crngt_err_mask())
+                    .field("vnc_err_mask", &self.vnc_err_mask())
+                    .field("watchdog_mask", &self.watchdog_mask())
+                    .field("dma_done_mask", &self.dma_done_mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngImr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngImr {
+                    ehr_valid_mask: super::vals::EhrValidMask,
+                    autocorr_err_mask: super::vals::AutocorrErrMask,
+                    crngt_err_mask: super::vals::CrngtErrMask,
+                    vnc_err_mask: super::vals::VncErrMask,
+                    watchdog_mask: super::vals::WatchdogMask,
+                    dma_done_mask: super::vals::DmaDoneMask,
+                }
+                let proxy = RngImr {
+                    ehr_valid_mask: self.ehr_valid_mask(),
+                    autocorr_err_mask: self.autocorr_err_mask(),
+                    crngt_err_mask: self.crngt_err_mask(),
+                    vnc_err_mask: self.vnc_err_mask(),
+                    watchdog_mask: self.watchdog_mask(),
+                    dma_done_mask: self.dma_done_mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt status register. Each bit of this register holds the interrupt status of a single interrupt source. If corresponding RNG_IMR bit is unmasked, an interrupt is generated."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6810,6 +9036,41 @@ pub mod cc_rng {
                 RngIsr(0)
             }
         }
+        impl core::fmt::Debug for RngIsr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngIsr")
+                    .field("ehr_valid_int", &self.ehr_valid_int())
+                    .field("autocorr_err_int", &self.autocorr_err_int())
+                    .field("crngt_err_int", &self.crngt_err_int())
+                    .field("vnc_err_int", &self.vnc_err_int())
+                    .field("watchdog_int", &self.watchdog_int())
+                    .field("dma_done_int", &self.dma_done_int())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngIsr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngIsr {
+                    ehr_valid_int: bool,
+                    autocorr_err_int: bool,
+                    crngt_err_int: bool,
+                    vnc_err_int: bool,
+                    watchdog_int: bool,
+                    dma_done_int: bool,
+                }
+                let proxy = RngIsr {
+                    ehr_valid_int: self.ehr_valid_int(),
+                    autocorr_err_int: self.autocorr_err_int(),
+                    crngt_err_int: self.crngt_err_int(),
+                    vnc_err_int: self.vnc_err_int(),
+                    watchdog_int: self.watchdog_int(),
+                    dma_done_int: self.dma_done_int(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the RNG engine."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6833,6 +9094,26 @@ pub mod cc_rng {
                 RngSwReset(0)
             }
         }
+        impl core::fmt::Debug for RngSwReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngSwReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngSwReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngSwReset {
+                    reset: bool,
+                }
+                let proxy = RngSwReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TRNG ring oscillator length configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6854,6 +9135,26 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> TrngConfig {
                 TrngConfig(0)
+            }
+        }
+        impl core::fmt::Debug for TrngConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TrngConfig")
+                    .field("rosc_len", &self.rosc_len())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TrngConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TrngConfig {
+                    rosc_len: super::vals::TrngConfigRoscLen,
+                }
+                let proxy = TrngConfig {
+                    rosc_len: self.rosc_len(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Debug register for the TRNG. This register is used to bypass TRNG tests in hardware."]
@@ -6901,6 +9202,32 @@ pub mod cc_rng {
                 TrngDebug(0)
             }
         }
+        impl core::fmt::Debug for TrngDebug {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TrngDebug")
+                    .field("vnc_bypass", &self.vnc_bypass())
+                    .field("crngt_bypass", &self.crngt_bypass())
+                    .field("autocorr_bypass", &self.autocorr_bypass())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TrngDebug {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TrngDebug {
+                    vnc_bypass: bool,
+                    crngt_bypass: bool,
+                    autocorr_bypass: bool,
+                }
+                let proxy = TrngDebug {
+                    vnc_bypass: self.vnc_bypass(),
+                    crngt_bypass: self.crngt_bypass(),
+                    autocorr_bypass: self.autocorr_bypass(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reset the TRNG, including internal counter of collected bits and registers EHR_DATA and TRNG_VALID."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6922,6 +9249,26 @@ pub mod cc_rng {
             #[inline(always)]
             fn default() -> TrngReset {
                 TrngReset(0)
+            }
+        }
+        impl core::fmt::Debug for TrngReset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TrngReset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TrngReset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TrngReset {
+                    reset: bool,
+                }
+                let proxy = TrngReset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This register indicates if TRNG entropy collection is valid."]
@@ -6947,10 +9294,31 @@ pub mod cc_rng {
                 TrngValid(0)
             }
         }
+        impl core::fmt::Debug for TrngValid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TrngValid")
+                    .field("ehr_data", &self.ehr_data())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TrngValid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TrngValid {
+                    ehr_data: bool,
+                }
+                let proxy = TrngValid {
+                    ehr_data: self.ehr_data(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum AutocorrErrMask {
             #[doc = "Do not mask autocorrelation interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -6980,7 +9348,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CrngtErrMask {
             #[doc = "Do not mask the CRNGT error interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -7010,7 +9379,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DmaDoneMask {
             #[doc = "Do not mask the RNG DMA completion interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -7040,7 +9410,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EhrValidMask {
             #[doc = "Do not mask EHR interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -7070,7 +9441,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EhrWidth {
             #[doc = "128 bits EHR width"]
             _128BITS = 0x0,
@@ -7100,7 +9472,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RngBusyStatus {
             #[doc = "RNG engine is idle"]
             IDLE = 0x0,
@@ -7130,7 +9503,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RngDmaBusyRoscLen {
             #[doc = "Shortest ROSC1 ring oscillator configuration used."]
             ROSC1 = 0x0,
@@ -7164,7 +9538,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RngDmaBusyStatus {
             #[doc = "RNG DMA engine is idle"]
             IDLE = 0x0,
@@ -7194,7 +9569,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TrngConfigRoscLen {
             #[doc = "Use shortest ROSC1 ring oscillator configuration."]
             ROSC1 = 0x0,
@@ -7228,7 +9604,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TrngStatus {
             #[doc = "TRNG is idle"]
             IDLE = 0x0,
@@ -7258,7 +9635,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum VncErrMask {
             #[doc = "Do not mask the von Neumann corrector error interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -7288,7 +9666,8 @@ pub mod cc_rng {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum WatchdogMask {
             #[doc = "Do not mask the watchdog interrupt i.e. interrupt is generated"]
             IRQENABLE = 0x0,
@@ -7378,6 +9757,26 @@ pub mod cc_rng_sram {
                 SramAddr(0)
             }
         }
+        impl core::fmt::Debug for SramAddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SramAddr")
+                    .field("sram_addr", &self.sram_addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SramAddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SramAddr {
+                    sram_addr: u16,
+                }
+                let proxy = SramAddr {
+                    sram_addr: self.sram_addr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RNG SRAM DMA engine is ready to read/write from/to RNG SRAM."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7401,10 +9800,31 @@ pub mod cc_rng_sram {
                 SramDataReady(0)
             }
         }
+        impl core::fmt::Debug for SramDataReady {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SramDataReady")
+                    .field("sram_ready", &self.sram_ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SramDataReady {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SramDataReady {
+                    sram_ready: super::vals::SramReady,
+                }
+                let proxy = SramDataReady {
+                    sram_ready: self.sram_ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SramReady {
             #[doc = "DMA is busy"]
             BUSY = 0x0,
@@ -7576,6 +9996,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7621,6 +10061,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7644,6 +10110,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7665,6 +10151,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -7714,6 +10220,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7735,6 +10267,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -7760,10 +10312,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -7797,7 +10370,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -7829,7 +10403,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -7859,7 +10434,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -7889,7 +10465,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -7919,7 +10496,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -8125,6 +10703,22 @@ pub mod clock {
                 Ctiv(0)
             }
         }
+        impl core::fmt::Debug for Ctiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiv").field("ctiv", &self.ctiv()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiv {
+                    ctiv: u8,
+                }
+                let proxy = Ctiv { ctiv: self.ctiv() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8146,6 +10740,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkrun {
                 Hfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK status"]
@@ -8182,6 +10796,29 @@ pub mod clock {
                 Hfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO debounce time. The HFXO is started by triggering the TASKS_HFCLKSTART task."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8203,6 +10840,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfxodebounce {
                 Hfxodebounce(0)
+            }
+        }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxodebounce")
+                    .field("hfxodebounce", &self.hfxodebounce())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxodebounce {
+                    hfxodebounce: super::vals::Hfxodebounce,
+                }
+                let proxy = Hfxodebounce {
+                    hfxodebounce: self.hfxodebounce(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -8283,6 +10940,41 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("ctto", &self.ctto())
+                    .field("ctstarted", &self.ctstarted())
+                    .field("ctstopped", &self.ctstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    ctto: bool,
+                    ctstarted: bool,
+                    ctstopped: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    ctto: self.ctto(),
+                    ctstarted: self.ctstarted(),
+                    ctstopped: self.ctstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8304,6 +10996,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK"]
@@ -8351,6 +11063,32 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .field("bypass", &self.bypass())
+                    .field("external", &self.external())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                    bypass: bool,
+                    external: bool,
+                }
+                let proxy = Lfclksrc {
+                    src: self.src(),
+                    bypass: self.bypass(),
+                    external: self.external(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8372,6 +11110,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFCLK status"]
@@ -8406,6 +11162,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkstat {
                 Lfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "LFRC mode configuration"]
@@ -8443,6 +11222,29 @@ pub mod clock {
                 Lfrcmode(0)
             }
         }
+        impl core::fmt::Debug for Lfrcmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfrcmode")
+                    .field("mode", &self.mode())
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfrcmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfrcmode {
+                    mode: super::vals::Mode,
+                    status: super::vals::LfrcmodeStatus,
+                }
+                let proxy = Lfrcmode {
+                    mode: self.mode(),
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clocking options for the trace port debug interface"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8478,10 +11280,34 @@ pub mod clock {
                 Traceconfig(0)
             }
         }
+        impl core::fmt::Debug for Traceconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceconfig")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .field("tracemux", &self.tracemux())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceconfig {
+                    traceportspeed: super::vals::Traceportspeed,
+                    tracemux: super::vals::Tracemux,
+                }
+                let proxy = Traceconfig {
+                    traceportspeed: self.traceportspeed(),
+                    tracemux: self.tracemux(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "64 MHz internal oscillator (HFINT)"]
             RC = 0x0,
@@ -8527,6 +11353,25 @@ pub mod clock {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxodebounce {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("DB256US"),
+                    0x40 => f.write_str("DB1024US"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxodebounce {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "DB256US"),
+                    0x40 => defmt::write!(f, "DB1024US"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxodebounce {
             #[inline(always)]
             fn from(val: u8) -> Hfxodebounce {
@@ -8540,7 +11385,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator (LFRC)"]
             RC = 0x0,
@@ -8573,7 +11419,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LfrcmodeStatus {
             #[doc = "Normal mode"]
             NORMAL = 0x0,
@@ -8603,7 +11450,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Normal mode"]
             NORMAL = 0x0,
@@ -8633,7 +11481,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tracemux {
             #[doc = "No trace signals routed to pins. All pins can be used as regular GPIOs."]
             GPIO = 0x0,
@@ -8666,7 +11515,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "32 MHz trace port clock (TRACECLK = 16 MHz)"]
             _32MHZ = 0x0,
@@ -8915,6 +11765,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8938,6 +11808,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8959,6 +11849,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -9017,6 +11923,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9051,6 +11986,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9072,6 +12030,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -9097,6 +12071,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9118,6 +12112,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -9187,6 +12201,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9221,10 +12267,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -9256,7 +12326,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -9298,7 +12369,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -9328,7 +12400,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -9358,7 +12431,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -9400,7 +12474,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -9439,7 +12514,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -9469,7 +12545,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -9548,6 +12625,26 @@ pub mod cryptocell {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -9640,6 +12737,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -9716,6 +12836,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10070,6 +13247,22 @@ pub mod ficr {
                 A0(0)
             }
         }
+        impl core::fmt::Debug for A0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A0").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A0 {
+                    a: u16,
+                }
+                let proxy = A0 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10091,6 +13284,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A1 {
                 A1(0)
+            }
+        }
+        impl core::fmt::Debug for A1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A1").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A1 {
+                    a: u16,
+                }
+                let proxy = A1 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A2"]
@@ -10116,6 +13325,22 @@ pub mod ficr {
                 A2(0)
             }
         }
+        impl core::fmt::Debug for A2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A2").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A2 {
+                    a: u16,
+                }
+                let proxy = A2 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10137,6 +13362,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A3 {
                 A3(0)
+            }
+        }
+        impl core::fmt::Debug for A3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A3").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A3 {
+                    a: u16,
+                }
+                let proxy = A3 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Slope definition A4"]
@@ -10162,6 +13403,22 @@ pub mod ficr {
                 A4(0)
             }
         }
+        impl core::fmt::Debug for A4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A4").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A4 {
+                    a: u16,
+                }
+                let proxy = A4 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Slope definition A5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10183,6 +13440,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> A5 {
                 A5(0)
+            }
+        }
+        impl core::fmt::Debug for A5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("A5").field("a", &self.a()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for A5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct A5 {
+                    a: u16,
+                }
+                let proxy = A5 { a: self.a() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B0"]
@@ -10208,6 +13481,22 @@ pub mod ficr {
                 B0(0)
             }
         }
+        impl core::fmt::Debug for B0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B0").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B0 {
+                    b: u16,
+                }
+                let proxy = B0 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10229,6 +13518,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B1 {
                 B1(0)
+            }
+        }
+        impl core::fmt::Debug for B1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B1").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B1 {
+                    b: u16,
+                }
+                let proxy = B1 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B2"]
@@ -10254,6 +13559,22 @@ pub mod ficr {
                 B2(0)
             }
         }
+        impl core::fmt::Debug for B2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B2").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B2 {
+                    b: u16,
+                }
+                let proxy = B2 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B3"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10275,6 +13596,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> B3 {
                 B3(0)
+            }
+        }
+        impl core::fmt::Debug for B3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B3").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B3 {
+                    b: u16,
+                }
+                let proxy = B3 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Y-intercept B4"]
@@ -10300,6 +13637,22 @@ pub mod ficr {
                 B4(0)
             }
         }
+        impl core::fmt::Debug for B4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B4").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B4 {
+                    b: u16,
+                }
+                let proxy = B4 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Y-intercept B5"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10323,6 +13676,22 @@ pub mod ficr {
                 B5(0)
             }
         }
+        impl core::fmt::Debug for B5 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("B5").field("b", &self.b()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for B5 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct B5 {
+                    b: u16,
+                }
+                let proxy = B5 { b: self.b() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10344,6 +13713,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Flash variant"]
@@ -10370,6 +13759,26 @@ pub mod ficr {
                 Flash(0)
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10392,6 +13801,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -10418,6 +13847,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Production test signature n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10440,6 +13885,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Prodtest {
                 Prodtest(0)
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prodtest")
+                    .field("prodtest", &self.prodtest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prodtest {
+                    prodtest: super::vals::Prodtest,
+                }
+                let proxy = Prodtest {
+                    prodtest: self.prodtest(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -10466,6 +13931,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T0"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10487,6 +13968,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T0 {
                 T0(0)
+            }
+        }
+        impl core::fmt::Debug for T0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T0").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T0 {
+                    t: u8,
+                }
+                let proxy = T0 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T1"]
@@ -10512,6 +14009,22 @@ pub mod ficr {
                 T1(0)
             }
         }
+        impl core::fmt::Debug for T1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T1").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T1 {
+                    t: u8,
+                }
+                let proxy = T1 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T2"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10533,6 +14046,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T2 {
                 T2(0)
+            }
+        }
+        impl core::fmt::Debug for T2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T2").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T2 {
+                    t: u8,
+                }
+                let proxy = T2 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Segment end T3"]
@@ -10558,6 +14087,22 @@ pub mod ficr {
                 T3(0)
             }
         }
+        impl core::fmt::Debug for T3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T3").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T3 {
+                    t: u8,
+                }
+                let proxy = T3 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Segment end T4"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10579,6 +14124,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> T4 {
                 T4(0)
+            }
+        }
+        impl core::fmt::Debug for T4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("T4").field("t", &self.t()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for T4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct T4 {
+                    t: u8,
+                }
+                let proxy = T4 { t: self.t() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
@@ -10637,6 +14198,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10691,6 +14281,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
@@ -10749,6 +14368,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST, and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10805,10 +14453,40 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -10862,6 +14540,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0x0400 => f.write_str("K1024"),
+                    0x0800 => f.write_str("K2048"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0x0400 => defmt::write!(f, "K1024"),
+                    0x0800 => defmt::write!(f, "K2048"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -10895,6 +14600,29 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QF"),
+                    0x2004 => f.write_str("QI"),
+                    0x2005 => f.write_str("CK"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QF"),
+                    0x2004 => defmt::write!(f, "QI"),
+                    0x2005 => defmt::write!(f, "CK"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -10924,6 +14652,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_2840 => f.write_str("N52840"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_2840 => defmt::write!(f, "N52840"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -10951,6 +14698,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Prodtest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xbb42_319f => f.write_str("DONE"),
+                    0xffff_ffff => f.write_str("NOT_DONE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prodtest {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xbb42_319f => defmt::write!(f, "DONE"),
+                    0xffff_ffff => defmt::write!(f, "NOT_DONE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Prodtest {
@@ -10988,6 +14754,33 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -11124,6 +14917,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11149,6 +14962,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -11178,6 +15080,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11203,6 +15194,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -11232,6 +15312,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11257,6 +15426,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -11286,6 +15544,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11313,6 +15660,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11338,6 +15774,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -11408,10 +15933,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -11441,7 +15999,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -11471,7 +16030,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -11513,7 +16073,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -11543,7 +16104,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -11576,7 +16138,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -11743,6 +16306,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: bool,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11781,10 +16376,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -11817,7 +16457,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -11847,7 +16488,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -12175,6 +16817,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12196,6 +16858,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module."]
@@ -12221,6 +16903,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12242,6 +16944,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -12289,6 +17011,32 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12312,6 +17060,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12333,6 +17101,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Master clock generator frequency."]
@@ -12359,6 +17147,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12380,6 +17188,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio."]
@@ -12405,6 +17229,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12426,6 +17270,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width."]
@@ -12451,6 +17311,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12474,10 +17354,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -12507,7 +17404,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -12540,7 +17438,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -12608,6 +17507,47 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -12621,7 +17561,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -12651,7 +17592,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -12702,7 +17644,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit."]
             _8BIT = 0x0,
@@ -12863,6 +17806,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12884,6 +17847,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -12909,6 +17892,26 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12930,6 +17933,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: bool,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -12988,6 +18007,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13009,6 +18057,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference select"]
@@ -13034,6 +18098,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13055,6 +18139,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13124,10 +18228,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -13160,7 +18297,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -13192,7 +18330,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -13222,7 +18361,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -13264,7 +18404,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -13322,7 +18463,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -13731,6 +18873,59 @@ pub mod mwu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Int {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13875,6 +19070,59 @@ pub mod mwu {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("region0wa", &self.region0wa())
+                    .field("region0ra", &self.region0ra())
+                    .field("region1wa", &self.region1wa())
+                    .field("region1ra", &self.region1ra())
+                    .field("region2wa", &self.region2wa())
+                    .field("region2ra", &self.region2ra())
+                    .field("region3wa", &self.region3wa())
+                    .field("region3ra", &self.region3ra())
+                    .field("pregion0wa", &self.pregion0wa())
+                    .field("pregion0ra", &self.pregion0ra())
+                    .field("pregion1wa", &self.pregion1wa())
+                    .field("pregion1ra", &self.pregion1ra())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    region0wa: bool,
+                    region0ra: bool,
+                    region1wa: bool,
+                    region1ra: bool,
+                    region2wa: bool,
+                    region2ra: bool,
+                    region3wa: bool,
+                    region3ra: bool,
+                    pregion0wa: bool,
+                    pregion0ra: bool,
+                    pregion1wa: bool,
+                    pregion1ra: bool,
+                }
+                let proxy = Nmi {
+                    region0wa: self.region0wa(),
+                    region0ra: self.region0ra(),
+                    region1wa: self.region1wa(),
+                    region1ra: self.region1ra(),
+                    region2wa: self.region2wa(),
+                    region2ra: self.region2ra(),
+                    region3wa: self.region3wa(),
+                    region3ra: self.region3ra(),
+                    pregion0wa: self.pregion0wa(),
+                    pregion0ra: self.pregion0ra(),
+                    pregion1wa: self.pregion1wa(),
+                    pregion1ra: self.pregion1ra(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable/disable regions watch"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13947,6 +19195,61 @@ pub mod mwu {
                 Regionen(0)
             }
         }
+        impl core::fmt::Debug for Regionen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regionen")
+                    .field(
+                        "rgn_wa",
+                        &[
+                            self.rgn_wa(0usize),
+                            self.rgn_wa(1usize),
+                            self.rgn_wa(2usize),
+                            self.rgn_wa(3usize),
+                        ],
+                    )
+                    .field(
+                        "rgn_ra",
+                        &[
+                            self.rgn_ra(0usize),
+                            self.rgn_ra(1usize),
+                            self.rgn_ra(2usize),
+                            self.rgn_ra(3usize),
+                        ],
+                    )
+                    .field("prgn_wa", &[self.prgn_wa(0usize), self.prgn_wa(1usize)])
+                    .field("prgn_ra", &[self.prgn_ra(0usize), self.prgn_ra(1usize)])
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regionen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regionen {
+                    rgn_wa: [bool; 4usize],
+                    rgn_ra: [bool; 4usize],
+                    prgn_wa: [bool; 2usize],
+                    prgn_ra: [bool; 2usize],
+                }
+                let proxy = Regionen {
+                    rgn_wa: [
+                        self.rgn_wa(0usize),
+                        self.rgn_wa(1usize),
+                        self.rgn_wa(2usize),
+                        self.rgn_wa(3usize),
+                    ],
+                    rgn_ra: [
+                        self.rgn_ra(0usize),
+                        self.rgn_ra(1usize),
+                        self.rgn_ra(2usize),
+                        self.rgn_ra(3usize),
+                    ],
+                    prgn_wa: [self.prgn_wa(0usize), self.prgn_wa(1usize)],
+                    prgn_ra: [self.prgn_ra(0usize), self.prgn_ra(1usize)],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Subregions of region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13972,6 +19275,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Subs {
                 Subs(0)
+            }
+        }
+        impl core::fmt::Debug for Subs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subs")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subs {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Subs {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Source of event/interrupt in region n, read access detected while corresponding subregion was enabled for watching"]
@@ -14001,6 +19393,95 @@ pub mod mwu {
                 Substatra(0)
             }
         }
+        impl core::fmt::Debug for Substatra {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatra")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatra {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatra {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatra {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Source of event/interrupt in region n, write access detected while corresponding subregion was enabled for watching"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14026,6 +19507,95 @@ pub mod mwu {
             #[inline(always)]
             fn default() -> Substatwa {
                 Substatwa(0)
+            }
+        }
+        impl core::fmt::Debug for Substatwa {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Substatwa")
+                    .field(
+                        "sr",
+                        &[
+                            self.sr(0usize),
+                            self.sr(1usize),
+                            self.sr(2usize),
+                            self.sr(3usize),
+                            self.sr(4usize),
+                            self.sr(5usize),
+                            self.sr(6usize),
+                            self.sr(7usize),
+                            self.sr(8usize),
+                            self.sr(9usize),
+                            self.sr(10usize),
+                            self.sr(11usize),
+                            self.sr(12usize),
+                            self.sr(13usize),
+                            self.sr(14usize),
+                            self.sr(15usize),
+                            self.sr(16usize),
+                            self.sr(17usize),
+                            self.sr(18usize),
+                            self.sr(19usize),
+                            self.sr(20usize),
+                            self.sr(21usize),
+                            self.sr(22usize),
+                            self.sr(23usize),
+                            self.sr(24usize),
+                            self.sr(25usize),
+                            self.sr(26usize),
+                            self.sr(27usize),
+                            self.sr(28usize),
+                            self.sr(29usize),
+                            self.sr(30usize),
+                            self.sr(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Substatwa {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Substatwa {
+                    sr: [bool; 32usize],
+                }
+                let proxy = Substatwa {
+                    sr: [
+                        self.sr(0usize),
+                        self.sr(1usize),
+                        self.sr(2usize),
+                        self.sr(3usize),
+                        self.sr(4usize),
+                        self.sr(5usize),
+                        self.sr(6usize),
+                        self.sr(7usize),
+                        self.sr(8usize),
+                        self.sr(9usize),
+                        self.sr(10usize),
+                        self.sr(11usize),
+                        self.sr(12usize),
+                        self.sr(13usize),
+                        self.sr(14usize),
+                        self.sr(15usize),
+                        self.sr(16usize),
+                        self.sr(17usize),
+                        self.sr(18usize),
+                        self.sr(19usize),
+                        self.sr(20usize),
+                        self.sr(21usize),
+                        self.sr(22usize),
+                        self.sr(23usize),
+                        self.sr(24usize),
+                        self.sr(25usize),
+                        self.sr(26usize),
+                        self.sr(27usize),
+                        self.sr(28usize),
+                        self.sr(29usize),
+                        self.sr(30usize),
+                        self.sr(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14386,6 +19956,24 @@ pub mod nfct {
                 Autocolresconfig(0)
             }
         }
+        impl core::fmt::Debug for Autocolresconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Autocolresconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Autocolresconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Autocolresconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Autocolresconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14407,6 +19995,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the presence or not of a valid field"]
@@ -14443,6 +20051,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14465,6 +20096,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u32,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -14490,6 +20141,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14511,6 +20182,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14690,6 +20381,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of the RAM buffer allocated to TXD and RXD data storage each"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14711,6 +20464,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Maxlen {
                 Maxlen(0)
+            }
+        }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
@@ -14758,6 +20531,32 @@ pub mod nfct {
                 Nfcid12ndLast(0)
             }
         }
+        impl core::fmt::Debug for Nfcid12ndLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid12ndLast")
+                    .field("nfcid1_v", &self.nfcid1_v())
+                    .field("nfcid1_u", &self.nfcid1_u())
+                    .field("nfcid1_t", &self.nfcid1_t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid12ndLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid12ndLast {
+                    nfcid1_v: u8,
+                    nfcid1_u: u8,
+                    nfcid1_t: u8,
+                }
+                let proxy = Nfcid12ndLast {
+                    nfcid1_v: self.nfcid1_v(),
+                    nfcid1_u: self.nfcid1_u(),
+                    nfcid1_t: self.nfcid1_t(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14801,6 +20600,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfcid13rdLast {
                 Nfcid13rdLast(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcid13rdLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid13rdLast")
+                    .field("nfcid1_s", &self.nfcid1_s())
+                    .field("nfcid1_r", &self.nfcid1_r())
+                    .field("nfcid1_q", &self.nfcid1_q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid13rdLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid13rdLast {
+                    nfcid1_s: u8,
+                    nfcid1_r: u8,
+                    nfcid1_q: u8,
+                }
+                let proxy = Nfcid13rdLast {
+                    nfcid1_s: self.nfcid1_s(),
+                    nfcid1_r: self.nfcid1_r(),
+                    nfcid1_q: self.nfcid1_q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
@@ -14859,6 +20684,35 @@ pub mod nfct {
                 Nfcid1Last(0)
             }
         }
+        impl core::fmt::Debug for Nfcid1Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid1Last")
+                    .field("nfcid1_z", &self.nfcid1_z())
+                    .field("nfcid1_y", &self.nfcid1_y())
+                    .field("nfcid1_x", &self.nfcid1_x())
+                    .field("nfcid1_w", &self.nfcid1_w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid1Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid1Last {
+                    nfcid1_z: u8,
+                    nfcid1_y: u8,
+                    nfcid1_x: u8,
+                    nfcid1_w: u8,
+                }
+                let proxy = Nfcid1Last {
+                    nfcid1_z: self.nfcid1_z(),
+                    nfcid1_y: self.nfcid1_y(),
+                    nfcid1_x: self.nfcid1_x(),
+                    nfcid1_w: self.nfcid1_w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NfcTag state register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14880,6 +20734,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfctagstate {
                 Nfctagstate(0)
+            }
+        }
+        impl core::fmt::Debug for Nfctagstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfctagstate")
+                    .field("nfctagstate", &self.nfctagstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfctagstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfctagstate {
+                    nfctagstate: super::vals::Nfctagstate,
+                }
+                let proxy = Nfctagstate {
+                    nfctagstate: self.nfctagstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of last incoming frame"]
@@ -14927,6 +20801,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14959,6 +20859,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -15004,6 +20927,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdFrameconfig {
                 RxdFrameconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -15073,6 +21022,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: bool,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15140,6 +21121,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15185,6 +21198,32 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .field("txframeend_enablerxdata", &self.txframeend_enablerxdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                    txframeend_enablerxdata: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                    txframeend_enablerxdata: self.txframeend_enablerxdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sleep state during automatic collision resolution"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15206,6 +21245,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Sleepstate {
                 Sleepstate(0)
+            }
+        }
+        impl core::fmt::Debug for Sleepstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sleepstate")
+                    .field("sleepstate", &self.sleepstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sleepstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sleepstate {
+                    sleepstate: super::vals::Sleepstate,
+                }
+                let proxy = Sleepstate {
+                    sleepstate: self.sleepstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Size of outgoing frame"]
@@ -15240,6 +21299,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -15298,10 +21380,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -15365,7 +21477,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits are discarded at end of frame (EoF)"]
             DISCARD_END = 0x0,
@@ -15395,7 +21508,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -15429,7 +21543,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Auto collision resolution enabled"]
             ENABLED = 0x0,
@@ -15459,7 +21574,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -15492,7 +21608,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfctagstate {
             #[doc = "Disabled or sense"]
             DISABLED = 0x0,
@@ -15532,7 +21649,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleepstate {
             #[doc = "State is IDLE."]
             IDLE = 0x0,
@@ -15662,6 +21780,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15683,6 +21817,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseall {
                 Eraseall(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for partial erase configuration"]
@@ -15708,6 +21862,26 @@ pub mod nvmc {
                 Erasepagepartialcfg(0)
             }
         }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing user information configuration registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15729,6 +21903,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Eraseuicr {
                 Eraseuicr(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseuicr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseuicr")
+                    .field("eraseuicr", &self.eraseuicr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseuicr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseuicr {
+                    eraseuicr: bool,
+                }
+                let proxy = Eraseuicr {
+                    eraseuicr: self.eraseuicr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-code cache configuration register"]
@@ -15765,6 +21959,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15786,6 +22003,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Ready {
                 Ready(0)
+            }
+        }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -15811,10 +22048,31 @@ pub mod nvmc {
                 Readynext(0)
             }
         }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -16024,6 +22282,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16047,6 +22325,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16068,6 +22366,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16115,6 +22433,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16136,6 +22480,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -16172,6 +22536,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16194,6 +22581,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Pdmclkctrl {
                 Pdmclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the ratio between PDM_CLK and output sample rate. Change PDMCLKCTRL accordingly."]
@@ -16219,10 +22624,31 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -16276,6 +22702,33 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    0x0980_0000 => f.write_str("_1231K"),
+                    0x0a00_0000 => f.write_str("_1280K"),
+                    0x0a80_0000 => f.write_str("_1333K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    0x0980_0000 => defmt::write!(f, "_1231K"),
+                    0x0a00_0000 => defmt::write!(f, "_1280K"),
+                    0x0a80_0000 => defmt::write!(f, "_1333K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -16307,6 +22760,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -16320,7 +22794,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -16350,7 +22825,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 64"]
             RATIO64 = 0x0,
@@ -16565,6 +23041,26 @@ pub mod power {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable DC/DC converter for REG0 stage"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16586,6 +23082,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Dcdcen0 {
                 Dcdcen0(0)
+            }
+        }
+        impl core::fmt::Debug for Dcdcen0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen0")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen0 {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen0 {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "General purpose retention register"]
@@ -16611,6 +23127,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16632,6 +23168,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret2 {
                 Gpregret2(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret2")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret2 {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret2 {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -16712,6 +23268,41 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .field("usbdetected", &self.usbdetected())
+                    .field("usbremoved", &self.usbremoved())
+                    .field("usbpwrrdy", &self.usbpwrrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                    usbdetected: bool,
+                    usbremoved: bool,
+                    usbpwrrdy: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                    usbdetected: self.usbdetected(),
+                    usbremoved: self.usbremoved(),
+                    usbpwrrdy: self.usbpwrrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Main supply status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16733,6 +23324,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Mainregstatus {
                 Mainregstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Mainregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mainregstatus")
+                    .field("mainregstatus", &self.mainregstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mainregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mainregstatus {
+                    mainregstatus: super::vals::Mainregstatus,
+                }
+                let proxy = Mainregstatus {
+                    mainregstatus: self.mainregstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power-fail comparator configuration"]
@@ -16780,6 +23391,32 @@ pub mod power {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("thresholdvddh", &self.thresholdvddh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    thresholdvddh: super::vals::Thresholdvddh,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    thresholdvddh: self.thresholdvddh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAMn power control register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16820,6 +23457,103 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "s_power",
+                        &[
+                            self.s_power(0usize),
+                            self.s_power(1usize),
+                            self.s_power(2usize),
+                            self.s_power(3usize),
+                            self.s_power(4usize),
+                            self.s_power(5usize),
+                            self.s_power(6usize),
+                            self.s_power(7usize),
+                            self.s_power(8usize),
+                            self.s_power(9usize),
+                            self.s_power(10usize),
+                            self.s_power(11usize),
+                            self.s_power(12usize),
+                            self.s_power(13usize),
+                            self.s_power(14usize),
+                            self.s_power(15usize),
+                        ],
+                    )
+                    .field(
+                        "s_retention",
+                        &[
+                            self.s_retention(0usize),
+                            self.s_retention(1usize),
+                            self.s_retention(2usize),
+                            self.s_retention(3usize),
+                            self.s_retention(4usize),
+                            self.s_retention(5usize),
+                            self.s_retention(6usize),
+                            self.s_retention(7usize),
+                            self.s_retention(8usize),
+                            self.s_retention(9usize),
+                            self.s_retention(10usize),
+                            self.s_retention(11usize),
+                            self.s_retention(12usize),
+                            self.s_retention(13usize),
+                            self.s_retention(14usize),
+                            self.s_retention(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    s_power: [bool; 16usize],
+                    s_retention: [bool; 16usize],
+                }
+                let proxy = Power {
+                    s_power: [
+                        self.s_power(0usize),
+                        self.s_power(1usize),
+                        self.s_power(2usize),
+                        self.s_power(3usize),
+                        self.s_power(4usize),
+                        self.s_power(5usize),
+                        self.s_power(6usize),
+                        self.s_power(7usize),
+                        self.s_power(8usize),
+                        self.s_power(9usize),
+                        self.s_power(10usize),
+                        self.s_power(11usize),
+                        self.s_power(12usize),
+                        self.s_power(13usize),
+                        self.s_power(14usize),
+                        self.s_power(15usize),
+                    ],
+                    s_retention: [
+                        self.s_retention(0usize),
+                        self.s_retention(1usize),
+                        self.s_retention(2usize),
+                        self.s_retention(3usize),
+                        self.s_retention(4usize),
+                        self.s_retention(5usize),
+                        self.s_retention(6usize),
+                        self.s_retention(7usize),
+                        self.s_retention(8usize),
+                        self.s_retention(9usize),
+                        self.s_retention(10usize),
+                        self.s_retention(11usize),
+                        self.s_retention(12usize),
+                        self.s_retention(13usize),
+                        self.s_retention(14usize),
+                        self.s_retention(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Deprecated register - RAM status register"]
@@ -16876,6 +23610,35 @@ pub mod power {
             #[inline(always)]
             fn default() -> Ramstatus {
                 Ramstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ramstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramstatus")
+                    .field("ramblock0", &self.ramblock0())
+                    .field("ramblock1", &self.ramblock1())
+                    .field("ramblock2", &self.ramblock2())
+                    .field("ramblock3", &self.ramblock3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramstatus {
+                    ramblock0: bool,
+                    ramblock1: bool,
+                    ramblock2: bool,
+                    ramblock3: bool,
+                }
+                let proxy = Ramstatus {
+                    ramblock0: self.ramblock0(),
+                    ramblock1: self.ramblock1(),
+                    ramblock2: self.ramblock2(),
+                    ramblock3: self.ramblock3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -16989,6 +23752,50 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("nfc", &self.nfc())
+                    .field("vbus", &self.vbus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    nfc: bool,
+                    vbus: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    nfc: self.nfc(),
+                    vbus: self.vbus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17010,6 +23817,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "USB supply status"]
@@ -17046,10 +23873,34 @@ pub mod power {
                 Usbregstatus(0)
             }
         }
+        impl core::fmt::Debug for Usbregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbregstatus")
+                    .field("vbusdetect", &self.vbusdetect())
+                    .field("outputrdy", &self.outputrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbregstatus {
+                    vbusdetect: bool,
+                    outputrdy: bool,
+                }
+                let proxy = Usbregstatus {
+                    vbusdetect: self.vbusdetect(),
+                    outputrdy: self.outputrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mainregstatus {
             #[doc = "Normal voltage mode. Voltage supplied on VDD."]
             NORMAL = 0x0,
@@ -17079,7 +23930,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -17133,7 +23985,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Thresholdvddh {
             #[doc = "Set threshold to 2.7 V"]
             V27 = 0x0,
@@ -17353,6 +24206,95 @@ pub mod ppi {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17378,6 +24320,95 @@ pub mod ppi {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -17595,6 +24626,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17616,6 +24663,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -17652,6 +24719,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17673,6 +24763,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -17697,6 +24807,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17788,6 +24916,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17810,6 +24976,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -17835,6 +25017,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17856,6 +25058,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -17880,6 +25102,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -17949,6 +25187,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -17966,6 +25236,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -17979,7 +25266,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -18027,6 +25315,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -18040,7 +25345,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -18070,7 +25376,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -18126,6 +25433,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -18139,7 +25463,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -18369,6 +25694,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18390,6 +25735,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -18415,6 +25780,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18436,6 +25821,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -18505,6 +25910,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18526,6 +25963,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -18551,6 +26008,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18574,6 +26051,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18595,6 +26092,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -18686,10 +26203,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -18719,7 +26275,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -18770,7 +26327,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -19180,6 +26738,41 @@ pub mod qspi {
                 Addrconf(0)
             }
         }
+        impl core::fmt::Debug for Addrconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Addrconf")
+                    .field("opcode", &self.opcode())
+                    .field("byte0", &self.byte0())
+                    .field("byte1", &self.byte1())
+                    .field("mode", &self.mode())
+                    .field("wipwait", &self.wipwait())
+                    .field("wren", &self.wren())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Addrconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Addrconf {
+                    opcode: u8,
+                    byte0: u8,
+                    byte1: u8,
+                    mode: super::vals::Mode,
+                    wipwait: bool,
+                    wren: bool,
+                }
+                let proxy = Addrconf {
+                    opcode: self.opcode(),
+                    byte0: self.byte0(),
+                    byte1: self.byte1(),
+                    mode: self.mode(),
+                    wipwait: self.wipwait(),
+                    wren: self.wren(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Custom instruction configuration register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19280,6 +26873,47 @@ pub mod qspi {
                 Cinstrconf(0)
             }
         }
+        impl core::fmt::Debug for Cinstrconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrconf")
+                    .field("opcode", &self.opcode())
+                    .field("length", &self.length())
+                    .field("lio2", &self.lio2())
+                    .field("lio3", &self.lio3())
+                    .field("wipwait", &self.wipwait())
+                    .field("wren", &self.wren())
+                    .field("lfen", &self.lfen())
+                    .field("lfstop", &self.lfstop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrconf {
+                    opcode: u8,
+                    length: super::vals::Length,
+                    lio2: bool,
+                    lio3: bool,
+                    wipwait: bool,
+                    wren: bool,
+                    lfen: bool,
+                    lfstop: bool,
+                }
+                let proxy = Cinstrconf {
+                    opcode: self.opcode(),
+                    length: self.length(),
+                    lio2: self.lio2(),
+                    lio3: self.lio3(),
+                    wipwait: self.wipwait(),
+                    wren: self.wren(),
+                    lfen: self.lfen(),
+                    lfstop: self.lfstop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Custom instruction data register 0."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19334,6 +26968,35 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Cinstrdat0 {
                 Cinstrdat0(0)
+            }
+        }
+        impl core::fmt::Debug for Cinstrdat0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrdat0")
+                    .field("byte0", &self.byte0())
+                    .field("byte1", &self.byte1())
+                    .field("byte2", &self.byte2())
+                    .field("byte3", &self.byte3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrdat0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrdat0 {
+                    byte0: u8,
+                    byte1: u8,
+                    byte2: u8,
+                    byte3: u8,
+                }
+                let proxy = Cinstrdat0 {
+                    byte0: self.byte0(),
+                    byte1: self.byte1(),
+                    byte2: self.byte2(),
+                    byte3: self.byte3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Custom instruction data register 1."]
@@ -19392,6 +27055,35 @@ pub mod qspi {
                 Cinstrdat1(0)
             }
         }
+        impl core::fmt::Debug for Cinstrdat1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrdat1")
+                    .field("byte4", &self.byte4())
+                    .field("byte5", &self.byte5())
+                    .field("byte6", &self.byte6())
+                    .field("byte7", &self.byte7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrdat1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrdat1 {
+                    byte4: u8,
+                    byte5: u8,
+                    byte6: u8,
+                    byte7: u8,
+                }
+                let proxy = Cinstrdat1 {
+                    byte4: self.byte4(),
+                    byte5: self.byte5(),
+                    byte6: self.byte6(),
+                    byte7: self.byte7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set the duration required to enter/exit deep power-down mode (DPM)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19426,6 +27118,29 @@ pub mod qspi {
                 Dpmdur(0)
             }
         }
+        impl core::fmt::Debug for Dpmdur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpmdur")
+                    .field("enter", &self.enter())
+                    .field("exit", &self.exit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpmdur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpmdur {
+                    enter: u16,
+                    exit: u16,
+                }
+                let proxy = Dpmdur {
+                    enter: self.enter(),
+                    exit: self.exit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable QSPI peripheral and acquire the pins selected in PSELn registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19447,6 +27162,26 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interface configuration."]
@@ -19517,6 +27252,38 @@ pub mod qspi {
                 Ifconfig0(0)
             }
         }
+        impl core::fmt::Debug for Ifconfig0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ifconfig0")
+                    .field("readoc", &self.readoc())
+                    .field("writeoc", &self.writeoc())
+                    .field("addrmode", &self.addrmode())
+                    .field("dpmenable", &self.dpmenable())
+                    .field("ppsize", &self.ppsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ifconfig0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ifconfig0 {
+                    readoc: super::vals::Readoc,
+                    writeoc: super::vals::Writeoc,
+                    addrmode: super::vals::Addrmode,
+                    dpmenable: bool,
+                    ppsize: super::vals::Ppsize,
+                }
+                let proxy = Ifconfig0 {
+                    readoc: self.readoc(),
+                    writeoc: self.writeoc(),
+                    addrmode: self.addrmode(),
+                    dpmenable: self.dpmenable(),
+                    ppsize: self.ppsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interface configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19574,6 +27341,35 @@ pub mod qspi {
                 Ifconfig1(0)
             }
         }
+        impl core::fmt::Debug for Ifconfig1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ifconfig1")
+                    .field("sckdelay", &self.sckdelay())
+                    .field("dpmen", &self.dpmen())
+                    .field("spimode", &self.spimode())
+                    .field("sckfreq", &self.sckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ifconfig1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ifconfig1 {
+                    sckdelay: u8,
+                    dpmen: bool,
+                    spimode: super::vals::Spimode,
+                    sckfreq: u8,
+                }
+                let proxy = Ifconfig1 {
+                    sckdelay: self.sckdelay(),
+                    dpmen: self.dpmen(),
+                    spimode: self.spimode(),
+                    sckfreq: self.sckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI interface timing."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19595,6 +27391,26 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Iftiming {
                 Iftiming(0)
+            }
+        }
+        impl core::fmt::Debug for Iftiming {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Iftiming")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Iftiming {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Iftiming {
+                    rxdelay: u8,
+                }
+                let proxy = Iftiming {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -19620,6 +27436,24 @@ pub mod qspi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of block to be erased."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19641,6 +27475,22 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Len {
                 Len(0)
+            }
+        }
+        impl core::fmt::Debug for Len {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Len").field("len", &self.len()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Len {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Len {
+                    len: super::vals::Len,
+                }
+                let proxy = Len { len: self.len() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read transfer length"]
@@ -19665,6 +27515,22 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> ReadCnt {
                 ReadCnt(0)
+            }
+        }
+        impl core::fmt::Debug for ReadCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReadCnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReadCnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReadCnt {
+                    cnt: u32,
+                }
+                let proxy = ReadCnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -19712,6 +27578,32 @@ pub mod qspi {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("dpm", &self.dpm())
+                    .field("ready", &self.ready())
+                    .field("sreg", &self.sreg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    dpm: bool,
+                    ready: bool,
+                    sreg: u8,
+                }
+                let proxy = Status {
+                    dpm: self.dpm(),
+                    ready: self.ready(),
+                    sreg: self.sreg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write transfer length"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19736,10 +27628,29 @@ pub mod qspi {
                 WriteCnt(0)
             }
         }
+        impl core::fmt::Debug for WriteCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("WriteCnt")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for WriteCnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct WriteCnt {
+                    cnt: u32,
+                }
+                let proxy = WriteCnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Addrmode {
             #[doc = "24-bit addressing."]
             _24BIT = 0x0,
@@ -19769,7 +27680,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "Erase 4 kB block (flash command 0x20)"]
             _4KB = 0x0,
@@ -19802,7 +27714,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             _RESERVED_0 = 0x0,
             #[doc = "Send opcode only."]
@@ -19853,7 +27766,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Do not send any instruction."]
             NO_INSTR = 0x0,
@@ -19887,7 +27801,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ppsize {
             #[doc = "256 bytes."]
             _256BYTES = 0x0,
@@ -19917,7 +27832,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Readoc {
             #[doc = "Single data line SPI. FAST_READ (opcode 0x0B)."]
             FASTREAD = 0x0,
@@ -19956,7 +27872,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Spimode {
             #[doc = "Mode 0: Data are captured on the clock rising edge and data is output on a falling edge. Base level of clock is 0 (CPOL=0, CPHA=0)."]
             MODE0 = 0x0,
@@ -19986,7 +27903,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Writeoc {
             #[doc = "Single data line SPI. PP (opcode 0x02)."]
             PP = 0x0,
@@ -20477,6 +28395,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20511,6 +28458,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20533,6 +28503,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -20559,6 +28549,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20580,6 +28590,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -20770,6 +28800,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20791,6 +28886,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -20816,6 +28927,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20837,6 +28964,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "IEEE 802.15.4 energy detect loop count"]
@@ -20863,6 +29010,26 @@ pub mod radio {
                 Edcnt(0)
             }
         }
+        impl core::fmt::Debug for Edcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edcnt")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edcnt {
+                    edcnt: u32,
+                }
+                let proxy = Edcnt {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect level"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20884,6 +29051,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edsample {
                 Edsample(0)
+            }
+        }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -20918,6 +29105,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -21185,6 +29395,92 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("framestart", &self.framestart())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("phyend", &self.phyend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    framestart: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    txready: bool,
+                    rxready: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    phyend: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    framestart: self.framestart(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    phyend: self.phyend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21206,6 +29502,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -21240,6 +29552,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -21345,6 +29680,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21413,6 +29789,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21447,6 +29855,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21468,6 +29899,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -21526,6 +29977,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21582,6 +30062,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21603,6 +30112,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -21705,6 +30234,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21727,6 +30297,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -21752,6 +30342,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21773,6 +30383,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -21996,6 +30622,80 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22017,6 +30717,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interframe spacing in us"]
@@ -22042,6 +30762,22 @@ pub mod radio {
                 Tifs(0)
             }
         }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22063,6 +30799,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -22088,10 +30844,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -22130,7 +30907,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125kbps"]
             LR125KBIT = 0x0,
@@ -22162,7 +30940,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -22192,7 +30971,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -22222,7 +31002,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -22255,7 +31036,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -22285,7 +31067,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -22319,7 +31102,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHZ .. 2500 MHz"]
             DEFAULT = 0x0,
@@ -22349,7 +31133,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbit/s Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -22398,7 +31183,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -22428,7 +31214,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -22462,7 +31249,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -22492,7 +31280,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -22522,7 +31311,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -22555,7 +31345,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -22606,7 +31397,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -22986,6 +31778,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23007,6 +31819,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -23032,6 +31864,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23053,6 +31905,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -23177,6 +32049,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current COUNTER value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23199,6 +32091,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -23250,6 +32162,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23299,6 +32250,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12 bit prescaler for COUNTER frequency (32768/(PRESCALER+1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23320,6 +32310,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -23569,6 +32579,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23661,6 +32691,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable SAADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23682,6 +32750,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -23792,6 +32880,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring of a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23826,6 +32997,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Last result is equal or above CH\\[n\\].LIMIT.HIGH"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23847,6 +33041,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Limith {
                 Limith(0)
+            }
+        }
+        impl core::fmt::Debug for Limith {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limith")
+                    .field("limith", &self.limith())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limith {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limith {
+                    limith: bool,
+                }
+                let proxy = Limith {
+                    limith: self.limith(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Last result is equal or below CH\\[n\\].LIMIT.LOW"]
@@ -23872,6 +33086,26 @@ pub mod saadc {
                 Limitl(0)
             }
         }
+        impl core::fmt::Debug for Limitl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limitl")
+                    .field("limitl", &self.limitl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limitl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limitl {
+                    limitl: bool,
+                }
+                let proxy = Limitl {
+                    limitl: self.limitl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of 16-bit samples to be written to output RAM buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23893,6 +33127,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -23918,6 +33172,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23939,6 +33213,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -23964,6 +33258,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23985,6 +33299,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -24022,6 +33354,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24045,10 +33400,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single-ended, PSELN will be ignored, negative input to SAADC shorted to GND"]
             SE = 0x0,
@@ -24078,7 +33454,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -24120,7 +33497,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -24171,7 +33549,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -24240,7 +33619,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -24270,7 +33650,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -24304,7 +33685,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -24338,7 +33720,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -24368,7 +33751,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "SAADC is ready. No on-going conversions."]
             READY = 0x0,
@@ -24398,7 +33782,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -24438,7 +33823,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bits"]
             _8BIT = 0x0,
@@ -24525,10 +33911,37 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -24704,6 +34117,32 @@ pub mod spi {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24725,6 +34164,26 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -24751,6 +34210,26 @@ pub mod spi {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24772,6 +34251,24 @@ pub mod spi {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RXD register. Register is cleared on read and the buffer pointer will be modified if read."]
@@ -24797,6 +34294,22 @@ pub mod spi {
                 Rxd(0)
             }
         }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24820,10 +34333,27 @@ pub mod spi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -24853,7 +34383,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -24883,7 +34414,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI"]
             DISABLED = 0x0,
@@ -24953,6 +34485,35 @@ pub mod spi {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -24966,7 +34527,8 @@ pub mod spi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -25325,6 +34887,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Minimum duration between edge of CSN and edge of SCK at the start and the end of a transaction, and minimum duration CSN will stay high between transactions if END-START shortcut is used"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25346,6 +34934,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csndur {
                 Csndur(0)
+            }
+        }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Polarity of CSN output"]
@@ -25371,6 +34979,26 @@ pub mod spim {
                 Csnpol(0)
             }
         }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol", &self.csnpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol: super::vals::Csnpol,
+                }
+                let proxy = Csnpol {
+                    csnpol: self.csnpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DCX configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25392,6 +35020,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Dcxcnt {
                 Dcxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable SPIM"]
@@ -25417,6 +35065,26 @@ pub mod spim {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25439,6 +35107,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -25508,6 +35196,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25529,6 +35249,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -25554,6 +35290,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25575,6 +35331,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -25600,6 +35374,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample delay for input serial data on MISO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25623,6 +35417,26 @@ pub mod spim {
                 Rxdelay(0)
             }
         }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25644,6 +35458,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Stall status for EasyDMA RAM accesses. The fields in this register are set to STALL by hardware whenever a stall occurs and can be cleared (set to NOSTALL) by the CPU."]
@@ -25680,6 +35514,29 @@ pub mod spim {
                 Stallstat(0)
             }
         }
+        impl core::fmt::Debug for Stallstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Stallstat")
+                    .field("tx", &self.tx())
+                    .field("rx", &self.rx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Stallstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Stallstat {
+                    tx: bool,
+                    rx: bool,
+                }
+                let proxy = Stallstat {
+                    tx: self.tx(),
+                    rx: self.rx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25701,6 +35558,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -25726,6 +35603,24 @@ pub mod spim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25749,10 +35644,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -25782,7 +35698,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -25812,7 +35729,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -25842,7 +35760,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -25916,6 +35835,39 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x0a00_0000 => f.write_str("M16"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x1400_0000 => f.write_str("M32"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x0a00_0000 => defmt::write!(f, "M16"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x1400_0000 => defmt::write!(f, "M32"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -25929,7 +35881,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -25959,7 +35912,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -25991,7 +35945,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -26288,6 +36243,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26311,6 +36292,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26332,6 +36329,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -26379,6 +36396,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26400,6 +36443,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -26425,6 +36484,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26446,6 +36525,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -26471,6 +36568,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26494,6 +36611,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26515,6 +36652,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -26551,6 +36708,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26572,6 +36752,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -26597,6 +36797,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26620,10 +36838,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -26653,7 +36892,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -26683,7 +36923,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -26727,7 +36968,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -26757,7 +36999,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -26789,7 +37032,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -26823,7 +37067,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -26970,6 +37215,26 @@ pub mod temp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod timer {
@@ -27087,6 +37352,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27114,6 +37399,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27137,6 +37459,22 @@ pub mod timer {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27158,6 +37496,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -27202,10 +37560,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -27239,7 +37655,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -27447,6 +37864,26 @@ pub mod twi {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWI"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27468,6 +37905,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -27515,6 +37972,32 @@ pub mod twi {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27537,6 +38020,26 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -27617,6 +38120,41 @@ pub mod twi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("rxdready", &self.rxdready())
+                    .field("txdsent", &self.txdsent())
+                    .field("error", &self.error())
+                    .field("bb", &self.bb())
+                    .field("suspended", &self.suspended())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    rxdready: bool,
+                    txdsent: bool,
+                    error: bool,
+                    bb: bool,
+                    suspended: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    rxdready: self.rxdready(),
+                    txdsent: self.txdsent(),
+                    error: self.error(),
+                    bb: self.bb(),
+                    suspended: self.suspended(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register. Register is cleared on read and the buffer pointer will be modified if read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27638,6 +38176,22 @@ pub mod twi {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -27674,6 +38228,29 @@ pub mod twi {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("bb_suspend", &self.bb_suspend())
+                    .field("bb_stop", &self.bb_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    bb_suspend: bool,
+                    bb_stop: bool,
+                }
+                let proxy = Shorts {
+                    bb_suspend: self.bb_suspend(),
+                    bb_stop: self.bb_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27697,10 +38274,27 @@ pub mod twi {
                 Txd(0)
             }
         }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWI"]
             DISABLED = 0x0,
@@ -27760,6 +38354,27 @@ pub mod twi {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0668_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0668_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Frequency {
@@ -28034,6 +38649,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28055,6 +38690,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -28102,6 +38757,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28124,6 +38805,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -28215,6 +38916,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28236,6 +38975,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -28261,6 +39020,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28282,6 +39059,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -28362,6 +39159,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28383,6 +39215,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -28408,6 +39260,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28431,10 +39301,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -28496,6 +39387,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -28509,7 +39421,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -28545,7 +39458,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -28849,6 +39763,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28883,6 +39817,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28904,6 +39861,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -28949,6 +39926,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -29029,6 +40032,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29050,6 +40088,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -29075,6 +40133,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29096,6 +40170,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -29121,6 +40215,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29142,6 +40254,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -29178,6 +40310,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29199,6 +40354,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -29224,6 +40399,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29247,10 +40440,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -29294,7 +40508,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -29326,7 +40541,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -29544,6 +40760,26 @@ pub mod uart {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29589,6 +40825,32 @@ pub mod uart {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29610,6 +40872,26 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -29666,6 +40948,35 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -29746,6 +41057,41 @@ pub mod uart {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    txdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    txdrdy: self.txdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RXD register. Register is cleared on read and the double buffered byte will be moved to RXD if it exists."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29767,6 +41113,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Rxd {
                 Rxd(0)
+            }
+        }
+        impl core::fmt::Debug for Rxd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxd").field("rxd", &self.rxd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxd {
+                    rxd: u8,
+                }
+                let proxy = Rxd { rxd: self.rxd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -29803,6 +41165,29 @@ pub mod uart {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("cts_startrx", &self.cts_startrx())
+                    .field("ncts_stoprx", &self.ncts_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    cts_startrx: bool,
+                    ncts_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    cts_startrx: self.cts_startrx(),
+                    ncts_stoprx: self.ncts_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TXD register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29824,6 +41209,22 @@ pub mod uart {
             #[inline(always)]
             fn default() -> Txd {
                 Txd(0)
+            }
+        }
+        impl core::fmt::Debug for Txd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txd").field("txd", &self.txd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txd {
+                    txd: u8,
+                }
+                let proxy = Txd { txd: self.txd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -29877,6 +41278,57 @@ pub mod uart {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003b_0000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_f000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_5000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_f000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d7_e000 => f.write_str("BAUD115200"),
+                    0x03af_b000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x075f_7000 => f.write_str("BAUD460800"),
+                    0x0ebe_d000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003b_0000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_f000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_5000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_f000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d7_e000 => defmt::write!(f, "BAUD115200"),
+                    0x03af_b000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x075f_7000 => defmt::write!(f, "BAUD460800"),
+                    0x0ebe_d000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -29890,7 +41342,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -29926,7 +41379,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UART"]
             DISABLED = 0x0,
@@ -29970,7 +41424,8 @@ pub mod uart {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -30280,6 +41735,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30325,6 +41800,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30346,6 +41847,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -30402,6 +41923,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -30537,6 +42087,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30560,6 +42160,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30581,6 +42201,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -30617,6 +42257,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30640,6 +42303,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30661,6 +42344,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -30714,6 +42417,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -30727,7 +42481,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -30763,7 +42518,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -30807,7 +42563,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -30927,6 +42684,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::Pall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Processor debug control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30961,6 +42736,29 @@ pub mod uicr {
                 Debugctrl(0)
             }
         }
+        impl core::fmt::Debug for Debugctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Debugctrl")
+                    .field("cpuniden", &self.cpuniden())
+                    .field("cpufpben", &self.cpufpben())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Debugctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Debugctrl {
+                    cpuniden: super::vals::Cpuniden,
+                    cpufpben: super::vals::Cpufpben,
+                }
+                let proxy = Debugctrl {
+                    cpuniden: self.cpuniden(),
+                    cpufpben: self.cpufpben(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Setting of pins dedicated to NFC functionality: NFC antenna or GPIO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30982,6 +42780,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Nfcpins {
                 Nfcpins(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcpins {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcpins")
+                    .field("protect", &self.protect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcpins {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcpins {
+                    protect: super::vals::Protect,
+                }
+                let proxy = Nfcpins {
+                    protect: self.protect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output voltage from REG0 regulator stage. The maximum output voltage from this stage is given as VDDH - V_VDDH-VDD."]
@@ -31007,6 +42825,24 @@ pub mod uicr {
                 Regout0(0)
             }
         }
+        impl core::fmt::Debug for Regout0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Regout0")
+                    .field("vout", &self.vout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Regout0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Regout0 {
+                    vout: super::vals::Vout,
+                }
+                let proxy = Regout0 { vout: self.vout() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -31024,6 +42860,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Cpufpben {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0xff => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpufpben {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0xff => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Cpufpben {
@@ -31053,6 +42908,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Cpuniden {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0xff => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpuniden {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0xff => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Cpuniden {
@@ -31086,6 +42960,27 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ENABLED"),
+                    0x5a => f.write_str("HW_DISABLED"),
+                    0xff => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ENABLED"),
+                    0x5a => defmt::write!(f, "HW_DISABLED"),
+                    0xff => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Pall {
             #[inline(always)]
             fn from(val: u8) -> Pall {
@@ -31099,7 +42994,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protect {
             #[doc = "Operation as GPIO pins. Same protection as normal GPIO pins."]
             DISABLED = 0x0,
@@ -31129,7 +43025,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Vout {
             #[doc = "1.8 V"]
             _1V8 = 0x0,
@@ -31701,6 +43598,32 @@ pub mod usbd {
                 Bmrequesttype(0)
             }
         }
+        impl core::fmt::Debug for Bmrequesttype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bmrequesttype")
+                    .field("recipient", &self.recipient())
+                    .field("type_", &self.type_())
+                    .field("direction", &self.direction())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bmrequesttype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bmrequesttype {
+                    recipient: super::vals::Recipient,
+                    type_: super::vals::Type,
+                    direction: super::vals::Io,
+                }
+                let proxy = Bmrequesttype {
+                    recipient: self.recipient(),
+                    type_: self.type_(),
+                    direction: self.direction(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 1, bRequest"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31724,6 +43647,26 @@ pub mod usbd {
                 Brequest(0)
             }
         }
+        impl core::fmt::Debug for Brequest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Brequest")
+                    .field("brequest", &self.brequest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Brequest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Brequest {
+                    brequest: super::vals::Brequest,
+                }
+                let proxy = Brequest {
+                    brequest: self.brequest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State D+ and D- lines will be forced into by the DPDMDRIVE task. The DPDMNODRIVE task reverts the control of the lines to MAC IP (no forcing)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31745,6 +43688,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Dpdmvalue {
                 Dpdmvalue(0)
+            }
+        }
+        impl core::fmt::Debug for Dpdmvalue {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpdmvalue")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpdmvalue {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpdmvalue {
+                    state: super::vals::State,
+                }
+                let proxy = Dpdmvalue {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data toggle control and status"]
@@ -31792,6 +43755,32 @@ pub mod usbd {
                 Dtoggle(0)
             }
         }
+        impl core::fmt::Debug for Dtoggle {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dtoggle")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dtoggle {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dtoggle {
+                    ep: u8,
+                    io: super::vals::Io,
+                    value: super::vals::Value,
+                }
+                let proxy = Dtoggle {
+                    ep: self.ep(),
+                    io: self.io(),
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable USB"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31813,6 +43802,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Provides information on which endpoint(s) an acknowledged data transfer has occurred (EPDATA event)"]
@@ -31857,6 +43866,67 @@ pub mod usbd {
                 Epdatastatus(0)
             }
         }
+        impl core::fmt::Debug for Epdatastatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epdatastatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epdatastatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epdatastatus {
+                    epin: [bool; 7usize],
+                    epout: [bool; 7usize],
+                }
+                let proxy = Epdatastatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: IN endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31879,6 +43949,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epin {
                 Epin(0)
+            }
+        }
+        impl core::fmt::Debug for Epin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epin")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epin {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = Epin {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
@@ -31904,6 +43994,26 @@ pub mod usbd {
                 EpinAmount(0)
             }
         }
+        impl core::fmt::Debug for EpinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinAmount {
+                    amount: u8,
+                }
+                let proxy = EpinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31925,6 +44035,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpinMaxcnt {
                 EpinMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint IN enable"]
@@ -31965,6 +44095,50 @@ pub mod usbd {
                 Epinen(0)
             }
         }
+        impl core::fmt::Debug for Epinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epinen")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("isoin", &self.isoin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epinen {
+                    in_: [bool; 8usize],
+                    isoin: bool,
+                }
+                let proxy = Epinen {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    isoin: self.isoin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31988,6 +44162,26 @@ pub mod usbd {
                 EpoutAmount(0)
             }
         }
+        impl core::fmt::Debug for EpoutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutAmount {
+                    amount: u8,
+                }
+                let proxy = EpoutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32009,6 +44203,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpoutMaxcnt {
                 EpoutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpoutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpoutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint OUT enable"]
@@ -32047,6 +44261,50 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epouten {
                 Epouten(0)
+            }
+        }
+        impl core::fmt::Debug for Epouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epouten")
+                    .field(
+                        "out",
+                        &[
+                            self.out(0usize),
+                            self.out(1usize),
+                            self.out(2usize),
+                            self.out(3usize),
+                            self.out(4usize),
+                            self.out(5usize),
+                            self.out(6usize),
+                            self.out(7usize),
+                        ],
+                    )
+                    .field("isoout", &self.isoout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epouten {
+                    out: [bool; 8usize],
+                    isoout: bool,
+                }
+                let proxy = Epouten {
+                    out: [
+                        self.out(0usize),
+                        self.out(1usize),
+                        self.out(2usize),
+                        self.out(3usize),
+                        self.out(4usize),
+                        self.out(5usize),
+                        self.out(6usize),
+                        self.out(7usize),
+                    ],
+                    isoout: self.isoout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "STALL endpoints"]
@@ -32094,6 +44352,32 @@ pub mod usbd {
                 Epstall(0)
             }
         }
+        impl core::fmt::Debug for Epstall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstall")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("stall", &self.stall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstall {
+                    ep: u8,
+                    io: super::vals::Io,
+                    stall: bool,
+                }
+                let proxy = Epstall {
+                    ep: self.ep(),
+                    io: self.io(),
+                    stall: self.stall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Provides information on which endpoint's EasyDMA registers have been captured"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32134,6 +44418,75 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epstatus {
                 Epstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Epstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                            self.epin(7usize),
+                            self.epin(8usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                            self.epout(7usize),
+                            self.epout(8usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstatus {
+                    epin: [bool; 9usize],
+                    epout: [bool; 9usize],
+                }
+                let proxy = Epstatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                        self.epin(7usize),
+                        self.epin(8usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                        self.epout(7usize),
+                        self.epout(8usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Details on what caused the USBEVENT event"]
@@ -32203,6 +44556,38 @@ pub mod usbd {
                 Eventcause(0)
             }
         }
+        impl core::fmt::Debug for Eventcause {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eventcause")
+                    .field("isooutcrc", &self.isooutcrc())
+                    .field("suspend", &self.suspend())
+                    .field("resume", &self.resume())
+                    .field("usbwuallowed", &self.usbwuallowed())
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eventcause {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eventcause {
+                    isooutcrc: bool,
+                    suspend: bool,
+                    resume: bool,
+                    usbwuallowed: bool,
+                    ready: bool,
+                }
+                let proxy = Eventcause {
+                    isooutcrc: self.isooutcrc(),
+                    suspend: self.suspend(),
+                    resume: self.resume(),
+                    usbwuallowed: self.usbwuallowed(),
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Returns the current value of the start of frame counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32224,6 +44609,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Framecntr {
                 Framecntr(0)
+            }
+        }
+        impl core::fmt::Debug for Framecntr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framecntr")
+                    .field("framecntr", &self.framecntr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framecntr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framecntr {
+                    framecntr: u16,
+                }
+                let proxy = Framecntr {
+                    framecntr: self.framecntr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: OUT endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
@@ -32248,6 +44653,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> HaltedEpout {
                 HaltedEpout(0)
+            }
+        }
+        impl core::fmt::Debug for HaltedEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HaltedEpout")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HaltedEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HaltedEpout {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = HaltedEpout {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -32391,6 +44816,98 @@ pub mod usbd {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("usbreset", &self.usbreset())
+                    .field("started", &self.started())
+                    .field(
+                        "endepin",
+                        &[
+                            self.endepin(0usize),
+                            self.endepin(1usize),
+                            self.endepin(2usize),
+                            self.endepin(3usize),
+                            self.endepin(4usize),
+                            self.endepin(5usize),
+                            self.endepin(6usize),
+                            self.endepin(7usize),
+                        ],
+                    )
+                    .field("ep0datadone", &self.ep0datadone())
+                    .field("endisoin", &self.endisoin())
+                    .field(
+                        "endepout",
+                        &[
+                            self.endepout(0usize),
+                            self.endepout(1usize),
+                            self.endepout(2usize),
+                            self.endepout(3usize),
+                            self.endepout(4usize),
+                            self.endepout(5usize),
+                            self.endepout(6usize),
+                            self.endepout(7usize),
+                        ],
+                    )
+                    .field("endisoout", &self.endisoout())
+                    .field("sof", &self.sof())
+                    .field("usbevent", &self.usbevent())
+                    .field("ep0setup", &self.ep0setup())
+                    .field("epdata", &self.epdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    usbreset: bool,
+                    started: bool,
+                    endepin: [bool; 8usize],
+                    ep0datadone: bool,
+                    endisoin: bool,
+                    endepout: [bool; 8usize],
+                    endisoout: bool,
+                    sof: bool,
+                    usbevent: bool,
+                    ep0setup: bool,
+                    epdata: bool,
+                }
+                let proxy = Int {
+                    usbreset: self.usbreset(),
+                    started: self.started(),
+                    endepin: [
+                        self.endepin(0usize),
+                        self.endepin(1usize),
+                        self.endepin(2usize),
+                        self.endepin(3usize),
+                        self.endepin(4usize),
+                        self.endepin(5usize),
+                        self.endepin(6usize),
+                        self.endepin(7usize),
+                    ],
+                    ep0datadone: self.ep0datadone(),
+                    endisoin: self.endisoin(),
+                    endepout: [
+                        self.endepout(0usize),
+                        self.endepout(1usize),
+                        self.endepout(2usize),
+                        self.endepout(3usize),
+                        self.endepout(4usize),
+                        self.endepout(5usize),
+                        self.endepout(6usize),
+                        self.endepout(7usize),
+                    ],
+                    endisoout: self.endisoout(),
+                    sof: self.sof(),
+                    usbevent: self.usbevent(),
+                    ep0setup: self.ep0setup(),
+                    epdata: self.epdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32412,6 +44929,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsoinAmount {
                 IsoinAmount(0)
+            }
+        }
+        impl core::fmt::Debug for IsoinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinAmount {
+                    amount: u16,
+                }
+                let proxy = IsoinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -32437,6 +44974,26 @@ pub mod usbd {
                 IsoinMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for IsoinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsoinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the response of the ISO IN endpoint to an IN token when no data is ready to be sent"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32458,6 +45015,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Isoinconfig {
                 Isoinconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Isoinconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoinconfig")
+                    .field("response", &self.response())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoinconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoinconfig {
+                    response: super::vals::Response,
+                }
+                let proxy = Isoinconfig {
+                    response: self.response(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received last on this ISO OUT data endpoint"]
@@ -32495,6 +45072,29 @@ pub mod usbd {
                 Isoout(0)
             }
         }
+        impl core::fmt::Debug for Isoout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoout")
+                    .field("size", &self.size())
+                    .field("zero", &self.zero())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoout {
+                    size: u16,
+                    zero: super::vals::Zero,
+                }
+                let proxy = Isoout {
+                    size: self.size(),
+                    zero: self.zero(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32518,6 +45118,26 @@ pub mod usbd {
                 IsooutAmount(0)
             }
         }
+        impl core::fmt::Debug for IsooutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutAmount {
+                    amount: u16,
+                }
+                let proxy = IsooutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32539,6 +45159,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsooutMaxcnt {
                 IsooutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for IsooutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsooutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the split of ISO buffers"]
@@ -32565,6 +45205,26 @@ pub mod usbd {
                 Isosplit(0)
             }
         }
+        impl core::fmt::Debug for Isosplit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isosplit")
+                    .field("split", &self.split())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isosplit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isosplit {
+                    split: super::vals::Split,
+                }
+                let proxy = Isosplit {
+                    split: self.split(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls USBD peripheral low power mode during USB suspend"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32586,6 +45246,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Lowpower {
                 Lowpower(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpower")
+                    .field("lowpower", &self.lowpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpower {
+                    lowpower: super::vals::Lowpower,
+                }
+                let proxy = Lowpower {
+                    lowpower: self.lowpower(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -32655,6 +45335,38 @@ pub mod usbd {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ep0datadone_startepin0", &self.ep0datadone_startepin0())
+                    .field("ep0datadone_startepout0", &self.ep0datadone_startepout0())
+                    .field("ep0datadone_ep0status", &self.ep0datadone_ep0status())
+                    .field("endepout0_ep0status", &self.endepout0_ep0status())
+                    .field("endepout0_ep0rcvout", &self.endepout0_ep0rcvout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ep0datadone_startepin0: bool,
+                    ep0datadone_startepout0: bool,
+                    ep0datadone_ep0status: bool,
+                    endepout0_ep0status: bool,
+                    endepout0_ep0rcvout: bool,
+                }
+                let proxy = Shorts {
+                    ep0datadone_startepin0: self.ep0datadone_startepin0(),
+                    ep0datadone_startepout0: self.ep0datadone_startepout0(),
+                    ep0datadone_ep0status: self.ep0datadone_ep0status(),
+                    endepout0_ep0status: self.endepout0_ep0status(),
+                    endepout0_ep0rcvout: self.endepout0_ep0rcvout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Number of bytes received last in the data stage of this OUT endpoint"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32676,6 +45388,24 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> SizeEpout {
                 SizeEpout(0)
+            }
+        }
+        impl core::fmt::Debug for SizeEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SizeEpout")
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SizeEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SizeEpout {
+                    size: u8,
+                }
+                let proxy = SizeEpout { size: self.size() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device USB address"]
@@ -32701,6 +45431,24 @@ pub mod usbd {
                 Usbaddr(0)
             }
         }
+        impl core::fmt::Debug for Usbaddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbaddr")
+                    .field("addr", &self.addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbaddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbaddr {
+                    addr: u8,
+                }
+                let proxy = Usbaddr { addr: self.addr() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control of the USB pull-up"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32722,6 +45470,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Usbpullup {
                 Usbpullup(0)
+            }
+        }
+        impl core::fmt::Debug for Usbpullup {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbpullup")
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbpullup {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbpullup {
+                    connect: bool,
+                }
+                let proxy = Usbpullup {
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 5, MSB of wIndex"]
@@ -32747,6 +45515,26 @@ pub mod usbd {
                 Windexh(0)
             }
         }
+        impl core::fmt::Debug for Windexh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexh")
+                    .field("windexh", &self.windexh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexh {
+                    windexh: u8,
+                }
+                let proxy = Windexh {
+                    windexh: self.windexh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 4, LSB of wIndex"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32768,6 +45556,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Windexl {
                 Windexl(0)
+            }
+        }
+        impl core::fmt::Debug for Windexl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexl")
+                    .field("windexl", &self.windexl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexl {
+                    windexl: u8,
+                }
+                let proxy = Windexl {
+                    windexl: self.windexl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 7, MSB of wLength"]
@@ -32793,6 +45601,26 @@ pub mod usbd {
                 Wlengthh(0)
             }
         }
+        impl core::fmt::Debug for Wlengthh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthh")
+                    .field("wlengthh", &self.wlengthh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthh {
+                    wlengthh: u8,
+                }
+                let proxy = Wlengthh {
+                    wlengthh: self.wlengthh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 6, LSB of wLength"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32814,6 +45642,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Wlengthl {
                 Wlengthl(0)
+            }
+        }
+        impl core::fmt::Debug for Wlengthl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthl")
+                    .field("wlengthl", &self.wlengthl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthl {
+                    wlengthl: u8,
+                }
+                let proxy = Wlengthl {
+                    wlengthl: self.wlengthl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 3, MSB of wValue"]
@@ -32839,6 +45687,26 @@ pub mod usbd {
                 Wvalueh(0)
             }
         }
+        impl core::fmt::Debug for Wvalueh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvalueh")
+                    .field("wvalueh", &self.wvalueh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvalueh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvalueh {
+                    wvalueh: u8,
+                }
+                let proxy = Wvalueh {
+                    wvalueh: self.wvalueh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 2, LSB of wValue"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32862,10 +45730,31 @@ pub mod usbd {
                 Wvaluel(0)
             }
         }
+        impl core::fmt::Debug for Wvaluel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvaluel")
+                    .field("wvaluel", &self.wvaluel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvaluel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvaluel {
+                    wvaluel: u8,
+                }
+                let proxy = Wvaluel {
+                    wvaluel: self.wvaluel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Brequest {
             #[doc = "Standard request GET_STATUS"]
             STD_GET_STATUS = 0x0,
@@ -33174,6 +46063,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Getstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("NOT_HALTED"),
+                    0x01 => f.write_str("HALTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Getstatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "NOT_HALTED"),
+                    0x01 => defmt::write!(f, "HALTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Getstatus {
             #[inline(always)]
             fn from(val: u16) -> Getstatus {
@@ -33187,7 +46095,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Io {
             #[doc = "Selects OUT endpoint"]
             OUT = 0x0,
@@ -33217,7 +46126,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lowpower {
             #[doc = "Software must write this value to exit low power mode and before performing a remote wake-up"]
             FORCE_NORMAL = 0x0,
@@ -33267,6 +46177,29 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Recipient {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DEVICE"),
+                    0x01 => f.write_str("INTERFACE"),
+                    0x02 => f.write_str("ENDPOINT"),
+                    0x03 => f.write_str("OTHER"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Recipient {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DEVICE"),
+                    0x01 => defmt::write!(f, "INTERFACE"),
+                    0x02 => defmt::write!(f, "ENDPOINT"),
+                    0x03 => defmt::write!(f, "OTHER"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Recipient {
             #[inline(always)]
             fn from(val: u8) -> Recipient {
@@ -33280,7 +46213,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Response {
             #[doc = "Endpoint does not respond in that case"]
             NO_RESP = 0x0,
@@ -33326,6 +46260,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Split {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ONE_DIR"),
+                    0x80 => f.write_str("HALF_IN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Split {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ONE_DIR"),
+                    0x80 => defmt::write!(f, "HALF_IN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Split {
             #[inline(always)]
             fn from(val: u16) -> Split {
@@ -33357,6 +46310,27 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("RESUME"),
+                    0x02 => f.write_str("J"),
+                    0x04 => f.write_str("K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "RESUME"),
+                    0x02 => defmt::write!(f, "J"),
+                    0x04 => defmt::write!(f, "K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for State {
             #[inline(always)]
             fn from(val: u8) -> State {
@@ -33370,7 +46344,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Type {
             #[doc = "Standard"]
             STANDARD = 0x0,
@@ -33403,7 +46378,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Value {
             #[doc = "No action on data toggle when writing the register with this value"]
             NOP = 0x0,
@@ -33436,7 +46412,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Zero {
             #[doc = "No zero-length data received, use value in SIZE"]
             NORMAL = 0x0,
@@ -33571,6 +46548,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33592,6 +46592,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -33621,6 +46641,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33643,6 +46704,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -33672,6 +46749,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33695,10 +46813,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatus", &self.runstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatus: bool,
+                }
+                let proxy = Runstatus {
+                    runstatus: self.runstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -33742,6 +46881,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -33755,7 +46911,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf5340-app/pac.rs
+++ b/src/chips/nrf5340-app/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - FPU"]
     FPU = 0,
@@ -655,6 +656,26 @@ pub mod cache {
                 Debuglock(0)
             }
         }
+        impl core::fmt::Debug for Debuglock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Debuglock")
+                    .field("debuglock", &self.debuglock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Debuglock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Debuglock {
+                    debuglock: bool,
+                }
+                let proxy = Debuglock {
+                    debuglock: self.debuglock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable cache."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -676,6 +697,26 @@ pub mod cache {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Erase the cache."]
@@ -701,6 +742,26 @@ pub mod cache {
                 Erase(0)
             }
         }
+        impl core::fmt::Debug for Erase {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erase")
+                    .field("erase", &self.erase())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erase {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erase {
+                    erase: bool,
+                }
+                let proxy = Erase {
+                    erase: self.erase(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Cache erase status."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -722,6 +783,26 @@ pub mod cache {
             #[inline(always)]
             fn default() -> Erasestatus {
                 Erasestatus(0)
+            }
+        }
+        impl core::fmt::Debug for Erasestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasestatus")
+                    .field("erasestatus", &self.erasestatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasestatus {
+                    erasestatus: super::vals::Erasestatus,
+                }
+                let proxy = Erasestatus {
+                    erasestatus: self.erasestatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Invalidate the cache."]
@@ -747,6 +828,26 @@ pub mod cache {
                 Invalidate(0)
             }
         }
+        impl core::fmt::Debug for Invalidate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Invalidate")
+                    .field("invalidate", &self.invalidate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Invalidate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Invalidate {
+                    invalidate: bool,
+                }
+                let proxy = Invalidate {
+                    invalidate: self.invalidate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Cache mode. Switching from Cache to Ram mode causes the RAM to be cleared. Switching from RAM to Cache mode causes the cache to be invalidated."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -768,6 +869,22 @@ pub mod cache {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear the profiling counters."]
@@ -793,6 +910,26 @@ pub mod cache {
                 Profilingclear(0)
             }
         }
+        impl core::fmt::Debug for Profilingclear {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Profilingclear")
+                    .field("clear", &self.clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Profilingclear {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Profilingclear {
+                    clear: bool,
+                }
+                let proxy = Profilingclear {
+                    clear: self.clear(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the profiling counters."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -814,6 +951,26 @@ pub mod cache {
             #[inline(always)]
             fn default() -> Profilingenable {
                 Profilingenable(0)
+            }
+        }
+        impl core::fmt::Debug for Profilingenable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Profilingenable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Profilingenable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Profilingenable {
+                    enable: bool,
+                }
+                let proxy = Profilingenable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Lock cache updates. Prevents updating of cache content on cache misses, but will continue to lookup instruction/data fetches in content already present in the cache. Ignored in RAM mode."]
@@ -839,10 +996,31 @@ pub mod cache {
                 Writelock(0)
             }
         }
+        impl core::fmt::Debug for Writelock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writelock")
+                    .field("writelock", &self.writelock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writelock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writelock {
+                    writelock: bool,
+                }
+                let proxy = Writelock {
+                    writelock: self.writelock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Erasestatus {
             #[doc = "Erase is not complete or hasn't started"]
             IDLE = 0x0,
@@ -872,7 +1050,8 @@ pub mod cache {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Cache mode"]
             CACHE = 0x0,
@@ -1083,10 +1262,37 @@ pub mod cacheinfo {
                 Way(0)
             }
         }
+        impl core::fmt::Debug for Way {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Way")
+                    .field("tag", &self.tag())
+                    .field("v", &self.v())
+                    .field("mru", &self.mru())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Way {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Way {
+                    tag: u32,
+                    v: bool,
+                    mru: super::vals::Mru,
+                }
+                let proxy = Way {
+                    tag: self.tag(),
+                    v: self.v(),
+                    mru: self.mru(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mru {
             #[doc = "Way0 was most recently used"]
             WAY0 = 0x0,
@@ -1486,6 +1692,26 @@ pub mod clock {
                 Frequency(0)
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u16,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Automatic or manual control of HFCLK192M"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1507,6 +1733,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclk192malwaysrun {
                 Hfclk192malwaysrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclk192malwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclk192malwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclk192malwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclk192malwaysrun {
+                    alwaysrun: super::vals::Hfclk192malwaysrunAlwaysrun,
+                }
+                let proxy = Hfclk192malwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFCLK192M frequency configuration"]
@@ -1532,6 +1778,26 @@ pub mod clock {
                 Hfclk192mctrl(0)
             }
         }
+        impl core::fmt::Debug for Hfclk192mctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclk192mctrl")
+                    .field("hclk192m", &self.hclk192m())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclk192mctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclk192mctrl {
+                    hclk192m: super::vals::Hclk192m,
+                }
+                let proxy = Hfclk192mctrl {
+                    hclk192m: self.hclk192m(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLK192MSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1555,6 +1821,26 @@ pub mod clock {
                 Hfclk192mrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclk192mrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclk192mrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclk192mrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclk192mrun {
+                    status: bool,
+                }
+                let proxy = Hfclk192mrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for HFCLK192M"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1576,6 +1862,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclk192msrc {
                 Hfclk192msrc(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclk192msrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclk192msrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclk192msrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclk192msrc {
+                    src: super::vals::Hfclk192msrcSrc,
+                }
+                let proxy = Hfclk192msrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which HFCLK192M source is running"]
@@ -1623,6 +1927,32 @@ pub mod clock {
                 Hfclk192mstat(0)
             }
         }
+        impl core::fmt::Debug for Hfclk192mstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclk192mstat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclk192mstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclk192mstat {
+                    src: super::vals::Hfclk192mstatSrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Hfclk192mstat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Automatic or manual control of HFCLK128M/HFCLK64M"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1644,6 +1974,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkalwaysrun {
                 Hfclkalwaysrun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkalwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkalwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkalwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkalwaysrun {
+                    alwaysrun: super::vals::HfclkalwaysrunAlwaysrun,
+                }
+                let proxy = Hfclkalwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Automatic or manual control of HFCLKAUDIO"]
@@ -1669,6 +2019,26 @@ pub mod clock {
                 Hfclkaudioalwaysrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkaudioalwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkaudioalwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkaudioalwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkaudioalwaysrun {
+                    alwaysrun: super::vals::HfclkaudioalwaysrunAlwaysrun,
+                }
+                let proxy = Hfclkaudioalwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that HFCLKAUDIOSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1690,6 +2060,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkaudiorun {
                 Hfclkaudiorun(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkaudiorun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkaudiorun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkaudiorun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkaudiorun {
+                    status: bool,
+                }
+                let proxy = Hfclkaudiorun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which HFCLKAUDIO source is running"]
@@ -1726,6 +2116,29 @@ pub mod clock {
                 Hfclkaudiostat(0)
             }
         }
+        impl core::fmt::Debug for Hfclkaudiostat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkaudiostat")
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkaudiostat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkaudiostat {
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Hfclkaudiostat {
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFCLK128M frequency configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1747,6 +2160,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkctrl {
                 Hfclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkctrl")
+                    .field("hclk", &self.hclk())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkctrl {
+                    hclk: super::vals::Hclk,
+                }
+                let proxy = Hfclkctrl { hclk: self.hclk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
@@ -1772,6 +2203,26 @@ pub mod clock {
                 Hfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for HFCLK128M/HFCLK64M"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1793,6 +2244,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclksrc {
                 Hfclksrc(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclksrc {
+                    src: super::vals::HfclksrcSrc,
+                }
+                let proxy = Hfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which HFCLK128M/HFCLK64M source is running This register value in any CLOCK instance reflects status only due to configurations/actions in that CLOCK instance."]
@@ -1838,6 +2307,32 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -1907,6 +2402,38 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("hfclkaudiostarted", &self.hfclkaudiostarted())
+                    .field("hfclk192mstarted", &self.hfclk192mstarted())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    hfclkaudiostarted: bool,
+                    hfclk192mstarted: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    hfclkaudiostarted: self.hfclkaudiostarted(),
+                    hfclk192mstarted: self.hfclk192mstarted(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Automatic or manual control of LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1928,6 +2455,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkalwaysrun {
                 Lfclkalwaysrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkalwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkalwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkalwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkalwaysrun {
+                    alwaysrun: super::vals::LfclkalwaysrunAlwaysrun,
+                }
+                let proxy = Lfclkalwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
@@ -1953,6 +2500,26 @@ pub mod clock {
                 Lfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1976,6 +2543,24 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1997,6 +2582,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which LFCLK source is running This register value in any CLOCK instance reflects status only due to configurations/actions in that CLOCK instance."]
@@ -2044,10 +2647,37 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hclk {
             #[doc = "Divide HFCLK by 1"]
             DIV1 = 0x0,
@@ -2079,7 +2709,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hclk192m {
             #[doc = "Divide HFCLK192M by 1"]
             DIV1 = 0x0,
@@ -2112,7 +2743,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hfclk192malwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -2142,7 +2774,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hfclk192msrcSrc {
             #[doc = "HFCLK192MSTART task starts HFINT oscillator"]
             HFINT = 0x0,
@@ -2172,7 +2805,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hfclk192mstatSrc {
             #[doc = "Clock source: HFINT - on-chip oscillator"]
             HFINT = 0x0,
@@ -2202,7 +2836,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkalwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -2232,7 +2867,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkaudioalwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -2262,7 +2898,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclksrcSrc {
             #[doc = "HFCLKSTART task starts HFINT oscillator"]
             HFINT = 0x0,
@@ -2292,7 +2929,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "Clock source: HFINT - 128 MHz on-chip oscillator"]
             HFINT = 0x0,
@@ -2322,7 +2960,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LfclkalwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -2352,7 +2991,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             _RESERVED_0 = 0x0,
             #[doc = "32.768 kHz RC oscillator"]
@@ -2654,6 +3294,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2677,6 +3337,26 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2698,6 +3378,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -2756,6 +3452,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current source select on analog input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2777,6 +3502,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Isource {
                 Isource(0)
+            }
+        }
+        impl core::fmt::Debug for Isource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isource")
+                    .field("isource", &self.isource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isource {
+                    isource: super::vals::Isource,
+                }
+                let proxy = Isource {
+                    isource: self.isource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mode configuration"]
@@ -2813,6 +3558,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2834,6 +3602,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference source select for single-ended mode"]
@@ -2859,6 +3643,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2880,6 +3684,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -2949,6 +3773,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2983,10 +3839,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -3018,7 +3898,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -3060,7 +3941,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -3090,7 +3972,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Isource {
             #[doc = "Current source disabled"]
             OFF = 0x0,
@@ -3124,7 +4007,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -3154,7 +4038,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -3196,7 +4081,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference (VDD &gt;= 1.7 V)"]
             INT1V2 = 0x0,
@@ -3235,7 +4121,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -3265,7 +4152,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -3344,6 +4232,26 @@ pub mod cryptocell {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -3534,6 +4442,26 @@ pub mod cti {
                 Cidr0(0)
             }
         }
+        impl core::fmt::Debug for Cidr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr0")
+                    .field("prmbl_0", &self.prmbl_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr0 {
+                    prmbl_0: super::vals::Prmbl0,
+                }
+                let proxy = Cidr0 {
+                    prmbl_0: self.prmbl_0(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID1 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3568,6 +4496,29 @@ pub mod cti {
                 Cidr1(0)
             }
         }
+        impl core::fmt::Debug for Cidr1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr1")
+                    .field("prmbl_1", &self.prmbl_1())
+                    .field("class", &self.class())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr1 {
+                    prmbl_1: super::vals::Prmbl1,
+                    class: super::vals::Class,
+                }
+                let proxy = Cidr1 {
+                    prmbl_1: self.prmbl_1(),
+                    class: self.class(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID2 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3591,6 +4542,26 @@ pub mod cti {
                 Cidr2(0)
             }
         }
+        impl core::fmt::Debug for Cidr2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr2")
+                    .field("prmbl_2", &self.prmbl_2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr2 {
+                    prmbl_2: super::vals::Prmbl2,
+                }
+                let proxy = Cidr2 {
+                    prmbl_2: self.prmbl_2(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID3 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3612,6 +4583,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Cidr3 {
                 Cidr3(0)
+            }
+        }
+        impl core::fmt::Debug for Cidr3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr3")
+                    .field("prmbl_3", &self.prmbl_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr3 {
+                    prmbl_3: super::vals::Prmbl3,
+                }
+                let proxy = Cidr3 {
+                    prmbl_3: self.prmbl_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Application Trigger Clear register"]
@@ -3670,6 +4661,35 @@ pub mod cti {
                 Ctiappclear(0)
             }
         }
+        impl core::fmt::Debug for Ctiappclear {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiappclear")
+                    .field("appclear_0", &self.appclear_0())
+                    .field("appclear_1", &self.appclear_1())
+                    .field("appclear_2", &self.appclear_2())
+                    .field("appclear_3", &self.appclear_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiappclear {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiappclear {
+                    appclear_0: bool,
+                    appclear_1: bool,
+                    appclear_2: bool,
+                    appclear_3: bool,
+                }
+                let proxy = Ctiappclear {
+                    appclear_0: self.appclear_0(),
+                    appclear_1: self.appclear_1(),
+                    appclear_2: self.appclear_2(),
+                    appclear_3: self.appclear_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Application Pulse register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3724,6 +4744,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiapppulse {
                 Ctiapppulse(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiapppulse {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiapppulse")
+                    .field("appulse_0", &self.appulse_0())
+                    .field("appulse_1", &self.appulse_1())
+                    .field("appulse_2", &self.appulse_2())
+                    .field("appulse_3", &self.appulse_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiapppulse {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiapppulse {
+                    appulse_0: bool,
+                    appulse_1: bool,
+                    appulse_2: bool,
+                    appulse_3: bool,
+                }
+                let proxy = Ctiapppulse {
+                    appulse_0: self.appulse_0(),
+                    appulse_1: self.appulse_1(),
+                    appulse_2: self.appulse_2(),
+                    appulse_3: self.appulse_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Application Trigger Set register"]
@@ -3782,6 +4831,35 @@ pub mod cti {
                 Ctiappset(0)
             }
         }
+        impl core::fmt::Debug for Ctiappset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiappset")
+                    .field("appset_0", &self.appset_0())
+                    .field("appset_1", &self.appset_1())
+                    .field("appset_2", &self.appset_2())
+                    .field("appset_3", &self.appset_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiappset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiappset {
+                    appset_0: super::vals::Appset0,
+                    appset_1: super::vals::Appset1,
+                    appset_2: super::vals::Appset2,
+                    appset_3: super::vals::Appset3,
+                }
+                let proxy = Ctiappset {
+                    appset_0: self.appset_0(),
+                    appset_1: self.appset_1(),
+                    appset_2: self.appset_2(),
+                    appset_3: self.appset_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Channel In Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3838,6 +4916,35 @@ pub mod cti {
                 Ctichinstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctichinstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctichinstatus")
+                    .field("ctichinstatus_0", &self.ctichinstatus_0())
+                    .field("ctichinstatus_1", &self.ctichinstatus_1())
+                    .field("ctichinstatus_2", &self.ctichinstatus_2())
+                    .field("ctichinstatus_3", &self.ctichinstatus_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctichinstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctichinstatus {
+                    ctichinstatus_0: bool,
+                    ctichinstatus_1: bool,
+                    ctichinstatus_2: bool,
+                    ctichinstatus_3: bool,
+                }
+                let proxy = Ctichinstatus {
+                    ctichinstatus_0: self.ctichinstatus_0(),
+                    ctichinstatus_1: self.ctichinstatus_1(),
+                    ctichinstatus_2: self.ctichinstatus_2(),
+                    ctichinstatus_3: self.ctichinstatus_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Control register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3859,6 +4966,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Cticontrol {
                 Cticontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Cticontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cticontrol")
+                    .field("glben", &self.glben())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cticontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cticontrol {
+                    glben: bool,
+                }
+                let proxy = Cticontrol {
+                    glben: self.glben(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable CTI Channel Gate register"]
@@ -3917,6 +5044,35 @@ pub mod cti {
                 Ctigate(0)
             }
         }
+        impl core::fmt::Debug for Ctigate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctigate")
+                    .field("ctigateen_0", &self.ctigateen_0())
+                    .field("ctigateen_1", &self.ctigateen_1())
+                    .field("ctigateen_2", &self.ctigateen_2())
+                    .field("ctigateen_3", &self.ctigateen_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctigate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctigate {
+                    ctigateen_0: bool,
+                    ctigateen_1: bool,
+                    ctigateen_2: bool,
+                    ctigateen_3: bool,
+                }
+                let proxy = Ctigate {
+                    ctigateen_0: self.ctigateen_0(),
+                    ctigateen_1: self.ctigateen_1(),
+                    ctigateen_2: self.ctigateen_2(),
+                    ctigateen_3: self.ctigateen_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: CTI Trigger input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3971,6 +5127,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiinen {
                 Ctiinen(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiinen")
+                    .field("triginen_0", &self.triginen_0())
+                    .field("triginen_1", &self.triginen_1())
+                    .field("triginen_2", &self.triginen_2())
+                    .field("triginen_3", &self.triginen_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiinen {
+                    triginen_0: bool,
+                    triginen_1: bool,
+                    triginen_2: bool,
+                    triginen_3: bool,
+                }
+                let proxy = Ctiinen {
+                    triginen_0: self.triginen_0(),
+                    triginen_1: self.triginen_1(),
+                    triginen_2: self.triginen_2(),
+                    triginen_3: self.triginen_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Interrupt Acknowledge register"]
@@ -4073,6 +5258,47 @@ pub mod cti {
                 Ctiintack(0)
             }
         }
+        impl core::fmt::Debug for Ctiintack {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiintack")
+                    .field("debugreq", &self.debugreq())
+                    .field("cpurestart", &self.cpurestart())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .field("etmevtin0", &self.etmevtin0())
+                    .field("etmevtin1", &self.etmevtin1())
+                    .field("etmevtin2", &self.etmevtin2())
+                    .field("etmevtin3", &self.etmevtin3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiintack {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiintack {
+                    debugreq: bool,
+                    cpurestart: bool,
+                    unused0: bool,
+                    unused1: bool,
+                    etmevtin0: bool,
+                    etmevtin1: bool,
+                    etmevtin2: bool,
+                    etmevtin3: bool,
+                }
+                let proxy = Ctiintack {
+                    debugreq: self.debugreq(),
+                    cpurestart: self.cpurestart(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                    etmevtin0: self.etmevtin0(),
+                    etmevtin1: self.etmevtin1(),
+                    etmevtin2: self.etmevtin2(),
+                    etmevtin3: self.etmevtin3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: CTI Trigger output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4127,6 +5353,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiouten {
                 Ctiouten(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiouten")
+                    .field("trigouten_0", &self.trigouten_0())
+                    .field("trigouten_1", &self.trigouten_1())
+                    .field("trigouten_2", &self.trigouten_2())
+                    .field("trigouten_3", &self.trigouten_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiouten {
+                    trigouten_0: bool,
+                    trigouten_1: bool,
+                    trigouten_2: bool,
+                    trigouten_3: bool,
+                }
+                let proxy = Ctiouten {
+                    trigouten_0: self.trigouten_0(),
+                    trigouten_1: self.trigouten_1(),
+                    trigouten_2: self.trigouten_2(),
+                    trigouten_3: self.trigouten_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Trigger In Status register"]
@@ -4229,6 +5484,47 @@ pub mod cti {
                 Ctitriginstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctitriginstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctitriginstatus")
+                    .field("cpuhalted", &self.cpuhalted())
+                    .field("dwtcompout0", &self.dwtcompout0())
+                    .field("dwtcompout1", &self.dwtcompout1())
+                    .field("dwtcompout2", &self.dwtcompout2())
+                    .field("etmevtout0", &self.etmevtout0())
+                    .field("etmevtout1", &self.etmevtout1())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctitriginstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctitriginstatus {
+                    cpuhalted: bool,
+                    dwtcompout0: bool,
+                    dwtcompout1: bool,
+                    dwtcompout2: bool,
+                    etmevtout0: bool,
+                    etmevtout1: bool,
+                    unused0: bool,
+                    unused1: bool,
+                }
+                let proxy = Ctitriginstatus {
+                    cpuhalted: self.cpuhalted(),
+                    dwtcompout0: self.dwtcompout0(),
+                    dwtcompout1: self.dwtcompout1(),
+                    dwtcompout2: self.dwtcompout2(),
+                    etmevtout0: self.etmevtout0(),
+                    etmevtout1: self.etmevtout1(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Trigger Out Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4329,6 +5625,47 @@ pub mod cti {
                 Ctitrigoutstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctitrigoutstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctitrigoutstatus")
+                    .field("debugreq", &self.debugreq())
+                    .field("cpurestart", &self.cpurestart())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .field("etmevtin0", &self.etmevtin0())
+                    .field("etmevtin1", &self.etmevtin1())
+                    .field("etmevtin2", &self.etmevtin2())
+                    .field("etmevtin3", &self.etmevtin3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctitrigoutstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctitrigoutstatus {
+                    debugreq: bool,
+                    cpurestart: bool,
+                    unused0: bool,
+                    unused1: bool,
+                    etmevtin0: bool,
+                    etmevtin1: bool,
+                    etmevtin2: bool,
+                    etmevtin3: bool,
+                }
+                let proxy = Ctitrigoutstatus {
+                    debugreq: self.debugreq(),
+                    cpurestart: self.cpurestart(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                    etmevtin0: self.etmevtin0(),
+                    etmevtin1: self.etmevtin1(),
+                    etmevtin2: self.etmevtin2(),
+                    etmevtin3: self.etmevtin3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device Architecture register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4350,6 +5687,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Devarch {
                 Devarch(0)
+            }
+        }
+        impl core::fmt::Debug for Devarch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devarch")
+                    .field("architecture", &self.architecture())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devarch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devarch {
+                    architecture: bool,
+                }
+                let proxy = Devarch {
+                    architecture: self.architecture(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device Configuration register"]
@@ -4397,6 +5754,32 @@ pub mod cti {
                 Devid(0)
             }
         }
+        impl core::fmt::Debug for Devid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devid")
+                    .field("extmuxnum", &self.extmuxnum())
+                    .field("numtrig", &self.numtrig())
+                    .field("numch", &self.numch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devid {
+                    extmuxnum: u8,
+                    numtrig: u8,
+                    numch: u8,
+                }
+                let proxy = Devid {
+                    extmuxnum: self.extmuxnum(),
+                    numtrig: self.numtrig(),
+                    numch: self.numch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device Type Identifier register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4431,6 +5814,29 @@ pub mod cti {
                 Devtype(0)
             }
         }
+        impl core::fmt::Debug for Devtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devtype")
+                    .field("major", &self.major())
+                    .field("sub", &self.sub())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devtype {
+                    major: super::vals::Major,
+                    sub: super::vals::Sub,
+                }
+                let proxy = Devtype {
+                    major: self.major(),
+                    sub: self.sub(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral ID0 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4452,6 +5858,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr0 {
                 Pidr0(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr0")
+                    .field("part_0", &self.part_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr0 {
+                    part_0: super::vals::Part0,
+                }
+                let proxy = Pidr0 {
+                    part_0: self.part_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID1 Register"]
@@ -4486,6 +5912,29 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr1 {
                 Pidr1(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr1")
+                    .field("part_1", &self.part_1())
+                    .field("des_0", &self.des_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr1 {
+                    part_1: super::vals::Part1,
+                    des_0: super::vals::Des0,
+                }
+                let proxy = Pidr1 {
+                    part_1: self.part_1(),
+                    des_0: self.des_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID2 Register"]
@@ -4533,6 +5982,32 @@ pub mod cti {
                 Pidr2(0)
             }
         }
+        impl core::fmt::Debug for Pidr2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr2")
+                    .field("des_1", &self.des_1())
+                    .field("jedec", &self.jedec())
+                    .field("revision", &self.revision())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr2 {
+                    des_1: super::vals::Des1,
+                    jedec: bool,
+                    revision: super::vals::Revision,
+                }
+                let proxy = Pidr2 {
+                    des_1: self.des_1(),
+                    jedec: self.jedec(),
+                    revision: self.revision(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral ID3 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4565,6 +6040,29 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr3 {
                 Pidr3(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr3")
+                    .field("cmod", &self.cmod())
+                    .field("revand", &self.revand())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr3 {
+                    cmod: super::vals::Cmod,
+                    revand: super::vals::Revand,
+                }
+                let proxy = Pidr3 {
+                    cmod: self.cmod(),
+                    revand: self.revand(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID4 Register"]
@@ -4601,10 +6099,34 @@ pub mod cti {
                 Pidr4(0)
             }
         }
+        impl core::fmt::Debug for Pidr4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr4")
+                    .field("des_2", &self.des_2())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr4 {
+                    des_2: super::vals::Des2,
+                    size: u8,
+                }
+                let proxy = Pidr4 {
+                    des_2: self.des_2(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset0 {
             #[doc = "Application trigger 0 is inactive."]
             INACTIVE = 0x0,
@@ -4634,7 +6156,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset1 {
             #[doc = "Application trigger 1 is inactive."]
             INACTIVE = 0x0,
@@ -4664,7 +6187,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset2 {
             #[doc = "Application trigger 2 is inactive."]
             INACTIVE = 0x0,
@@ -4694,7 +6218,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset3 {
             #[doc = "Application trigger 3 is inactive."]
             INACTIVE = 0x0,
@@ -4724,7 +6249,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Class {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -4767,7 +6293,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cmod {
             #[doc = "Indicates that the customer has not modified this component."]
             UNMODIFIED = 0x0,
@@ -4810,7 +6337,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des0 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -4853,7 +6381,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des1 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -4888,7 +6417,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des2 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -4931,7 +6461,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Major {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -4988,6 +6519,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x21 => f.write_str("PARTNUMBER_L"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x21 => defmt::write!(f, "PARTNUMBER_L"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Part0 {
             #[inline(always)]
             fn from(val: u8) -> Part0 {
@@ -5001,7 +6549,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Part1 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -5058,6 +6607,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0d => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0d => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl0 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl0 {
@@ -5071,7 +6637,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prmbl1 {
             #[doc = "Bits\\[11:8\\] of the identification code."]
             VALUE = 0x0,
@@ -5128,6 +6695,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x05 => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl2 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x05 => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl2 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl2 {
@@ -5155,6 +6739,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xb1 => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl3 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xb1 => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl3 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl3 {
@@ -5168,7 +6769,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Revand {
             #[doc = "Indicates that there are no errata fixes to this component."]
             NO_ERRATA = 0x0,
@@ -5211,7 +6813,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Revision {
             #[doc = "This device is at r0p0"]
             REV0P0 = 0x0,
@@ -5254,7 +6857,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sub {
             _RESERVED_0 = 0x0,
             #[doc = "Indicates that this component is a sub-triggering component."]
@@ -5485,6 +7089,24 @@ pub mod ctrlapperi {
                 ApprotectLock(0)
             }
         }
+        impl core::fmt::Debug for ApprotectLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectLock {
+                    lock: bool,
+                }
+                let proxy = ApprotectLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register locks the ERASEPROTECT.DISABLE register from being written until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5506,6 +7128,24 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> EraseprotectLock {
                 EraseprotectLock(0)
+            }
+        }
+        impl core::fmt::Debug for EraseprotectLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectLock {
+                    lock: bool,
+                }
+                let proxy = EraseprotectLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This register shows a status that indicates if data sent from the debugger to the CPU has been read."]
@@ -5531,6 +7171,26 @@ pub mod ctrlapperi {
                 Rxstatus(0)
             }
         }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register locks the SECUREAPPROTECT.DISABLE register from being written until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5552,6 +7212,24 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> SecureapprotectLock {
                 SecureapprotectLock(0)
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectLock {
+                    lock: bool,
+                }
+                let proxy = SecureapprotectLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status bits for CTRL-AP peripheral."]
@@ -5599,6 +7277,32 @@ pub mod ctrlapperi {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("uicrapprotect", &self.uicrapprotect())
+                    .field("uicrsecureapprotect", &self.uicrsecureapprotect())
+                    .field("dbgifacemode", &self.dbgifacemode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    uicrapprotect: super::vals::Uicrapprotect,
+                    uicrsecureapprotect: super::vals::Uicrsecureapprotect,
+                    dbgifacemode: bool,
+                }
+                let proxy = Status {
+                    uicrapprotect: self.uicrapprotect(),
+                    uicrsecureapprotect: self.uicrsecureapprotect(),
+                    dbgifacemode: self.dbgifacemode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if the data sent from the CPU to the debugger has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5622,10 +7326,31 @@ pub mod ctrlapperi {
                 Txstatus(0)
             }
         }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Uicrapprotect {
             #[doc = "APPROTECT was enabled in UICR"]
             ENABLED = 0x0,
@@ -5655,7 +7380,8 @@ pub mod ctrlapperi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Uicrsecureapprotect {
             #[doc = "SECUREAPPROTECT was enabled in UICR"]
             ENABLED = 0x0,
@@ -5817,6 +7543,26 @@ pub mod dcnf {
                 Cpuid(0)
             }
         }
+        impl core::fmt::Debug for Cpuid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cpuid")
+                    .field("cpuid", &self.cpuid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpuid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cpuid {
+                    cpuid: u8,
+                }
+                let proxy = Cpuid {
+                    cpuid: self.cpuid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Control access from master connected to AMLI master port EXTCODE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5840,6 +7586,26 @@ pub mod dcnf {
                 ExtcodeProtect(0)
             }
         }
+        impl core::fmt::Debug for ExtcodeProtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtcodeProtect")
+                    .field("slave0", &self.slave0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtcodeProtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtcodeProtect {
+                    slave0: super::vals::ExtcodeProtectSlave0,
+                }
+                let proxy = ExtcodeProtect {
+                    slave0: self.slave0(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Control access for master connected to AMLI master port EXTPERI\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5861,6 +7627,26 @@ pub mod dcnf {
             #[inline(always)]
             fn default() -> ExtperiProtect {
                 ExtperiProtect(0)
+            }
+        }
+        impl core::fmt::Debug for ExtperiProtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtperiProtect")
+                    .field("slave0", &self.slave0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtperiProtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtperiProtect {
+                    slave0: super::vals::ExtperiProtectSlave0,
+                }
+                let proxy = ExtperiProtect {
+                    slave0: self.slave0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control access from master connected to AMLI master port EXTRAM\\[n\\]"]
@@ -5963,10 +7749,52 @@ pub mod dcnf {
                 ExtramProtect(0)
             }
         }
+        impl core::fmt::Debug for ExtramProtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtramProtect")
+                    .field("slave0", &self.slave0())
+                    .field("slave1", &self.slave1())
+                    .field("slave2", &self.slave2())
+                    .field("slave3", &self.slave3())
+                    .field("slave4", &self.slave4())
+                    .field("slave5", &self.slave5())
+                    .field("slave6", &self.slave6())
+                    .field("slave7", &self.slave7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtramProtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtramProtect {
+                    slave0: super::vals::ExtramProtectSlave0,
+                    slave1: super::vals::Slave1,
+                    slave2: super::vals::Slave2,
+                    slave3: super::vals::Slave3,
+                    slave4: super::vals::Slave4,
+                    slave5: super::vals::Slave5,
+                    slave6: super::vals::Slave6,
+                    slave7: super::vals::Slave7,
+                }
+                let proxy = ExtramProtect {
+                    slave0: self.slave0(),
+                    slave1: self.slave1(),
+                    slave2: self.slave2(),
+                    slave3: self.slave3(),
+                    slave4: self.slave4(),
+                    slave5: self.slave5(),
+                    slave6: self.slave6(),
+                    slave7: self.slave7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtcodeProtectSlave0 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -5996,7 +7824,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtperiProtectSlave0 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6026,7 +7855,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtramProtectSlave0 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6056,7 +7886,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave1 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6086,7 +7917,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave2 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6116,7 +7948,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave3 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6146,7 +7979,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave4 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6176,7 +8010,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave5 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6206,7 +8041,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave6 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6236,7 +8072,8 @@ pub mod dcnf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Slave7 {
             #[doc = "Access to slave is allowed"]
             ALLOWED = 0x0,
@@ -6404,6 +8241,95 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6429,6 +8355,95 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -6525,6 +8540,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -6789,6 +8861,26 @@ pub mod ficr {
                 Codepagesize(0)
             }
         }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codepagesize")
+                    .field("codepagesize", &self.codepagesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codepagesize {
+                    codepagesize: super::vals::Codepagesize,
+                }
+                let proxy = Codepagesize {
+                    codepagesize: self.codepagesize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Code memory size"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6813,6 +8905,26 @@ pub mod ficr {
                 Codesize(0)
             }
         }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codesize")
+                    .field("codesize", &self.codesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codesize {
+                    codesize: super::vals::Codesize,
+                }
+                let proxy = Codesize {
+                    codesize: self.codesize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration identifier"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6834,6 +8946,24 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Configid {
                 Configid(0)
+            }
+        }
+        impl core::fmt::Debug for Configid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configid")
+                    .field("hwid", &self.hwid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configid {
+                    hwid: u16,
+                }
+                let proxy = Configid { hwid: self.hwid() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device type"]
@@ -6860,6 +8990,26 @@ pub mod ficr {
                 Devicetype(0)
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devicetype")
+                    .field("devicetype", &self.devicetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devicetype {
+                    devicetype: super::vals::Devicetype,
+                }
+                let proxy = Devicetype {
+                    devicetype: self.devicetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Flash variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6882,6 +9032,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Flash {
                 Flash(0)
+            }
+        }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Package option"]
@@ -6908,6 +9078,26 @@ pub mod ficr {
                 Package(0)
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part code"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6932,6 +9122,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6954,6 +9160,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Ram {
                 Ram(0)
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -7012,6 +9234,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7066,6 +9317,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -7124,6 +9404,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7180,6 +9489,35 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part Variant, Hardware version and Production configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7202,6 +9540,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Variant {
                 Variant(0)
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "XOSC32M capacitor selection trim values"]
@@ -7238,6 +9596,29 @@ pub mod ficr {
                 Xosc32mtrim(0)
             }
         }
+        impl core::fmt::Debug for Xosc32mtrim {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32mtrim")
+                    .field("slope", &self.slope())
+                    .field("offset", &self.offset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32mtrim {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32mtrim {
+                    slope: u8,
+                    offset: u8,
+                }
+                let proxy = Xosc32mtrim {
+                    slope: self.slope(),
+                    offset: self.offset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -7253,6 +9634,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x1000 => f.write_str("K4096"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x1000 => defmt::write!(f, "K4096"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codepagesize {
@@ -7282,6 +9680,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("P256"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "P256"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Codesize {
             #[inline(always)]
             fn from(val: u32) -> Codesize {
@@ -7309,6 +9724,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DIE"),
+                    0xffff_ffff => f.write_str("FPGA"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DIE"),
+                    0xffff_ffff => defmt::write!(f, "FPGA"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Devicetype {
@@ -7348,6 +9782,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0x0400 => f.write_str("K1024"),
+                    0x0800 => f.write_str("K2048"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0x0400 => defmt::write!(f, "K1024"),
+                    0x0800 => defmt::write!(f, "K2048"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -7379,6 +9840,27 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QK"),
+                    0x2005 => f.write_str("CL"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QK"),
+                    0x2005 => defmt::write!(f, "CL"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -7406,6 +9888,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5340 => f.write_str("N5340"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5340 => defmt::write!(f, "N5340"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Part {
@@ -7447,6 +9948,35 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -7476,6 +10006,27 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x434c_4141 => f.write_str("CLAA"),
+                    0x514b_4141 => f.write_str("QKAA"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x434c_4141 => defmt::write!(f, "CLAA"),
+                    0x514b_4141 => defmt::write!(f, "QKAA"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -7634,6 +10185,41 @@ pub mod fpu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("invalidoperation", &self.invalidoperation())
+                    .field("dividebyzero", &self.dividebyzero())
+                    .field("overflow", &self.overflow())
+                    .field("underflow", &self.underflow())
+                    .field("inexact", &self.inexact())
+                    .field("denormalinput", &self.denormalinput())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    invalidoperation: bool,
+                    dividebyzero: bool,
+                    overflow: bool,
+                    underflow: bool,
+                    inexact: bool,
+                    denormalinput: bool,
+                }
+                let proxy = Int {
+                    invalidoperation: self.invalidoperation(),
+                    dividebyzero: self.dividebyzero(),
+                    overflow: self.overflow(),
+                    underflow: self.underflow(),
+                    inexact: self.inexact(),
+                    denormalinput: self.denormalinput(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod gpio {
@@ -7739,6 +10325,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select between default DETECT signal behavior and LDETECT mode (For secure pin only)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7760,6 +10366,26 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> DetectmodeSec {
                 DetectmodeSec(0)
+            }
+        }
+        impl core::fmt::Debug for DetectmodeSec {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DetectmodeSec")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DetectmodeSec {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DetectmodeSec {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = DetectmodeSec {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Direction of GPIO pins"]
@@ -7789,6 +10415,95 @@ pub mod gpio {
                 Dir(0)
             }
         }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR clear register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7814,6 +10529,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirclr {
                 Dirclr(0)
+            }
+        }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR set register"]
@@ -7843,6 +10647,95 @@ pub mod gpio {
                 Dirset(0)
             }
         }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7868,6 +10761,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> In {
                 In(0)
+            }
+        }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
@@ -7897,6 +10879,95 @@ pub mod gpio {
                 Latch(0)
             }
         }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7922,6 +10993,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Out {
                 Out(0)
+            }
+        }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear individual bits in GPIO port"]
@@ -7951,6 +11111,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7976,6 +11225,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -8058,10 +11396,46 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .field("mcusel", &self.mcusel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                    mcusel: super::vals::Mcusel,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                    mcusel: self.mcusel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -8091,7 +11465,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -8121,7 +11496,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -8172,7 +11548,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -8202,7 +11579,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mcusel {
             #[doc = "Application MCU"]
             APP_MCU = 0x0,
@@ -8240,7 +11618,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -8273,7 +11652,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -8488,6 +11868,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: bool,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8526,6 +11938,50 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latency selection for Event mode (MODE=Event) with rising or falling edge detection on the pin."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8549,10 +12005,31 @@ pub mod gpiote {
                 Latency(0)
             }
         }
+        impl core::fmt::Debug for Latency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latency")
+                    .field("latency", &self.latency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latency {
+                    latency: super::vals::Latency,
+                }
+                let proxy = Latency {
+                    latency: self.latency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Latency {
             #[doc = "Low power setting, for signals with minimum hold time tGPIOTE,HOLD,LP; refer to Electrical specification section"]
             LOW_POWER = 0x0,
@@ -8582,7 +12059,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -8615,7 +12093,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -8645,7 +12124,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -9025,6 +12505,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9046,6 +12546,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source selection for the I2S module"]
@@ -9082,6 +12602,29 @@ pub mod i2s {
                 Clkconfig(0)
             }
         }
+        impl core::fmt::Debug for Clkconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkconfig")
+                    .field("clksrc", &self.clksrc())
+                    .field("bypass", &self.bypass())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkconfig {
+                    clksrc: super::vals::Clksrc,
+                    bypass: bool,
+                }
+                let proxy = Clkconfig {
+                    clksrc: self.clksrc(),
+                    bypass: self.bypass(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable I2S module"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9105,6 +12648,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9126,6 +12689,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -9184,6 +12767,35 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .field("framestart", &self.framestart())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                    framestart: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                    framestart: self.framestart(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9207,6 +12819,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9228,6 +12860,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I2S clock generator control"]
@@ -9254,6 +12906,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9275,6 +12947,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio"]
@@ -9300,6 +12988,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9321,6 +13029,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width"]
@@ -9346,6 +13070,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9369,10 +13113,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -9402,7 +13163,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -9435,7 +13197,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clksrc {
             #[doc = "32MHz peripheral clock"]
             PCLK32M = 0x0,
@@ -9465,7 +13228,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -9543,6 +13307,57 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    0x2800_0000 => f.write_str("_32MDIV6"),
+                    0x3000_0000 => f.write_str("_32MDIV5"),
+                    0x4000_0000 => f.write_str("_32MDIV4"),
+                    0x5000_0000 => f.write_str("_32MDIV3"),
+                    0x8000_0000 => f.write_str("_32MDIV2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    0x2800_0000 => defmt::write!(f, "_32MDIV6"),
+                    0x3000_0000 => defmt::write!(f, "_32MDIV5"),
+                    0x4000_0000 => defmt::write!(f, "_32MDIV4"),
+                    0x5000_0000 => defmt::write!(f, "_32MDIV3"),
+                    0x8000_0000 => defmt::write!(f, "_32MDIV2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -9556,7 +13371,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -9586,7 +13402,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -9637,7 +13454,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit sample."]
             _8BIT = 0x0,
@@ -9961,6 +13779,71 @@ pub mod ipc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("receive0", &self.receive0())
+                    .field("receive1", &self.receive1())
+                    .field("receive2", &self.receive2())
+                    .field("receive3", &self.receive3())
+                    .field("receive4", &self.receive4())
+                    .field("receive5", &self.receive5())
+                    .field("receive6", &self.receive6())
+                    .field("receive7", &self.receive7())
+                    .field("receive8", &self.receive8())
+                    .field("receive9", &self.receive9())
+                    .field("receive10", &self.receive10())
+                    .field("receive11", &self.receive11())
+                    .field("receive12", &self.receive12())
+                    .field("receive13", &self.receive13())
+                    .field("receive14", &self.receive14())
+                    .field("receive15", &self.receive15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    receive0: bool,
+                    receive1: bool,
+                    receive2: bool,
+                    receive3: bool,
+                    receive4: bool,
+                    receive5: bool,
+                    receive6: bool,
+                    receive7: bool,
+                    receive8: bool,
+                    receive9: bool,
+                    receive10: bool,
+                    receive11: bool,
+                    receive12: bool,
+                    receive13: bool,
+                    receive14: bool,
+                    receive15: bool,
+                }
+                let proxy = Int {
+                    receive0: self.receive0(),
+                    receive1: self.receive1(),
+                    receive2: self.receive2(),
+                    receive3: self.receive3(),
+                    receive4: self.receive4(),
+                    receive5: self.receive5(),
+                    receive6: self.receive6(),
+                    receive7: self.receive7(),
+                    receive8: self.receive8(),
+                    receive9: self.receive9(),
+                    receive10: self.receive10(),
+                    receive11: self.receive11(),
+                    receive12: self.receive12(),
+                    receive13: self.receive13(),
+                    receive14: self.receive14(),
+                    receive15: self.receive15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Receive event configuration for EVENTS_RECEIVE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10147,6 +14030,71 @@ pub mod ipc {
             #[inline(always)]
             fn default() -> ReceiveCnf {
                 ReceiveCnf(0)
+            }
+        }
+        impl core::fmt::Debug for ReceiveCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReceiveCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .field("chen8", &self.chen8())
+                    .field("chen9", &self.chen9())
+                    .field("chen10", &self.chen10())
+                    .field("chen11", &self.chen11())
+                    .field("chen12", &self.chen12())
+                    .field("chen13", &self.chen13())
+                    .field("chen14", &self.chen14())
+                    .field("chen15", &self.chen15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReceiveCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReceiveCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                    chen8: bool,
+                    chen9: bool,
+                    chen10: bool,
+                    chen11: bool,
+                    chen12: bool,
+                    chen13: bool,
+                    chen14: bool,
+                    chen15: bool,
+                }
+                let proxy = ReceiveCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                    chen8: self.chen8(),
+                    chen9: self.chen9(),
+                    chen10: self.chen10(),
+                    chen11: self.chen11(),
+                    chen12: self.chen12(),
+                    chen13: self.chen13(),
+                    chen14: self.chen14(),
+                    chen15: self.chen15(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Send event configuration for TASKS_SEND\\[n\\]"]
@@ -10337,6 +14285,71 @@ pub mod ipc {
                 SendCnf(0)
             }
         }
+        impl core::fmt::Debug for SendCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SendCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .field("chen8", &self.chen8())
+                    .field("chen9", &self.chen9())
+                    .field("chen10", &self.chen10())
+                    .field("chen11", &self.chen11())
+                    .field("chen12", &self.chen12())
+                    .field("chen13", &self.chen13())
+                    .field("chen14", &self.chen14())
+                    .field("chen15", &self.chen15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SendCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SendCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                    chen8: bool,
+                    chen9: bool,
+                    chen10: bool,
+                    chen11: bool,
+                    chen12: bool,
+                    chen13: bool,
+                    chen14: bool,
+                    chen15: bool,
+                }
+                let proxy = SendCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                    chen8: self.chen8(),
+                    chen9: self.chen9(),
+                    chen10: self.chen10(),
+                    chen11: self.chen11(),
+                    chen12: self.chen12(),
+                    chen13: self.chen13(),
+                    chen14: self.chen14(),
+                    chen15: self.chen15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod kmu {
@@ -10455,6 +14468,32 @@ pub mod kmu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("keyslot_pushed", &self.keyslot_pushed())
+                    .field("keyslot_revoked", &self.keyslot_revoked())
+                    .field("keyslot_error", &self.keyslot_error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    keyslot_pushed: bool,
+                    keyslot_revoked: bool,
+                    keyslot_error: bool,
+                }
+                let proxy = Int {
+                    keyslot_pushed: self.keyslot_pushed(),
+                    keyslot_revoked: self.keyslot_revoked(),
+                    keyslot_error: self.keyslot_error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select key slot to be read over AHB or pushed over secure APB when TASKS_PUSH_KEYSLOT is started"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10476,6 +14515,24 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Selectkeyslot {
                 Selectkeyslot(0)
+            }
+        }
+        impl core::fmt::Debug for Selectkeyslot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selectkeyslot")
+                    .field("id", &self.id())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selectkeyslot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selectkeyslot {
+                    id: u8,
+                }
+                let proxy = Selectkeyslot { id: self.id() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status bits for KMU operation"]
@@ -10510,6 +14567,29 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Status {
                 Status(0)
+            }
+        }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("selected", &self.selected())
+                    .field("blocked", &self.blocked())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    selected: bool,
+                    blocked: bool,
+                }
+                let proxy = Status {
+                    selected: self.selected(),
+                    blocked: self.blocked(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -10690,6 +14770,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10711,6 +14811,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -10736,6 +14856,26 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("extrefsel", &self.extrefsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    extrefsel: super::vals::Extrefsel,
+                }
+                let proxy = Extrefsel {
+                    extrefsel: self.extrefsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10757,6 +14897,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: bool,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -10815,6 +14971,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10836,6 +15021,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Psel {
                 Psel(0)
+            }
+        }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel").field("psel", &self.psel()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    psel: super::vals::PselPsel,
+                }
+                let proxy = Psel { psel: self.psel() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reference select"]
@@ -10861,6 +15062,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10882,6 +15103,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -10951,10 +15192,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -10987,7 +15261,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -11019,7 +15294,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extrefsel {
             #[doc = "Use AIN0 as external analog reference"]
             ANALOG_REFERENCE0 = 0x0,
@@ -11049,7 +15325,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselPsel {
             #[doc = "AIN0 selected as analog input"]
             ANALOG_INPUT0 = 0x0,
@@ -11091,7 +15368,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -11149,7 +15427,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -11226,6 +15505,26 @@ pub mod mutex {
             #[inline(always)]
             fn default() -> Mutex {
                 Mutex(0)
+            }
+        }
+        impl core::fmt::Debug for Mutex {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mutex")
+                    .field("mutex", &self.mutex())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mutex {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mutex {
+                    mutex: bool,
+                }
+                let proxy = Mutex {
+                    mutex: self.mutex(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -11754,6 +16053,24 @@ pub mod nfct {
                 Autocolresconfig(0)
             }
         }
+        impl core::fmt::Debug for Autocolresconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Autocolresconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Autocolresconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Autocolresconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Autocolresconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11775,6 +16092,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the presence or not of a valid field"]
@@ -11811,6 +16148,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11833,6 +16193,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u32,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -11858,6 +16238,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11879,6 +16279,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -12058,6 +16478,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of the RAM buffer allocated to TXD and RXD data storage each"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12081,6 +16563,26 @@ pub mod nfct {
                 Maxlen(0)
             }
         }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables the modulation output to a GPIO pin which can be connected to a second external antenna."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12102,6 +16604,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Modulationctrl {
                 Modulationctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Modulationctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationctrl")
+                    .field("modulationctrl", &self.modulationctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationctrl {
+                    modulationctrl: super::vals::Modulationctrl,
+                }
+                let proxy = Modulationctrl {
+                    modulationctrl: self.modulationctrl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Pin select for Modulation control"]
@@ -12150,6 +16672,32 @@ pub mod nfct {
                 Modulationpsel(0)
             }
         }
+        impl core::fmt::Debug for Modulationpsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationpsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationpsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationpsel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::super::shared::vals::Connect,
+                }
+                let proxy = Modulationpsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12195,6 +16743,32 @@ pub mod nfct {
                 Nfcid12ndLast(0)
             }
         }
+        impl core::fmt::Debug for Nfcid12ndLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid12ndLast")
+                    .field("nfcid1_v", &self.nfcid1_v())
+                    .field("nfcid1_u", &self.nfcid1_u())
+                    .field("nfcid1_t", &self.nfcid1_t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid12ndLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid12ndLast {
+                    nfcid1_v: u8,
+                    nfcid1_u: u8,
+                    nfcid1_t: u8,
+                }
+                let proxy = Nfcid12ndLast {
+                    nfcid1_v: self.nfcid1_v(),
+                    nfcid1_u: self.nfcid1_u(),
+                    nfcid1_t: self.nfcid1_t(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12238,6 +16812,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfcid13rdLast {
                 Nfcid13rdLast(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcid13rdLast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid13rdLast")
+                    .field("nfcid1_s", &self.nfcid1_s())
+                    .field("nfcid1_r", &self.nfcid1_r())
+                    .field("nfcid1_q", &self.nfcid1_q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid13rdLast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid13rdLast {
+                    nfcid1_s: u8,
+                    nfcid1_r: u8,
+                    nfcid1_q: u8,
+                }
+                let proxy = Nfcid13rdLast {
+                    nfcid1_s: self.nfcid1_s(),
+                    nfcid1_r: self.nfcid1_r(),
+                    nfcid1_q: self.nfcid1_q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
@@ -12296,6 +16896,35 @@ pub mod nfct {
                 Nfcid1Last(0)
             }
         }
+        impl core::fmt::Debug for Nfcid1Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcid1Last")
+                    .field("nfcid1_z", &self.nfcid1_z())
+                    .field("nfcid1_y", &self.nfcid1_y())
+                    .field("nfcid1_x", &self.nfcid1_x())
+                    .field("nfcid1_w", &self.nfcid1_w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcid1Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcid1Last {
+                    nfcid1_z: u8,
+                    nfcid1_y: u8,
+                    nfcid1_x: u8,
+                    nfcid1_w: u8,
+                }
+                let proxy = Nfcid1Last {
+                    nfcid1_z: self.nfcid1_z(),
+                    nfcid1_y: self.nfcid1_y(),
+                    nfcid1_x: self.nfcid1_x(),
+                    nfcid1_w: self.nfcid1_w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current operating state of NFC tag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12317,6 +16946,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Nfctagstate {
                 Nfctagstate(0)
+            }
+        }
+        impl core::fmt::Debug for Nfctagstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfctagstate")
+                    .field("nfctagstate", &self.nfctagstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfctagstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfctagstate {
+                    nfctagstate: super::vals::Nfctagstate,
+                }
+                let proxy = Nfctagstate {
+                    nfctagstate: self.nfctagstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of last incoming frame"]
@@ -12364,6 +17013,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12396,6 +17071,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -12441,6 +17139,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdFrameconfig {
                 RxdFrameconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -12510,6 +17234,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: bool,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12577,6 +17333,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12622,6 +17410,32 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .field("txframeend_enablerxdata", &self.txframeend_enablerxdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                    txframeend_enablerxdata: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                    txframeend_enablerxdata: self.txframeend_enablerxdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sleep state during automatic collision resolution"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12643,6 +17457,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Sleepstate {
                 Sleepstate(0)
+            }
+        }
+        impl core::fmt::Debug for Sleepstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sleepstate")
+                    .field("sleepstate", &self.sleepstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sleepstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sleepstate {
+                    sleepstate: super::vals::Sleepstate,
+                }
+                let proxy = Sleepstate {
+                    sleepstate: self.sleepstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Size of outgoing frame"]
@@ -12677,6 +17511,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -12735,10 +17592,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -12802,7 +17689,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits are discarded at end of frame (EoF)"]
             DISCARD_END = 0x0,
@@ -12832,7 +17720,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -12866,7 +17755,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Auto collision resolution enabled"]
             ENABLED = 0x0,
@@ -12896,7 +17786,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Modulationctrl {
             #[doc = "Invalid, defaults to same behaviour as for Internal"]
             INVALID = 0x0,
@@ -12930,7 +17821,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -12963,7 +17855,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfctagstate {
             #[doc = "Disabled or sense"]
             DISABLED = 0x0,
@@ -13003,7 +17896,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleepstate {
             #[doc = "State is IDLE."]
             IDLE = 0x0,
@@ -13113,6 +18007,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Non-secure configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13134,6 +18044,24 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Configns {
                 Configns(0)
+            }
+        }
+        impl core::fmt::Debug for Configns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configns")
+                    .field("wen", &self.wen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configns {
+                    wen: super::vals::ConfignsWen,
+                }
+                let proxy = Configns { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for erasing all non-volatile user memory"]
@@ -13159,6 +18087,26 @@ pub mod nvmc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for partial erase configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13180,6 +18128,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Erasepagepartialcfg {
                 Erasepagepartialcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -13205,6 +18173,26 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13226,6 +18214,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Readynext {
                 Readynext(0)
+            }
+        }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Non-secure APPROTECT enable register"]
@@ -13263,10 +18271,34 @@ pub mod nvmc {
                 Writeuicrns(0)
             }
         }
+        impl core::fmt::Debug for Writeuicrns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writeuicrns")
+                    .field("set", &self.set())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writeuicrns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writeuicrns {
+                    set: bool,
+                    key: super::vals::Key,
+                }
+                let proxy = Writeuicrns {
+                    set: self.set(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfignsWen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -13313,6 +18345,23 @@ pub mod nvmc {
                 self.0
             }
         }
+        impl core::fmt::Debug for Key {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0afb_e5a7 => f.write_str("KEYVALID"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Key {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0afb_e5a7 => defmt::write!(f, "KEYVALID"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Key {
             #[inline(always)]
             fn from(val: u32) -> Key {
@@ -13326,7 +18375,8 @@ pub mod nvmc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -13444,6 +18494,26 @@ pub mod oscillators {
                 Bypass(0)
             }
         }
+        impl core::fmt::Debug for Bypass {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bypass")
+                    .field("bypass", &self.bypass())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bypass {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bypass {
+                    bypass: bool,
+                }
+                let proxy = Bypass {
+                    bypass: self.bypass(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control usage of internal load capacitors"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13465,6 +18535,26 @@ pub mod oscillators {
             #[inline(always)]
             fn default() -> Intcap {
                 Intcap(0)
+            }
+        }
+        impl core::fmt::Debug for Intcap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Intcap")
+                    .field("intcap", &self.intcap())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Intcap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Intcap {
+                    intcap: super::vals::Intcap,
+                }
+                let proxy = Intcap {
+                    intcap: self.intcap(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Programmable capacitance of XC1 and XC2"]
@@ -13501,10 +18591,34 @@ pub mod oscillators {
                 Xosc32mcaps(0)
             }
         }
+        impl core::fmt::Debug for Xosc32mcaps {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32mcaps")
+                    .field("capvalue", &self.capvalue())
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32mcaps {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32mcaps {
+                    capvalue: u8,
+                    enable: bool,
+                }
+                let proxy = Xosc32mcaps {
+                    capvalue: self.capvalue(),
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Intcap {
             #[doc = "Use external load capacitors"]
             EXTERNAL = 0x0,
@@ -13755,6 +18869,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13778,6 +18912,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13799,6 +18953,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -13846,6 +19020,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13869,6 +19069,26 @@ pub mod pdm {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13890,6 +19110,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Mclkconfig {
                 Mclkconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Mclkconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mclkconfig")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mclkconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mclkconfig {
+                    src: super::vals::Src,
+                }
+                let proxy = Mclkconfig { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -13926,6 +19164,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13948,6 +19209,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Pdmclkctrl {
                 Pdmclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the ratio between PDM_CLK and output sample rate. Change PDMCLKCTRL accordingly."]
@@ -13973,10 +19252,31 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -14030,6 +19330,33 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    0x0980_0000 => f.write_str("_1231K"),
+                    0x0a00_0000 => f.write_str("_1280K"),
+                    0x0a80_0000 => f.write_str("_1333K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    0x0980_0000 => defmt::write!(f, "_1231K"),
+                    0x0a00_0000 => defmt::write!(f, "_1280K"),
+                    0x0a80_0000 => defmt::write!(f, "_1333K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -14061,6 +19388,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -14074,7 +19422,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -14104,7 +19453,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 64"]
             RATIO64 = 0x0,
@@ -14134,7 +19484,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Src {
             #[doc = "32 MHz peripheral clock"]
             PCLK32M = 0x0,
@@ -14291,6 +19642,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14334,6 +19705,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14613,6 +20010,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14634,6 +20047,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -14670,6 +20103,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14691,6 +20147,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -14715,6 +20191,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14806,6 +20300,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14828,6 +20360,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -14853,6 +20401,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14874,6 +20442,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -14898,6 +20486,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14967,6 +20571,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -14984,6 +20620,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -14997,7 +20650,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -15045,6 +20699,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -15058,7 +20729,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -15088,7 +20760,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -15144,6 +20817,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -15157,7 +20847,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -15457,6 +21148,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15478,6 +21189,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -15503,6 +21234,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15524,6 +21275,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -15593,6 +21364,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15614,6 +21417,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -15639,6 +21462,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15662,6 +21505,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15683,6 +21546,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15774,10 +21657,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -15807,7 +21729,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -15858,7 +21781,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -16439,6 +22363,41 @@ pub mod qspi {
                 Addrconf(0)
             }
         }
+        impl core::fmt::Debug for Addrconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Addrconf")
+                    .field("opcode", &self.opcode())
+                    .field("byte0", &self.byte0())
+                    .field("byte1", &self.byte1())
+                    .field("mode", &self.mode())
+                    .field("wipwait", &self.wipwait())
+                    .field("wren", &self.wren())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Addrconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Addrconf {
+                    opcode: u8,
+                    byte0: u8,
+                    byte1: u8,
+                    mode: super::vals::Mode,
+                    wipwait: bool,
+                    wren: bool,
+                }
+                let proxy = Addrconf {
+                    opcode: self.opcode(),
+                    byte0: self.byte0(),
+                    byte1: self.byte1(),
+                    mode: self.mode(),
+                    wipwait: self.wipwait(),
+                    wren: self.wren(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Custom instruction configuration register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16539,6 +22498,47 @@ pub mod qspi {
                 Cinstrconf(0)
             }
         }
+        impl core::fmt::Debug for Cinstrconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrconf")
+                    .field("opcode", &self.opcode())
+                    .field("length", &self.length())
+                    .field("lio2", &self.lio2())
+                    .field("lio3", &self.lio3())
+                    .field("wipwait", &self.wipwait())
+                    .field("wren", &self.wren())
+                    .field("lfen", &self.lfen())
+                    .field("lfstop", &self.lfstop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrconf {
+                    opcode: u8,
+                    length: super::vals::Length,
+                    lio2: bool,
+                    lio3: bool,
+                    wipwait: bool,
+                    wren: bool,
+                    lfen: bool,
+                    lfstop: bool,
+                }
+                let proxy = Cinstrconf {
+                    opcode: self.opcode(),
+                    length: self.length(),
+                    lio2: self.lio2(),
+                    lio3: self.lio3(),
+                    wipwait: self.wipwait(),
+                    wren: self.wren(),
+                    lfen: self.lfen(),
+                    lfstop: self.lfstop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Custom instruction data register 0."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16593,6 +22593,35 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Cinstrdat0 {
                 Cinstrdat0(0)
+            }
+        }
+        impl core::fmt::Debug for Cinstrdat0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrdat0")
+                    .field("byte0", &self.byte0())
+                    .field("byte1", &self.byte1())
+                    .field("byte2", &self.byte2())
+                    .field("byte3", &self.byte3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrdat0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrdat0 {
+                    byte0: u8,
+                    byte1: u8,
+                    byte2: u8,
+                    byte3: u8,
+                }
+                let proxy = Cinstrdat0 {
+                    byte0: self.byte0(),
+                    byte1: self.byte1(),
+                    byte2: self.byte2(),
+                    byte3: self.byte3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Custom instruction data register 1."]
@@ -16651,6 +22680,35 @@ pub mod qspi {
                 Cinstrdat1(0)
             }
         }
+        impl core::fmt::Debug for Cinstrdat1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cinstrdat1")
+                    .field("byte4", &self.byte4())
+                    .field("byte5", &self.byte5())
+                    .field("byte6", &self.byte6())
+                    .field("byte7", &self.byte7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cinstrdat1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cinstrdat1 {
+                    byte4: u8,
+                    byte5: u8,
+                    byte6: u8,
+                    byte7: u8,
+                }
+                let proxy = Cinstrdat1 {
+                    byte4: self.byte4(),
+                    byte5: self.byte5(),
+                    byte6: self.byte6(),
+                    byte7: self.byte7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable stream cipher for EasyDMA"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16672,6 +22730,26 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> DmaEncEnable {
                 DmaEncEnable(0)
+            }
+        }
+        impl core::fmt::Debug for DmaEncEnable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DmaEncEnable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DmaEncEnable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DmaEncEnable {
+                    enable: bool,
+                }
+                let proxy = DmaEncEnable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Set the duration required to enter/exit deep power-down mode (DPM)."]
@@ -16706,6 +22784,29 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Dpmdur {
                 Dpmdur(0)
+            }
+        }
+        impl core::fmt::Debug for Dpmdur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpmdur")
+                    .field("enter", &self.enter())
+                    .field("exit", &self.exit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpmdur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpmdur {
+                    enter: u16,
+                    exit: u16,
+                }
+                let proxy = Dpmdur {
+                    enter: self.enter(),
+                    exit: self.exit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Interface configuration."]
@@ -16776,6 +22877,38 @@ pub mod qspi {
                 Ifconfig0(0)
             }
         }
+        impl core::fmt::Debug for Ifconfig0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ifconfig0")
+                    .field("readoc", &self.readoc())
+                    .field("writeoc", &self.writeoc())
+                    .field("addrmode", &self.addrmode())
+                    .field("dpmenable", &self.dpmenable())
+                    .field("ppsize", &self.ppsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ifconfig0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ifconfig0 {
+                    readoc: super::vals::Readoc,
+                    writeoc: super::vals::Writeoc,
+                    addrmode: super::vals::Addrmode,
+                    dpmenable: bool,
+                    ppsize: super::vals::Ppsize,
+                }
+                let proxy = Ifconfig0 {
+                    readoc: self.readoc(),
+                    writeoc: self.writeoc(),
+                    addrmode: self.addrmode(),
+                    dpmenable: self.dpmenable(),
+                    ppsize: self.ppsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interface configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16833,6 +22966,35 @@ pub mod qspi {
                 Ifconfig1(0)
             }
         }
+        impl core::fmt::Debug for Ifconfig1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ifconfig1")
+                    .field("sckdelay", &self.sckdelay())
+                    .field("dpmen", &self.dpmen())
+                    .field("spimode", &self.spimode())
+                    .field("sckfreq", &self.sckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ifconfig1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ifconfig1 {
+                    sckdelay: u8,
+                    dpmen: bool,
+                    spimode: super::vals::Spimode,
+                    sckfreq: u8,
+                }
+                let proxy = Ifconfig1 {
+                    sckdelay: self.sckdelay(),
+                    dpmen: self.dpmen(),
+                    spimode: self.spimode(),
+                    sckfreq: self.sckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI interface timing."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16854,6 +23016,26 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Iftiming {
                 Iftiming(0)
+            }
+        }
+        impl core::fmt::Debug for Iftiming {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Iftiming")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Iftiming {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Iftiming {
+                    rxdelay: u8,
+                }
+                let proxy = Iftiming {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16879,6 +23061,24 @@ pub mod qspi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("ready", &self.ready()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of block to be erased."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16900,6 +23100,22 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> Len {
                 Len(0)
+            }
+        }
+        impl core::fmt::Debug for Len {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Len").field("len", &self.len()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Len {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Len {
+                    len: super::vals::Len,
+                }
+                let proxy = Len { len: self.len() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable QSPI peripheral and acquire the pins selected in PSELn registers"]
@@ -16925,6 +23141,26 @@ pub mod qspi {
                 QspiEnable(0)
             }
         }
+        impl core::fmt::Debug for QspiEnable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("QspiEnable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for QspiEnable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct QspiEnable {
+                    enable: bool,
+                }
+                let proxy = QspiEnable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read transfer length"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16947,6 +23183,22 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> ReadCnt {
                 ReadCnt(0)
+            }
+        }
+        impl core::fmt::Debug for ReadCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReadCnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReadCnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReadCnt {
+                    cnt: u32,
+                }
+                let proxy = ReadCnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -16994,6 +23246,32 @@ pub mod qspi {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("dpm", &self.dpm())
+                    .field("ready", &self.ready())
+                    .field("sreg", &self.sreg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    dpm: bool,
+                    ready: bool,
+                    sreg: u8,
+                }
+                let proxy = Status {
+                    dpm: self.dpm(),
+                    ready: self.ready(),
+                    sreg: self.sreg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write transfer length"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17016,6 +23294,24 @@ pub mod qspi {
             #[inline(always)]
             fn default() -> WriteCnt {
                 WriteCnt(0)
+            }
+        }
+        impl core::fmt::Debug for WriteCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("WriteCnt")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for WriteCnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct WriteCnt {
+                    cnt: u32,
+                }
+                let proxy = WriteCnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable stream cipher for XIP"]
@@ -17041,6 +23337,26 @@ pub mod qspi {
                 XipEncEnable(0)
             }
         }
+        impl core::fmt::Debug for XipEncEnable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("XipEncEnable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for XipEncEnable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct XipEncEnable {
+                    enable: bool,
+                }
+                let proxy = XipEncEnable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable Execute in Place operation."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17064,10 +23380,31 @@ pub mod qspi {
                 Xipen(0)
             }
         }
+        impl core::fmt::Debug for Xipen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xipen")
+                    .field("xipen", &self.xipen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xipen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xipen {
+                    xipen: bool,
+                }
+                let proxy = Xipen {
+                    xipen: self.xipen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Addrmode {
             #[doc = "24-bit addressing."]
             _24BIT = 0x0,
@@ -17097,7 +23434,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "Erase 4 kB block (flash command 0x20)"]
             _4KB = 0x0,
@@ -17130,7 +23468,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             _RESERVED_0 = 0x0,
             #[doc = "Send opcode only."]
@@ -17181,7 +23520,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Do not send any instruction."]
             NO_INSTR = 0x0,
@@ -17215,7 +23555,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ppsize {
             #[doc = "256 bytes."]
             _256BYTES = 0x0,
@@ -17245,7 +23586,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Readoc {
             #[doc = "Single data line SPI. FAST_READ (opcode 0x0B)."]
             FASTREAD = 0x0,
@@ -17284,7 +23626,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Spimode {
             #[doc = "Mode 0: Data are captured on the clock rising edge and data is output on a falling edge. Base level of clock is 0 (CPOL=0, CPHA=0)."]
             MODE0 = 0x0,
@@ -17314,7 +23657,8 @@ pub mod qspi {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Writeoc {
             #[doc = "Single data line SPI. PP (opcode 0x02)."]
             PP = 0x0,
@@ -17493,6 +23837,26 @@ pub mod regulators {
                 Mainregstatus(0)
             }
         }
+        impl core::fmt::Debug for Mainregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mainregstatus")
+                    .field("vregh", &self.vregh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mainregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mainregstatus {
+                    vregh: bool,
+                }
+                let proxy = Mainregstatus {
+                    vregh: self.vregh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power-fail comparator configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17538,6 +23902,32 @@ pub mod regulators {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("thresholdvddh", &self.thresholdvddh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    thresholdvddh: super::vals::Thresholdvddh,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    thresholdvddh: self.thresholdvddh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17559,6 +23949,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DC/DC enable register for VREGH"]
@@ -17584,6 +23994,26 @@ pub mod regulators {
                 VreghDcdcen(0)
             }
         }
+        impl core::fmt::Debug for VreghDcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("VreghDcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for VreghDcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct VreghDcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = VreghDcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DC/DC enable register for VREGMAIN"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17605,6 +24035,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> VregmainDcdcen {
                 VregmainDcdcen(0)
+            }
+        }
+        impl core::fmt::Debug for VregmainDcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("VregmainDcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for VregmainDcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct VregmainDcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = VregmainDcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DC/DC enable register for VREGRADIO"]
@@ -17630,10 +24080,31 @@ pub mod regulators {
                 VregradioDcdcen(0)
             }
         }
+        impl core::fmt::Debug for VregradioDcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("VregradioDcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for VregradioDcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct VregradioDcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = VregradioDcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -17685,7 +24156,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Thresholdvddh {
             #[doc = "Set threshold to 2.7 V"]
             V27 = 0x0,
@@ -17816,6 +24288,26 @@ pub mod reset {
             #[inline(always)]
             fn default() -> Forceoff {
                 Forceoff(0)
+            }
+        }
+        impl core::fmt::Debug for Forceoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceoff")
+                    .field("forceoff", &self.forceoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceoff {
+                    forceoff: super::vals::Forceoff,
+                }
+                let proxy = Forceoff {
+                    forceoff: self.forceoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -17951,10 +24443,61 @@ pub mod reset {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog0", &self.dog0())
+                    .field("ctrlap", &self.ctrlap())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("nfc", &self.nfc())
+                    .field("dog1", &self.dog1())
+                    .field("vbus", &self.vbus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog0: bool,
+                    ctrlap: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    nfc: bool,
+                    dog1: bool,
+                    vbus: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog0: self.dog0(),
+                    ctrlap: self.ctrlap(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    nfc: self.nfc(),
+                    dog1: self.dog1(),
+                    vbus: self.vbus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Forceoff {
             #[doc = "Release Force-OFF"]
             RELEASE = 0x0,
@@ -18176,6 +24719,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18198,6 +24761,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -18249,6 +24832,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18298,6 +24920,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768 / (PRESCALER + 1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18319,6 +24980,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -18346,6 +25027,39 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "comparen_clear",
+                        &[
+                            self.comparen_clear(0usize),
+                            self.comparen_clear(1usize),
+                            self.comparen_clear(2usize),
+                            self.comparen_clear(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    comparen_clear: [bool; 4usize],
+                }
+                let proxy = Shorts {
+                    comparen_clear: [
+                        self.comparen_clear(0usize),
+                        self.comparen_clear(1usize),
+                        self.comparen_clear(2usize),
+                        self.comparen_clear(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -18702,6 +25416,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18794,6 +25528,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18815,6 +25587,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -18925,6 +25717,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18959,6 +25834,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18980,6 +25878,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -19005,6 +25923,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19026,6 +25964,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -19051,6 +26009,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19072,6 +26050,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -19109,6 +26105,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19132,10 +26151,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single-ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -19165,7 +26205,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -19207,7 +26248,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -19258,7 +26300,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -19327,7 +26370,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -19357,7 +26401,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -19391,7 +26436,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -19425,7 +26471,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -19455,7 +26502,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No ongoing conversion."]
             READY = 0x0,
@@ -19485,7 +26533,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -19525,7 +26574,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -19612,6 +26662,32 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event DONE"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19642,6 +26718,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task CAL"]
@@ -19676,10 +26775,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -20101,6 +27224,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Minimum duration between edge of CSN and edge of SCK. When SHORTS.END_START is used, this is also the minimum duration CSN must stay high between transactions."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20122,6 +27271,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csndur {
                 Csndur(0)
+            }
+        }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Polarity of CSN output"]
@@ -20147,6 +27316,26 @@ pub mod spim {
                 Csnpol(0)
             }
         }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol", &self.csnpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol: super::vals::Csnpol,
+                }
+                let proxy = Csnpol {
+                    csnpol: self.csnpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DCX configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20168,6 +27357,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Dcxcnt {
                 Dcxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable SPIM"]
@@ -20193,6 +27402,26 @@ pub mod spim {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20215,6 +27444,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -20284,6 +27533,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20305,6 +27586,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -20330,6 +27627,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20351,6 +27668,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -20376,6 +27711,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample delay for input serial data on MISO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20399,6 +27754,26 @@ pub mod spim {
                 Rxdelay(0)
             }
         }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20420,6 +27795,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Stall status for EasyDMA RAM accesses. The fields in this register are set to STALL by hardware whenever a stall occurres and can be cleared (set to NOSTALL) by the CPU."]
@@ -20456,6 +27851,29 @@ pub mod spim {
                 Stallstat(0)
             }
         }
+        impl core::fmt::Debug for Stallstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Stallstat")
+                    .field("tx", &self.tx())
+                    .field("rx", &self.rx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Stallstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Stallstat {
+                    tx: bool,
+                    rx: bool,
+                }
+                let proxy = Stallstat {
+                    tx: self.tx(),
+                    rx: self.rx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20477,6 +27895,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -20502,6 +27940,24 @@ pub mod spim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20525,10 +27981,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -20558,7 +28035,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -20588,7 +28066,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -20618,7 +28097,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -20692,6 +28172,39 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x0a00_0000 => f.write_str("M16"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x1400_0000 => f.write_str("M32"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x0a00_0000 => defmt::write!(f, "M16"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x1400_0000 => defmt::write!(f, "M32"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -20705,7 +28218,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -20735,7 +28249,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -20767,7 +28282,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -21099,6 +28615,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21122,6 +28664,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21143,6 +28701,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -21190,6 +28768,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21211,6 +28815,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -21236,6 +28856,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21257,6 +28897,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -21282,6 +28940,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21305,6 +28983,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21326,6 +29024,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -21362,6 +29080,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21383,6 +29124,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -21408,6 +29169,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21431,10 +29210,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -21464,7 +29264,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -21494,7 +29295,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -21538,7 +29340,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -21568,7 +29371,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -21600,7 +29404,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -21634,7 +29439,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -22014,6 +29820,22 @@ pub mod spu {
                 Cap(0)
             }
         }
+        impl core::fmt::Debug for Cap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cap").field("tzm", &self.tzm()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cap {
+                    tzm: super::vals::Tzm,
+                }
+                let proxy = Cap { tzm: self.tzm() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure bits to lock down CPU features at runtime"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22081,6 +29903,38 @@ pub mod spu {
                 Cpulock(0)
             }
         }
+        impl core::fmt::Debug for Cpulock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cpulock")
+                    .field("locksvtaircr", &self.locksvtaircr())
+                    .field("locknsvtor", &self.locknsvtor())
+                    .field("locksmpu", &self.locksmpu())
+                    .field("locknsmpu", &self.locknsmpu())
+                    .field("locksau", &self.locksau())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpulock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cpulock {
+                    locksvtaircr: bool,
+                    locknsvtor: bool,
+                    locksmpu: bool,
+                    locknsmpu: bool,
+                    locksau: bool,
+                }
+                let proxy = Cpulock {
+                    locksvtaircr: self.locksvtaircr(),
+                    locknsvtor: self.locknsvtor(),
+                    locksmpu: self.locksmpu(),
+                    locknsmpu: self.locknsmpu(),
+                    locksau: self.locksau(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22100,6 +29954,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> DppiLock {
                 DppiLock(0)
+            }
+        }
+        impl core::fmt::Debug for DppiLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiLock {
+                    lock: bool,
+                }
+                let proxy = DppiLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for the DPPI channels"]
@@ -22466,6 +30338,119 @@ pub mod spu {
                 DppiPerm(0)
             }
         }
+        impl core::fmt::Debug for DppiPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiPerm")
+                    .field("channel0", &self.channel0())
+                    .field("channel1", &self.channel1())
+                    .field("channel2", &self.channel2())
+                    .field("channel3", &self.channel3())
+                    .field("channel4", &self.channel4())
+                    .field("channel5", &self.channel5())
+                    .field("channel6", &self.channel6())
+                    .field("channel7", &self.channel7())
+                    .field("channel8", &self.channel8())
+                    .field("channel9", &self.channel9())
+                    .field("channel10", &self.channel10())
+                    .field("channel11", &self.channel11())
+                    .field("channel12", &self.channel12())
+                    .field("channel13", &self.channel13())
+                    .field("channel14", &self.channel14())
+                    .field("channel15", &self.channel15())
+                    .field("channel16", &self.channel16())
+                    .field("channel17", &self.channel17())
+                    .field("channel18", &self.channel18())
+                    .field("channel19", &self.channel19())
+                    .field("channel20", &self.channel20())
+                    .field("channel21", &self.channel21())
+                    .field("channel22", &self.channel22())
+                    .field("channel23", &self.channel23())
+                    .field("channel24", &self.channel24())
+                    .field("channel25", &self.channel25())
+                    .field("channel26", &self.channel26())
+                    .field("channel27", &self.channel27())
+                    .field("channel28", &self.channel28())
+                    .field("channel29", &self.channel29())
+                    .field("channel30", &self.channel30())
+                    .field("channel31", &self.channel31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiPerm {
+                    channel0: bool,
+                    channel1: bool,
+                    channel2: bool,
+                    channel3: bool,
+                    channel4: bool,
+                    channel5: bool,
+                    channel6: bool,
+                    channel7: bool,
+                    channel8: bool,
+                    channel9: bool,
+                    channel10: bool,
+                    channel11: bool,
+                    channel12: bool,
+                    channel13: bool,
+                    channel14: bool,
+                    channel15: bool,
+                    channel16: bool,
+                    channel17: bool,
+                    channel18: bool,
+                    channel19: bool,
+                    channel20: bool,
+                    channel21: bool,
+                    channel22: bool,
+                    channel23: bool,
+                    channel24: bool,
+                    channel25: bool,
+                    channel26: bool,
+                    channel27: bool,
+                    channel28: bool,
+                    channel29: bool,
+                    channel30: bool,
+                    channel31: bool,
+                }
+                let proxy = DppiPerm {
+                    channel0: self.channel0(),
+                    channel1: self.channel1(),
+                    channel2: self.channel2(),
+                    channel3: self.channel3(),
+                    channel4: self.channel4(),
+                    channel5: self.channel5(),
+                    channel6: self.channel6(),
+                    channel7: self.channel7(),
+                    channel8: self.channel8(),
+                    channel9: self.channel9(),
+                    channel10: self.channel10(),
+                    channel11: self.channel11(),
+                    channel12: self.channel12(),
+                    channel13: self.channel13(),
+                    channel14: self.channel14(),
+                    channel15: self.channel15(),
+                    channel16: self.channel16(),
+                    channel17: self.channel17(),
+                    channel18: self.channel18(),
+                    channel19: self.channel19(),
+                    channel20: self.channel20(),
+                    channel21: self.channel21(),
+                    channel22: self.channel22(),
+                    channel23: self.channel23(),
+                    channel24: self.channel24(),
+                    channel25: self.channel25(),
+                    channel26: self.channel26(),
+                    channel27: self.channel27(),
+                    channel28: self.channel28(),
+                    channel29: self.channel29(),
+                    channel30: self.channel30(),
+                    channel31: self.channel31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access for bus access generated from the external domain n List capabilities of the external domain n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22509,6 +30494,32 @@ pub mod spu {
                 ExtdomainPerm(0)
             }
         }
+        impl core::fmt::Debug for ExtdomainPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtdomainPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtdomainPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtdomainPerm {
+                    securemapping: super::vals::ExtdomainPermSecuremapping,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = ExtdomainPerm {
+                    securemapping: self.securemapping(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which flash region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22541,6 +30552,29 @@ pub mod spu {
                 FlashnscRegion(0)
             }
         }
+        impl core::fmt::Debug for FlashnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = FlashnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22571,6 +30605,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> FlashnscSize {
                 FlashnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for FlashnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscSize {
+                    size: super::vals::FlashnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = FlashnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for flash region n"]
@@ -22638,6 +30695,38 @@ pub mod spu {
                 FlashregionPerm(0)
             }
         }
+        impl core::fmt::Debug for FlashregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = FlashregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22657,6 +30746,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> GpioportLock {
                 GpioportLock(0)
+            }
+        }
+        impl core::fmt::Debug for GpioportLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportLock {
+                    lock: bool,
+                }
+                let proxy = GpioportLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for pins 0 to 31 of port n"]
@@ -23023,6 +31130,119 @@ pub mod spu {
                 GpioportPerm(0)
             }
         }
+        impl core::fmt::Debug for GpioportPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportPerm")
+                    .field("pin0", &self.pin0())
+                    .field("pin1", &self.pin1())
+                    .field("pin2", &self.pin2())
+                    .field("pin3", &self.pin3())
+                    .field("pin4", &self.pin4())
+                    .field("pin5", &self.pin5())
+                    .field("pin6", &self.pin6())
+                    .field("pin7", &self.pin7())
+                    .field("pin8", &self.pin8())
+                    .field("pin9", &self.pin9())
+                    .field("pin10", &self.pin10())
+                    .field("pin11", &self.pin11())
+                    .field("pin12", &self.pin12())
+                    .field("pin13", &self.pin13())
+                    .field("pin14", &self.pin14())
+                    .field("pin15", &self.pin15())
+                    .field("pin16", &self.pin16())
+                    .field("pin17", &self.pin17())
+                    .field("pin18", &self.pin18())
+                    .field("pin19", &self.pin19())
+                    .field("pin20", &self.pin20())
+                    .field("pin21", &self.pin21())
+                    .field("pin22", &self.pin22())
+                    .field("pin23", &self.pin23())
+                    .field("pin24", &self.pin24())
+                    .field("pin25", &self.pin25())
+                    .field("pin26", &self.pin26())
+                    .field("pin27", &self.pin27())
+                    .field("pin28", &self.pin28())
+                    .field("pin29", &self.pin29())
+                    .field("pin30", &self.pin30())
+                    .field("pin31", &self.pin31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportPerm {
+                    pin0: bool,
+                    pin1: bool,
+                    pin2: bool,
+                    pin3: bool,
+                    pin4: bool,
+                    pin5: bool,
+                    pin6: bool,
+                    pin7: bool,
+                    pin8: bool,
+                    pin9: bool,
+                    pin10: bool,
+                    pin11: bool,
+                    pin12: bool,
+                    pin13: bool,
+                    pin14: bool,
+                    pin15: bool,
+                    pin16: bool,
+                    pin17: bool,
+                    pin18: bool,
+                    pin19: bool,
+                    pin20: bool,
+                    pin21: bool,
+                    pin22: bool,
+                    pin23: bool,
+                    pin24: bool,
+                    pin25: bool,
+                    pin26: bool,
+                    pin27: bool,
+                    pin28: bool,
+                    pin29: bool,
+                    pin30: bool,
+                    pin31: bool,
+                }
+                let proxy = GpioportPerm {
+                    pin0: self.pin0(),
+                    pin1: self.pin1(),
+                    pin2: self.pin2(),
+                    pin3: self.pin3(),
+                    pin4: self.pin4(),
+                    pin5: self.pin5(),
+                    pin6: self.pin6(),
+                    pin7: self.pin7(),
+                    pin8: self.pin8(),
+                    pin9: self.pin9(),
+                    pin10: self.pin10(),
+                    pin11: self.pin11(),
+                    pin12: self.pin12(),
+                    pin13: self.pin13(),
+                    pin14: self.pin14(),
+                    pin15: self.pin15(),
+                    pin16: self.pin16(),
+                    pin17: self.pin17(),
+                    pin18: self.pin18(),
+                    pin19: self.pin19(),
+                    pin20: self.pin20(),
+                    pin21: self.pin21(),
+                    pin22: self.pin22(),
+                    pin23: self.pin23(),
+                    pin24: self.pin24(),
+                    pin25: self.pin25(),
+                    pin26: self.pin26(),
+                    pin27: self.pin27(),
+                    pin28: self.pin28(),
+                    pin29: self.pin29(),
+                    pin30: self.pin30(),
+                    pin31: self.pin31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23066,6 +31286,32 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ramaccerr", &self.ramaccerr())
+                    .field("flashaccerr", &self.flashaccerr())
+                    .field("periphaccerr", &self.periphaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ramaccerr: bool,
+                    flashaccerr: bool,
+                    periphaccerr: bool,
+                }
+                let proxy = Int {
+                    ramaccerr: self.ramaccerr(),
+                    flashaccerr: self.flashaccerr(),
+                    periphaccerr: self.periphaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: List capabilities and access permissions for the peripheral with ID n"]
@@ -23145,6 +31391,41 @@ pub mod spu {
                 PeriphidPerm(0)
             }
         }
+        impl core::fmt::Debug for PeriphidPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PeriphidPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("dma", &self.dma())
+                    .field("secattr", &self.secattr())
+                    .field("dmasec", &self.dmasec())
+                    .field("lock", &self.lock())
+                    .field("present", &self.present())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PeriphidPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PeriphidPerm {
+                    securemapping: super::vals::PeriphidPermSecuremapping,
+                    dma: super::vals::Dma,
+                    secattr: bool,
+                    dmasec: bool,
+                    lock: bool,
+                    present: super::vals::Present,
+                }
+                let proxy = PeriphidPerm {
+                    securemapping: self.securemapping(),
+                    dma: self.dma(),
+                    secattr: self.secattr(),
+                    dmasec: self.dmasec(),
+                    lock: self.lock(),
+                    present: self.present(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which RAM region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23177,6 +31458,29 @@ pub mod spu {
                 RamnscRegion(0)
             }
         }
+        impl core::fmt::Debug for RamnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = RamnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23207,6 +31511,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> RamnscSize {
                 RamnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for RamnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscSize {
+                    size: super::vals::RamnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = RamnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for RAM region n"]
@@ -23274,10 +31601,43 @@ pub mod spu {
                 RamregionPerm(0)
             }
         }
+        impl core::fmt::Debug for RamregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = RamregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dma {
             #[doc = "Peripheral has no DMA capability"]
             NO_DMA = 0x0,
@@ -23310,7 +31670,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtdomainPermSecuremapping {
             #[doc = "The bus access from this external domain always have the non-secure attribute set"]
             NON_SECURE = 0x0,
@@ -23343,7 +31704,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum FlashnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -23394,7 +31756,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PeriphidPermSecuremapping {
             #[doc = "This peripheral is always accessible as a non-secure peripheral"]
             NON_SECURE = 0x0,
@@ -23428,7 +31791,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "Peripheral is not present"]
             NOT_PRESENT = 0x0,
@@ -23458,7 +31822,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RamnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -23509,7 +31874,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tzm {
             #[doc = "Arm TrustZone support not available"]
             NOT_AVAILABLE = 0x0,
@@ -23659,6 +32025,26 @@ pub mod tad {
                 Clockstart(0)
             }
         }
+        impl core::fmt::Debug for Clockstart {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clockstart")
+                    .field("start", &self.start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clockstart {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clockstart {
+                    start: bool,
+                }
+                let proxy = Clockstart {
+                    start: self.start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Stop all trace and debug clocks."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23680,6 +32066,24 @@ pub mod tad {
                 Clockstop(0)
             }
         }
+        impl core::fmt::Debug for Clockstop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clockstop")
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clockstop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clockstop {
+                    stop: bool,
+                }
+                let proxy = Clockstop { stop: self.stop() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable debug domain and aquire selected GPIOs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23699,6 +32103,26 @@ pub mod tad {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clocking options for the Trace Port debug interface Reset behavior is the same as debug components"]
@@ -23724,6 +32148,26 @@ pub mod tad {
                 Traceportspeed(0)
             }
         }
+        impl core::fmt::Debug for Traceportspeed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceportspeed")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceportspeed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceportspeed {
+                    traceportspeed: super::vals::Traceportspeed,
+                }
+                let proxy = Traceportspeed {
+                    traceportspeed: self.traceportspeed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -23739,6 +32183,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTraceclkPin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0c => f.write_str("TRACECLK"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTraceclkPin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0c => defmt::write!(f, "TRACECLK"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTraceclkPin {
@@ -23768,6 +32229,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata0Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0b => f.write_str("TRACEDATA0"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata0Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0b => defmt::write!(f, "TRACEDATA0"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata0Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata0Pin {
@@ -23793,6 +32271,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTracedata1Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0a => f.write_str("TRACEDATA1"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata1Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0a => defmt::write!(f, "TRACEDATA1"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTracedata1Pin {
@@ -23822,6 +32317,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata2Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x09 => f.write_str("TRACEDATA2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata2Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x09 => defmt::write!(f, "TRACEDATA2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata2Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata2Pin {
@@ -23849,6 +32361,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata3Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x08 => f.write_str("TRACEDATA3"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata3Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x08 => defmt::write!(f, "TRACEDATA3"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata3Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata3Pin {
@@ -23862,7 +32391,8 @@ pub mod tad {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "Trace Port clock is: 64MHz"]
             _64MHZ = 0x0,
@@ -24079,6 +32609,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24106,6 +32656,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24127,6 +32714,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -24152,6 +32755,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24173,6 +32796,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -24217,10 +32860,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -24254,7 +32955,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -24630,6 +33332,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24651,6 +33373,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -24698,6 +33440,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24720,6 +33488,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -24811,6 +33599,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24832,6 +33658,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -24857,6 +33703,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24878,6 +33742,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -24947,6 +33831,38 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24968,6 +33884,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -24993,6 +33929,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25016,10 +33970,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -25083,6 +34058,29 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    0x0ff0_0000 => f.write_str("K1000"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    0x0ff0_0000 => defmt::write!(f, "K1000"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -25096,7 +34094,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -25132,7 +34131,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -25513,6 +34513,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25547,6 +34567,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25568,6 +34611,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -25613,6 +34676,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -25693,6 +34782,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25714,6 +34838,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -25739,6 +34883,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25760,6 +34920,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -25785,6 +34965,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25806,6 +35004,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -25842,6 +35060,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25863,6 +35104,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -25888,6 +35149,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25911,10 +35190,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -25958,7 +35258,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -25990,7 +35291,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -26414,6 +35716,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26470,6 +35792,35 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26491,6 +35842,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -26547,6 +35918,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -26682,6 +36082,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26705,6 +36155,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26726,6 +36196,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -26762,6 +36252,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26785,6 +36298,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26806,6 +36339,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -26859,6 +36412,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -26872,7 +36476,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -26908,7 +36513,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -26952,7 +36558,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -26982,7 +36589,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -27185,6 +36793,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::ApprotectPall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27207,6 +36833,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Eraseprotect {
                 Eraseprotect(0)
+            }
+        }
+        impl core::fmt::Debug for Eraseprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseprotect {
+                    pall: super::vals::EraseprotectPall,
+                }
+                let proxy = Eraseprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HFXO startup counter"]
@@ -27232,6 +36876,26 @@ pub mod uicr {
                 Hfxocnt(0)
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxocnt")
+                    .field("hfxocnt", &self.hfxocnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxocnt {
+                    hfxocnt: super::vals::Hfxocnt,
+                }
+                let proxy = Hfxocnt {
+                    hfxocnt: self.hfxocnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Setting of pins dedicated to NFC functionality: NFC antenna or GPIO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27253,6 +36917,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Nfcpins {
                 Nfcpins(0)
+            }
+        }
+        impl core::fmt::Debug for Nfcpins {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfcpins")
+                    .field("protect", &self.protect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfcpins {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfcpins {
+                    protect: super::vals::Protect,
+                }
+                let proxy = Nfcpins {
+                    protect: self.protect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: One time programmable memory"]
@@ -27287,6 +36971,29 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Otp {
                 Otp(0)
+            }
+        }
+        impl core::fmt::Debug for Otp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Otp")
+                    .field("lower", &self.lower())
+                    .field("upper", &self.upper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Otp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Otp {
+                    lower: u16,
+                    upper: u16,
+                }
+                let proxy = Otp {
+                    lower: self.lower(),
+                    upper: self.upper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Define permissions for the key slot. Bits 0-15 and 16-31 can only be written when equal to 0xFFFF."]
@@ -27346,6 +37053,35 @@ pub mod uicr {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("push", &self.push())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: bool,
+                    read: bool,
+                    push: bool,
+                    state: super::vals::State,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                    push: self.push(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Secure access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27368,6 +37104,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Secureapprotect {
                 Secureapprotect(0)
+            }
+        }
+        impl core::fmt::Debug for Secureapprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Secureapprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Secureapprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Secureapprotect {
+                    pall: super::vals::SecureapprotectPall,
+                }
+                let proxy = Secureapprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SW-DP Target instance"]
@@ -27393,6 +37147,26 @@ pub mod uicr {
                 Tinstance(0)
             }
         }
+        impl core::fmt::Debug for Tinstance {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tinstance")
+                    .field("tinstance", &self.tinstance())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tinstance {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tinstance {
+                    tinstance: u8,
+                }
+                let proxy = Tinstance {
+                    tinstance: self.tinstance(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output voltage from the high voltage (VREGH) regulator stage. The maximum output voltage from this stage is given as VDDH - VREGHDROP."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27416,6 +37190,26 @@ pub mod uicr {
                 Vreghvout(0)
             }
         }
+        impl core::fmt::Debug for Vreghvout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Vreghvout")
+                    .field("vreghvout", &self.vreghvout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Vreghvout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Vreghvout {
+                    vreghvout: super::vals::Vreghvout,
+                }
+                let proxy = Vreghvout {
+                    vreghvout: self.vreghvout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -27433,6 +37227,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0x50fa_50fa => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0x50fa_50fa => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectPall {
@@ -27462,6 +37275,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for EraseprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for EraseprotectPall {
@@ -27495,6 +37327,27 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_DEBOUNCE_TIME"),
+                    0xfe => f.write_str("MAX_DEBOUNCE_TIME"),
+                    0xff => f.write_str("DEFAULT_DEBOUNCE_TIME"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_DEBOUNCE_TIME"),
+                    0xfe => defmt::write!(f, "MAX_DEBOUNCE_TIME"),
+                    0xff => defmt::write!(f, "DEFAULT_DEBOUNCE_TIME"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxocnt {
             #[inline(always)]
             fn from(val: u8) -> Hfxocnt {
@@ -27508,7 +37361,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protect {
             #[doc = "Operation as GPIO pins. Same protection as normal GPIO pins"]
             DISABLED = 0x0,
@@ -27554,6 +37408,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for SecureapprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0x50fa_50fa => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0x50fa_50fa => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for SecureapprotectPall {
             #[inline(always)]
             fn from(val: u32) -> SecureapprotectPall {
@@ -27567,7 +37440,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Key value registers can no longer be read or pushed"]
             REVOKED = 0x0,
@@ -27597,7 +37471,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Vreghvout {
             #[doc = "1.8 V"]
             _1V8 = 0x0,
@@ -28317,6 +38192,32 @@ pub mod usbd {
                 Bmrequesttype(0)
             }
         }
+        impl core::fmt::Debug for Bmrequesttype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bmrequesttype")
+                    .field("recipient", &self.recipient())
+                    .field("type_", &self.type_())
+                    .field("direction", &self.direction())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bmrequesttype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bmrequesttype {
+                    recipient: super::vals::Recipient,
+                    type_: super::vals::Type,
+                    direction: super::vals::Io,
+                }
+                let proxy = Bmrequesttype {
+                    recipient: self.recipient(),
+                    type_: self.type_(),
+                    direction: self.direction(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 1, bRequest"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28340,6 +38241,26 @@ pub mod usbd {
                 Brequest(0)
             }
         }
+        impl core::fmt::Debug for Brequest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Brequest")
+                    .field("brequest", &self.brequest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Brequest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Brequest {
+                    brequest: super::vals::Brequest,
+                }
+                let proxy = Brequest {
+                    brequest: self.brequest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State D+ and D- lines will be forced into by the DPDMDRIVE task. The DPDMNODRIVE task reverts the control of the lines to MAC IP (no forcing)."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28361,6 +38282,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Dpdmvalue {
                 Dpdmvalue(0)
+            }
+        }
+        impl core::fmt::Debug for Dpdmvalue {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dpdmvalue")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dpdmvalue {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dpdmvalue {
+                    state: super::vals::State,
+                }
+                let proxy = Dpdmvalue {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data toggle control and status"]
@@ -28408,6 +38349,32 @@ pub mod usbd {
                 Dtoggle(0)
             }
         }
+        impl core::fmt::Debug for Dtoggle {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dtoggle")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dtoggle {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dtoggle {
+                    ep: u8,
+                    io: super::vals::Io,
+                    value: super::vals::Value,
+                }
+                let proxy = Dtoggle {
+                    ep: self.ep(),
+                    io: self.io(),
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable USB"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28429,6 +38396,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Provides information on which endpoint(s) an acknowledged data transfer has occurred (EPDATA event)"]
@@ -28473,6 +38460,67 @@ pub mod usbd {
                 Epdatastatus(0)
             }
         }
+        impl core::fmt::Debug for Epdatastatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epdatastatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epdatastatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epdatastatus {
+                    epin: [bool; 7usize],
+                    epout: [bool; 7usize],
+                }
+                let proxy = Epdatastatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: IN endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28495,6 +38543,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epin {
                 Epin(0)
+            }
+        }
+        impl core::fmt::Debug for Epin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epin")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epin {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = Epin {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
@@ -28520,6 +38588,26 @@ pub mod usbd {
                 EpinAmount(0)
             }
         }
+        impl core::fmt::Debug for EpinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinAmount {
+                    amount: u8,
+                }
+                let proxy = EpinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28541,6 +38629,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpinMaxcnt {
                 EpinMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpinMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint IN enable"]
@@ -28581,6 +38689,50 @@ pub mod usbd {
                 Epinen(0)
             }
         }
+        impl core::fmt::Debug for Epinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epinen")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("isoin", &self.isoin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epinen {
+                    in_: [bool; 8usize],
+                    isoin: bool,
+                }
+                let proxy = Epinen {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    isoin: self.isoin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28604,6 +38756,26 @@ pub mod usbd {
                 EpoutAmount(0)
             }
         }
+        impl core::fmt::Debug for EpoutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutAmount {
+                    amount: u8,
+                }
+                let proxy = EpoutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28625,6 +38797,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> EpoutMaxcnt {
                 EpoutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for EpoutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EpoutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EpoutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EpoutMaxcnt {
+                    maxcnt: u8,
+                }
+                let proxy = EpoutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Endpoint OUT enable"]
@@ -28663,6 +38855,50 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epouten {
                 Epouten(0)
+            }
+        }
+        impl core::fmt::Debug for Epouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epouten")
+                    .field(
+                        "out",
+                        &[
+                            self.out(0usize),
+                            self.out(1usize),
+                            self.out(2usize),
+                            self.out(3usize),
+                            self.out(4usize),
+                            self.out(5usize),
+                            self.out(6usize),
+                            self.out(7usize),
+                        ],
+                    )
+                    .field("isoout", &self.isoout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epouten {
+                    out: [bool; 8usize],
+                    isoout: bool,
+                }
+                let proxy = Epouten {
+                    out: [
+                        self.out(0usize),
+                        self.out(1usize),
+                        self.out(2usize),
+                        self.out(3usize),
+                        self.out(4usize),
+                        self.out(5usize),
+                        self.out(6usize),
+                        self.out(7usize),
+                    ],
+                    isoout: self.isoout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "STALL endpoints"]
@@ -28710,6 +38946,32 @@ pub mod usbd {
                 Epstall(0)
             }
         }
+        impl core::fmt::Debug for Epstall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstall")
+                    .field("ep", &self.ep())
+                    .field("io", &self.io())
+                    .field("stall", &self.stall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstall {
+                    ep: u8,
+                    io: super::vals::Io,
+                    stall: bool,
+                }
+                let proxy = Epstall {
+                    ep: self.ep(),
+                    io: self.io(),
+                    stall: self.stall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Provides information on which endpoint's EasyDMA registers have been captured"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28750,6 +39012,75 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Epstatus {
                 Epstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Epstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Epstatus")
+                    .field(
+                        "epin",
+                        &[
+                            self.epin(0usize),
+                            self.epin(1usize),
+                            self.epin(2usize),
+                            self.epin(3usize),
+                            self.epin(4usize),
+                            self.epin(5usize),
+                            self.epin(6usize),
+                            self.epin(7usize),
+                            self.epin(8usize),
+                        ],
+                    )
+                    .field(
+                        "epout",
+                        &[
+                            self.epout(0usize),
+                            self.epout(1usize),
+                            self.epout(2usize),
+                            self.epout(3usize),
+                            self.epout(4usize),
+                            self.epout(5usize),
+                            self.epout(6usize),
+                            self.epout(7usize),
+                            self.epout(8usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Epstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Epstatus {
+                    epin: [bool; 9usize],
+                    epout: [bool; 9usize],
+                }
+                let proxy = Epstatus {
+                    epin: [
+                        self.epin(0usize),
+                        self.epin(1usize),
+                        self.epin(2usize),
+                        self.epin(3usize),
+                        self.epin(4usize),
+                        self.epin(5usize),
+                        self.epin(6usize),
+                        self.epin(7usize),
+                        self.epin(8usize),
+                    ],
+                    epout: [
+                        self.epout(0usize),
+                        self.epout(1usize),
+                        self.epout(2usize),
+                        self.epout(3usize),
+                        self.epout(4usize),
+                        self.epout(5usize),
+                        self.epout(6usize),
+                        self.epout(7usize),
+                        self.epout(8usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Details on what caused the USBEVENT event"]
@@ -28819,6 +39150,38 @@ pub mod usbd {
                 Eventcause(0)
             }
         }
+        impl core::fmt::Debug for Eventcause {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eventcause")
+                    .field("isooutcrc", &self.isooutcrc())
+                    .field("suspend", &self.suspend())
+                    .field("resume", &self.resume())
+                    .field("usbwuallowed", &self.usbwuallowed())
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eventcause {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eventcause {
+                    isooutcrc: bool,
+                    suspend: bool,
+                    resume: bool,
+                    usbwuallowed: bool,
+                    ready: bool,
+                }
+                let proxy = Eventcause {
+                    isooutcrc: self.isooutcrc(),
+                    suspend: self.suspend(),
+                    resume: self.resume(),
+                    usbwuallowed: self.usbwuallowed(),
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Returns the current value of the start of frame counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28840,6 +39203,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Framecntr {
                 Framecntr(0)
+            }
+        }
+        impl core::fmt::Debug for Framecntr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framecntr")
+                    .field("framecntr", &self.framecntr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framecntr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framecntr {
+                    framecntr: u16,
+                }
+                let proxy = Framecntr {
+                    framecntr: self.framecntr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: OUT endpoint halted status. Can be used as is as response to a GetStatus() request to endpoint."]
@@ -28864,6 +39247,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> HaltedEpout {
                 HaltedEpout(0)
+            }
+        }
+        impl core::fmt::Debug for HaltedEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HaltedEpout")
+                    .field("getstatus", &self.getstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HaltedEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HaltedEpout {
+                    getstatus: super::vals::Getstatus,
+                }
+                let proxy = HaltedEpout {
+                    getstatus: self.getstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -29007,6 +39410,98 @@ pub mod usbd {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("usbreset", &self.usbreset())
+                    .field("started", &self.started())
+                    .field(
+                        "endepin",
+                        &[
+                            self.endepin(0usize),
+                            self.endepin(1usize),
+                            self.endepin(2usize),
+                            self.endepin(3usize),
+                            self.endepin(4usize),
+                            self.endepin(5usize),
+                            self.endepin(6usize),
+                            self.endepin(7usize),
+                        ],
+                    )
+                    .field("ep0datadone", &self.ep0datadone())
+                    .field("endisoin", &self.endisoin())
+                    .field(
+                        "endepout",
+                        &[
+                            self.endepout(0usize),
+                            self.endepout(1usize),
+                            self.endepout(2usize),
+                            self.endepout(3usize),
+                            self.endepout(4usize),
+                            self.endepout(5usize),
+                            self.endepout(6usize),
+                            self.endepout(7usize),
+                        ],
+                    )
+                    .field("endisoout", &self.endisoout())
+                    .field("sof", &self.sof())
+                    .field("usbevent", &self.usbevent())
+                    .field("ep0setup", &self.ep0setup())
+                    .field("epdata", &self.epdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    usbreset: bool,
+                    started: bool,
+                    endepin: [bool; 8usize],
+                    ep0datadone: bool,
+                    endisoin: bool,
+                    endepout: [bool; 8usize],
+                    endisoout: bool,
+                    sof: bool,
+                    usbevent: bool,
+                    ep0setup: bool,
+                    epdata: bool,
+                }
+                let proxy = Int {
+                    usbreset: self.usbreset(),
+                    started: self.started(),
+                    endepin: [
+                        self.endepin(0usize),
+                        self.endepin(1usize),
+                        self.endepin(2usize),
+                        self.endepin(3usize),
+                        self.endepin(4usize),
+                        self.endepin(5usize),
+                        self.endepin(6usize),
+                        self.endepin(7usize),
+                    ],
+                    ep0datadone: self.ep0datadone(),
+                    endisoin: self.endisoin(),
+                    endepout: [
+                        self.endepout(0usize),
+                        self.endepout(1usize),
+                        self.endepout(2usize),
+                        self.endepout(3usize),
+                        self.endepout(4usize),
+                        self.endepout(5usize),
+                        self.endepout(6usize),
+                        self.endepout(7usize),
+                    ],
+                    endisoout: self.endisoout(),
+                    sof: self.sof(),
+                    usbevent: self.usbevent(),
+                    ep0setup: self.ep0setup(),
+                    epdata: self.epdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29028,6 +39523,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsoinAmount {
                 IsoinAmount(0)
+            }
+        }
+        impl core::fmt::Debug for IsoinAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinAmount {
+                    amount: u16,
+                }
+                let proxy = IsoinAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -29053,6 +39568,26 @@ pub mod usbd {
                 IsoinMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for IsoinMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsoinMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsoinMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsoinMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsoinMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the response of the ISO IN endpoint to an IN token when no data is ready to be sent"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29074,6 +39609,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Isoinconfig {
                 Isoinconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Isoinconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoinconfig")
+                    .field("response", &self.response())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoinconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoinconfig {
+                    response: super::vals::Response,
+                }
+                let proxy = Isoinconfig {
+                    response: self.response(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received last on this ISO OUT data endpoint"]
@@ -29111,6 +39666,29 @@ pub mod usbd {
                 Isoout(0)
             }
         }
+        impl core::fmt::Debug for Isoout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isoout")
+                    .field("size", &self.size())
+                    .field("zero", &self.zero())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isoout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isoout {
+                    size: u16,
+                    zero: super::vals::Zero,
+                }
+                let proxy = Isoout {
+                    size: self.size(),
+                    zero: self.zero(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29134,6 +39712,26 @@ pub mod usbd {
                 IsooutAmount(0)
             }
         }
+        impl core::fmt::Debug for IsooutAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutAmount {
+                    amount: u16,
+                }
+                let proxy = IsooutAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29155,6 +39753,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> IsooutMaxcnt {
                 IsooutMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for IsooutMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IsooutMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IsooutMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IsooutMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = IsooutMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the split of ISO buffers"]
@@ -29181,6 +39799,26 @@ pub mod usbd {
                 Isosplit(0)
             }
         }
+        impl core::fmt::Debug for Isosplit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isosplit")
+                    .field("split", &self.split())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isosplit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isosplit {
+                    split: super::vals::Split,
+                }
+                let proxy = Isosplit {
+                    split: self.split(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls USBD peripheral low power mode during USB suspend"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29202,6 +39840,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Lowpower {
                 Lowpower(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpower")
+                    .field("lowpower", &self.lowpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpower {
+                    lowpower: super::vals::Lowpower,
+                }
+                let proxy = Lowpower {
+                    lowpower: self.lowpower(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -29271,6 +39929,38 @@ pub mod usbd {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ep0datadone_startepin0", &self.ep0datadone_startepin0())
+                    .field("ep0datadone_startepout0", &self.ep0datadone_startepout0())
+                    .field("ep0datadone_ep0status", &self.ep0datadone_ep0status())
+                    .field("endepout0_ep0status", &self.endepout0_ep0status())
+                    .field("endepout0_ep0rcvout", &self.endepout0_ep0rcvout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ep0datadone_startepin0: bool,
+                    ep0datadone_startepout0: bool,
+                    ep0datadone_ep0status: bool,
+                    endepout0_ep0status: bool,
+                    endepout0_ep0rcvout: bool,
+                }
+                let proxy = Shorts {
+                    ep0datadone_startepin0: self.ep0datadone_startepin0(),
+                    ep0datadone_startepout0: self.ep0datadone_startepout0(),
+                    ep0datadone_ep0status: self.ep0datadone_ep0status(),
+                    endepout0_ep0status: self.endepout0_ep0status(),
+                    endepout0_ep0rcvout: self.endepout0_ep0rcvout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Number of bytes received last in the data stage of this OUT endpoint"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29292,6 +39982,24 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> SizeEpout {
                 SizeEpout(0)
+            }
+        }
+        impl core::fmt::Debug for SizeEpout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SizeEpout")
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SizeEpout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SizeEpout {
+                    size: u8,
+                }
+                let proxy = SizeEpout { size: self.size() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device USB address"]
@@ -29317,6 +40025,24 @@ pub mod usbd {
                 Usbaddr(0)
             }
         }
+        impl core::fmt::Debug for Usbaddr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbaddr")
+                    .field("addr", &self.addr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbaddr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbaddr {
+                    addr: u8,
+                }
+                let proxy = Usbaddr { addr: self.addr() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Control of the USB pull-up"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29338,6 +40064,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Usbpullup {
                 Usbpullup(0)
+            }
+        }
+        impl core::fmt::Debug for Usbpullup {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbpullup")
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbpullup {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbpullup {
+                    connect: bool,
+                }
+                let proxy = Usbpullup {
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 5, MSB of wIndex"]
@@ -29363,6 +40109,26 @@ pub mod usbd {
                 Windexh(0)
             }
         }
+        impl core::fmt::Debug for Windexh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexh")
+                    .field("windexh", &self.windexh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexh {
+                    windexh: u8,
+                }
+                let proxy = Windexh {
+                    windexh: self.windexh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 4, LSB of wIndex"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29384,6 +40150,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Windexl {
                 Windexl(0)
+            }
+        }
+        impl core::fmt::Debug for Windexl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Windexl")
+                    .field("windexl", &self.windexl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Windexl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Windexl {
+                    windexl: u8,
+                }
+                let proxy = Windexl {
+                    windexl: self.windexl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 7, MSB of wLength"]
@@ -29409,6 +40195,26 @@ pub mod usbd {
                 Wlengthh(0)
             }
         }
+        impl core::fmt::Debug for Wlengthh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthh")
+                    .field("wlengthh", &self.wlengthh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthh {
+                    wlengthh: u8,
+                }
+                let proxy = Wlengthh {
+                    wlengthh: self.wlengthh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 6, LSB of wLength"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29430,6 +40236,26 @@ pub mod usbd {
             #[inline(always)]
             fn default() -> Wlengthl {
                 Wlengthl(0)
+            }
+        }
+        impl core::fmt::Debug for Wlengthl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wlengthl")
+                    .field("wlengthl", &self.wlengthl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wlengthl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wlengthl {
+                    wlengthl: u8,
+                }
+                let proxy = Wlengthl {
+                    wlengthl: self.wlengthl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SETUP data, byte 3, MSB of wValue"]
@@ -29455,6 +40281,26 @@ pub mod usbd {
                 Wvalueh(0)
             }
         }
+        impl core::fmt::Debug for Wvalueh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvalueh")
+                    .field("wvalueh", &self.wvalueh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvalueh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvalueh {
+                    wvalueh: u8,
+                }
+                let proxy = Wvalueh {
+                    wvalueh: self.wvalueh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SETUP data, byte 2, LSB of wValue"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29478,10 +40324,31 @@ pub mod usbd {
                 Wvaluel(0)
             }
         }
+        impl core::fmt::Debug for Wvaluel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Wvaluel")
+                    .field("wvaluel", &self.wvaluel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Wvaluel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Wvaluel {
+                    wvaluel: u8,
+                }
+                let proxy = Wvaluel {
+                    wvaluel: self.wvaluel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Brequest {
             #[doc = "Standard request GET_STATUS"]
             STD_GET_STATUS = 0x0,
@@ -29790,6 +40657,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Getstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("NOT_HALTED"),
+                    0x01 => f.write_str("HALTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Getstatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "NOT_HALTED"),
+                    0x01 => defmt::write!(f, "HALTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Getstatus {
             #[inline(always)]
             fn from(val: u16) -> Getstatus {
@@ -29803,7 +40689,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Io {
             #[doc = "Selects OUT endpoint"]
             OUT = 0x0,
@@ -29833,7 +40720,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lowpower {
             #[doc = "Software must write this value to exit low power mode and before performing a remote wake-up"]
             FORCE_NORMAL = 0x0,
@@ -29883,6 +40771,29 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Recipient {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DEVICE"),
+                    0x01 => f.write_str("INTERFACE"),
+                    0x02 => f.write_str("ENDPOINT"),
+                    0x03 => f.write_str("OTHER"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Recipient {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DEVICE"),
+                    0x01 => defmt::write!(f, "INTERFACE"),
+                    0x02 => defmt::write!(f, "ENDPOINT"),
+                    0x03 => defmt::write!(f, "OTHER"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Recipient {
             #[inline(always)]
             fn from(val: u8) -> Recipient {
@@ -29896,7 +40807,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Response {
             #[doc = "Endpoint does not respond in that case"]
             NO_RESP = 0x0,
@@ -29942,6 +40854,25 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for Split {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("ONE_DIR"),
+                    0x80 => f.write_str("HALF_IN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Split {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "ONE_DIR"),
+                    0x80 => defmt::write!(f, "HALF_IN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Split {
             #[inline(always)]
             fn from(val: u16) -> Split {
@@ -29973,6 +40904,27 @@ pub mod usbd {
                 self.0
             }
         }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("RESUME"),
+                    0x02 => f.write_str("J"),
+                    0x04 => f.write_str("K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "RESUME"),
+                    0x02 => defmt::write!(f, "J"),
+                    0x04 => defmt::write!(f, "K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for State {
             #[inline(always)]
             fn from(val: u8) -> State {
@@ -29986,7 +40938,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Type {
             #[doc = "Standard"]
             STANDARD = 0x0,
@@ -30019,7 +40972,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Value {
             #[doc = "No action on data toggle when writing the register with this value"]
             NOP = 0x0,
@@ -30052,7 +41006,8 @@ pub mod usbd {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Zero {
             #[doc = "No zero-length data received, use value in SIZE"]
             NORMAL = 0x0,
@@ -30205,6 +41160,32 @@ pub mod usbreg {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("usbdetected", &self.usbdetected())
+                    .field("usbremoved", &self.usbremoved())
+                    .field("usbpwrrdy", &self.usbpwrrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    usbdetected: bool,
+                    usbremoved: bool,
+                    usbpwrrdy: bool,
+                }
+                let proxy = Int {
+                    usbdetected: self.usbdetected(),
+                    usbremoved: self.usbremoved(),
+                    usbpwrrdy: self.usbpwrrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "USB supply status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30237,6 +41218,29 @@ pub mod usbreg {
             #[inline(always)]
             fn default() -> Usbregstatus {
                 Usbregstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Usbregstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Usbregstatus")
+                    .field("vbusdetect", &self.vbusdetect())
+                    .field("outputrdy", &self.outputrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Usbregstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Usbregstatus {
+                    vbusdetect: bool,
+                    outputrdy: bool,
+                }
+                let proxy = Usbregstatus {
+                    vbusdetect: self.vbusdetect(),
+                    outputrdy: self.outputrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -30338,6 +41342,103 @@ pub mod vmc {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "spower",
+                        &[
+                            self.spower(0usize),
+                            self.spower(1usize),
+                            self.spower(2usize),
+                            self.spower(3usize),
+                            self.spower(4usize),
+                            self.spower(5usize),
+                            self.spower(6usize),
+                            self.spower(7usize),
+                            self.spower(8usize),
+                            self.spower(9usize),
+                            self.spower(10usize),
+                            self.spower(11usize),
+                            self.spower(12usize),
+                            self.spower(13usize),
+                            self.spower(14usize),
+                            self.spower(15usize),
+                        ],
+                    )
+                    .field(
+                        "sretention",
+                        &[
+                            self.sretention(0usize),
+                            self.sretention(1usize),
+                            self.sretention(2usize),
+                            self.sretention(3usize),
+                            self.sretention(4usize),
+                            self.sretention(5usize),
+                            self.sretention(6usize),
+                            self.sretention(7usize),
+                            self.sretention(8usize),
+                            self.sretention(9usize),
+                            self.sretention(10usize),
+                            self.sretention(11usize),
+                            self.sretention(12usize),
+                            self.sretention(13usize),
+                            self.sretention(14usize),
+                            self.sretention(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    spower: [bool; 16usize],
+                    sretention: [bool; 16usize],
+                }
+                let proxy = Power {
+                    spower: [
+                        self.spower(0usize),
+                        self.spower(1usize),
+                        self.spower(2usize),
+                        self.spower(3usize),
+                        self.spower(4usize),
+                        self.spower(5usize),
+                        self.spower(6usize),
+                        self.spower(7usize),
+                        self.spower(8usize),
+                        self.spower(9usize),
+                        self.spower(10usize),
+                        self.spower(11usize),
+                        self.spower(12usize),
+                        self.spower(13usize),
+                        self.spower(14usize),
+                        self.spower(15usize),
+                    ],
+                    sretention: [
+                        self.sretention(0usize),
+                        self.sretention(1usize),
+                        self.sretention(2usize),
+                        self.sretention(3usize),
+                        self.sretention(4usize),
+                        self.sretention(5usize),
+                        self.sretention(6usize),
+                        self.sretention(7usize),
+                        self.sretention(8usize),
+                        self.sretention(9usize),
+                        self.sretention(10usize),
+                        self.sretention(11usize),
+                        self.sretention(12usize),
+                        self.sretention(13usize),
+                        self.sretention(14usize),
+                        self.sretention(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -30510,6 +41611,32 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .field("stopen", &self.stopen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                    stopen: bool,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                    stopen: self.stopen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30542,6 +41669,29 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -30578,6 +41728,29 @@ pub mod wdt {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Nmi {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Request status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30605,6 +41778,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30627,6 +41841,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -30656,6 +41886,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30677,6 +41948,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Runstatus {
                 Runstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Task stop enable"]
@@ -30703,10 +41994,27 @@ pub mod wdt {
                 Tsen(0)
             }
         }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tsen").field("tsen", &self.tsen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tsen {
+                    tsen: super::vals::Tsen,
+                }
+                let proxy = Tsen { tsen: self.tsen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause WDT while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -30750,6 +42058,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -30763,7 +42088,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause WDT while the CPU is sleeping"]
             PAUSE = 0x0,
@@ -30805,6 +42131,23 @@ pub mod wdt {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("ENABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "ENABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Tsen {

--- a/src/chips/nrf5340-net/pac.rs
+++ b/src/chips/nrf5340-net/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "5 - CLOCK_POWER"]
     CLOCK_POWER = 5,
@@ -346,6 +347,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -391,6 +412,32 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of IRKs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -412,6 +459,22 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Nirk {
                 Nirk(0)
+            }
+        }
+        impl core::fmt::Debug for Nirk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nirk").field("nirk", &self.nirk()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nirk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nirk {
+                    nirk: u8,
+                }
+                let proxy = Nirk { nirk: self.nirk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Resolution status"]
@@ -437,10 +500,31 @@ pub mod aar {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: u8,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -564,10 +648,34 @@ pub mod acl {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: super::vals::Write,
+                    read: super::vals::Read,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Read {
             #[doc = "Allow read instructions to region n."]
             ENABLE = 0x0,
@@ -597,7 +705,8 @@ pub mod acl {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Write {
             #[doc = "Allow write and erase instructions to region n."]
             ENABLE = 0x0,
@@ -823,6 +932,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Header (S0) mask."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -844,6 +973,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Headermask {
                 Headermask(0)
+            }
+        }
+        impl core::fmt::Debug for Headermask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Headermask")
+                    .field("headermask", &self.headermask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Headermask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Headermask {
+                    headermask: u8,
+                }
+                let proxy = Headermask {
+                    headermask: self.headermask(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -891,6 +1040,32 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endksgen", &self.endksgen())
+                    .field("endcrypt", &self.endcrypt())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endksgen: bool,
+                    endcrypt: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    endksgen: self.endksgen(),
+                    endcrypt: self.endcrypt(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Length of keystream generated when MODE.LENGTH = Extended"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -914,6 +1089,26 @@ pub mod ccm {
                 Maxpacketsize(0)
             }
         }
+        impl core::fmt::Debug for Maxpacketsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxpacketsize")
+                    .field("maxpacketsize", &self.maxpacketsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxpacketsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxpacketsize {
+                    maxpacketsize: u8,
+                }
+                let proxy = Maxpacketsize {
+                    maxpacketsize: self.maxpacketsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MIC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -935,6 +1130,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Micstatus {
                 Micstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Micstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Micstatus")
+                    .field("micstatus", &self.micstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Micstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Micstatus {
+                    micstatus: super::vals::Micstatus,
+                }
+                let proxy = Micstatus {
+                    micstatus: self.micstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -984,6 +1199,32 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("datarate", &self.datarate())
+                    .field("length", &self.length())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    datarate: super::vals::Datarate,
+                    length: super::vals::Length,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    datarate: self.datarate(),
+                    length: self.length(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1005,6 +1246,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Rateoverride {
                 Rateoverride(0)
+            }
+        }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -1030,10 +1291,31 @@ pub mod ccm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endksgen_crypt", &self.endksgen_crypt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endksgen_crypt: bool,
+                }
+                let proxy = Shorts {
+                    endksgen_crypt: self.endksgen_crypt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1067,7 +1349,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1099,7 +1382,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Length {
             #[doc = "Default length. Effective length of LENGTH field in encrypted/decrypted packet is 5 bits. A keystream for packet payloads up to 27 bytes will be generated."]
             DEFAULT = 0x0,
@@ -1129,7 +1413,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Micstatus {
             #[doc = "MIC check failed"]
             CHECK_FAILED = 0x0,
@@ -1159,7 +1444,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -1189,7 +1475,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "1 Mbps"]
             _1MBIT = 0x0,
@@ -1438,6 +1725,26 @@ pub mod clock {
                 Hfclkalwaysrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkalwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkalwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkalwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkalwaysrun {
+                    alwaysrun: super::vals::HfclkalwaysrunAlwaysrun,
+                }
+                let proxy = Hfclkalwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFCLK128M frequency configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1459,6 +1766,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkctrl {
                 Hfclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkctrl")
+                    .field("hclk", &self.hclk())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkctrl {
+                    hclk: super::vals::Hclk,
+                }
+                let proxy = Hfclkctrl { hclk: self.hclk() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating that HFCLKSTART task has been triggered"]
@@ -1484,6 +1809,26 @@ pub mod clock {
                 Hfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for HFCLK128M/HFCLK64M"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1505,6 +1850,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclksrc {
                 Hfclksrc(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclksrc {
+                    src: super::vals::HfclksrcSrc,
+                }
+                let proxy = Hfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which HFCLK128M/HFCLK64M source is running This register value in any CLOCK instance reflects status only due to configurations/actions in that CLOCK instance."]
@@ -1552,6 +1915,32 @@ pub mod clock {
                 Hfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1597,6 +1986,32 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Automatic or manual control of LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1618,6 +2033,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkalwaysrun {
                 Lfclkalwaysrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkalwaysrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkalwaysrun")
+                    .field("alwaysrun", &self.alwaysrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkalwaysrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkalwaysrun {
+                    alwaysrun: super::vals::LfclkalwaysrunAlwaysrun,
+                }
+                let proxy = Lfclkalwaysrun {
+                    alwaysrun: self.alwaysrun(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
@@ -1643,6 +2078,26 @@ pub mod clock {
                 Lfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1666,6 +2121,24 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set when LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1687,6 +2160,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status indicating which LFCLK source is running This register value in any CLOCK instance reflects status only due to configurations/actions in that CLOCK instance."]
@@ -1734,10 +2225,37 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hclk {
             #[doc = "Divide HFCLK by 1"]
             DIV1 = 0x0,
@@ -1769,7 +2287,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkalwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -1799,7 +2318,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclksrcSrc {
             #[doc = "HFCLKSTART task starts HFINT oscillator"]
             HFINT = 0x0,
@@ -1829,7 +2349,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "Clock source: HFINT - 128 MHz on-chip oscillator"]
             HFINT = 0x0,
@@ -1859,7 +2380,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LfclkalwaysrunAlwaysrun {
             #[doc = "Use automatic clock control"]
             AUTOMATIC = 0x0,
@@ -1889,7 +2411,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             _RESERVED_0 = 0x0,
             #[doc = "32.768 kHz RC oscillator"]
@@ -2186,6 +2709,26 @@ pub mod cti {
                 Cidr0(0)
             }
         }
+        impl core::fmt::Debug for Cidr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr0")
+                    .field("prmbl_0", &self.prmbl_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr0 {
+                    prmbl_0: super::vals::Prmbl0,
+                }
+                let proxy = Cidr0 {
+                    prmbl_0: self.prmbl_0(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID1 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2220,6 +2763,29 @@ pub mod cti {
                 Cidr1(0)
             }
         }
+        impl core::fmt::Debug for Cidr1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr1")
+                    .field("prmbl_1", &self.prmbl_1())
+                    .field("class", &self.class())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr1 {
+                    prmbl_1: super::vals::Prmbl1,
+                    class: super::vals::Class,
+                }
+                let proxy = Cidr1 {
+                    prmbl_1: self.prmbl_1(),
+                    class: self.class(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID2 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2243,6 +2809,26 @@ pub mod cti {
                 Cidr2(0)
             }
         }
+        impl core::fmt::Debug for Cidr2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr2")
+                    .field("prmbl_2", &self.prmbl_2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr2 {
+                    prmbl_2: super::vals::Prmbl2,
+                }
+                let proxy = Cidr2 {
+                    prmbl_2: self.prmbl_2(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Component ID3 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2264,6 +2850,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Cidr3 {
                 Cidr3(0)
+            }
+        }
+        impl core::fmt::Debug for Cidr3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cidr3")
+                    .field("prmbl_3", &self.prmbl_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cidr3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cidr3 {
+                    prmbl_3: super::vals::Prmbl3,
+                }
+                let proxy = Cidr3 {
+                    prmbl_3: self.prmbl_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Application Trigger Clear register"]
@@ -2322,6 +2928,35 @@ pub mod cti {
                 Ctiappclear(0)
             }
         }
+        impl core::fmt::Debug for Ctiappclear {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiappclear")
+                    .field("appclear_0", &self.appclear_0())
+                    .field("appclear_1", &self.appclear_1())
+                    .field("appclear_2", &self.appclear_2())
+                    .field("appclear_3", &self.appclear_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiappclear {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiappclear {
+                    appclear_0: bool,
+                    appclear_1: bool,
+                    appclear_2: bool,
+                    appclear_3: bool,
+                }
+                let proxy = Ctiappclear {
+                    appclear_0: self.appclear_0(),
+                    appclear_1: self.appclear_1(),
+                    appclear_2: self.appclear_2(),
+                    appclear_3: self.appclear_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Application Pulse register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2376,6 +3011,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiapppulse {
                 Ctiapppulse(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiapppulse {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiapppulse")
+                    .field("appulse_0", &self.appulse_0())
+                    .field("appulse_1", &self.appulse_1())
+                    .field("appulse_2", &self.appulse_2())
+                    .field("appulse_3", &self.appulse_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiapppulse {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiapppulse {
+                    appulse_0: bool,
+                    appulse_1: bool,
+                    appulse_2: bool,
+                    appulse_3: bool,
+                }
+                let proxy = Ctiapppulse {
+                    appulse_0: self.appulse_0(),
+                    appulse_1: self.appulse_1(),
+                    appulse_2: self.appulse_2(),
+                    appulse_3: self.appulse_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Application Trigger Set register"]
@@ -2434,6 +3098,35 @@ pub mod cti {
                 Ctiappset(0)
             }
         }
+        impl core::fmt::Debug for Ctiappset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiappset")
+                    .field("appset_0", &self.appset_0())
+                    .field("appset_1", &self.appset_1())
+                    .field("appset_2", &self.appset_2())
+                    .field("appset_3", &self.appset_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiappset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiappset {
+                    appset_0: super::vals::Appset0,
+                    appset_1: super::vals::Appset1,
+                    appset_2: super::vals::Appset2,
+                    appset_3: super::vals::Appset3,
+                }
+                let proxy = Ctiappset {
+                    appset_0: self.appset_0(),
+                    appset_1: self.appset_1(),
+                    appset_2: self.appset_2(),
+                    appset_3: self.appset_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Channel In Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2490,6 +3183,35 @@ pub mod cti {
                 Ctichinstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctichinstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctichinstatus")
+                    .field("ctichinstatus_0", &self.ctichinstatus_0())
+                    .field("ctichinstatus_1", &self.ctichinstatus_1())
+                    .field("ctichinstatus_2", &self.ctichinstatus_2())
+                    .field("ctichinstatus_3", &self.ctichinstatus_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctichinstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctichinstatus {
+                    ctichinstatus_0: bool,
+                    ctichinstatus_1: bool,
+                    ctichinstatus_2: bool,
+                    ctichinstatus_3: bool,
+                }
+                let proxy = Ctichinstatus {
+                    ctichinstatus_0: self.ctichinstatus_0(),
+                    ctichinstatus_1: self.ctichinstatus_1(),
+                    ctichinstatus_2: self.ctichinstatus_2(),
+                    ctichinstatus_3: self.ctichinstatus_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Control register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2511,6 +3233,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Cticontrol {
                 Cticontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Cticontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cticontrol")
+                    .field("glben", &self.glben())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cticontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cticontrol {
+                    glben: bool,
+                }
+                let proxy = Cticontrol {
+                    glben: self.glben(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable CTI Channel Gate register"]
@@ -2569,6 +3311,35 @@ pub mod cti {
                 Ctigate(0)
             }
         }
+        impl core::fmt::Debug for Ctigate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctigate")
+                    .field("ctigateen_0", &self.ctigateen_0())
+                    .field("ctigateen_1", &self.ctigateen_1())
+                    .field("ctigateen_2", &self.ctigateen_2())
+                    .field("ctigateen_3", &self.ctigateen_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctigate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctigate {
+                    ctigateen_0: bool,
+                    ctigateen_1: bool,
+                    ctigateen_2: bool,
+                    ctigateen_3: bool,
+                }
+                let proxy = Ctigate {
+                    ctigateen_0: self.ctigateen_0(),
+                    ctigateen_1: self.ctigateen_1(),
+                    ctigateen_2: self.ctigateen_2(),
+                    ctigateen_3: self.ctigateen_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: CTI Trigger input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2623,6 +3394,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiinen {
                 Ctiinen(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiinen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiinen")
+                    .field("triginen_0", &self.triginen_0())
+                    .field("triginen_1", &self.triginen_1())
+                    .field("triginen_2", &self.triginen_2())
+                    .field("triginen_3", &self.triginen_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiinen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiinen {
+                    triginen_0: bool,
+                    triginen_1: bool,
+                    triginen_2: bool,
+                    triginen_3: bool,
+                }
+                let proxy = Ctiinen {
+                    triginen_0: self.triginen_0(),
+                    triginen_1: self.triginen_1(),
+                    triginen_2: self.triginen_2(),
+                    triginen_3: self.triginen_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Interrupt Acknowledge register"]
@@ -2725,6 +3525,47 @@ pub mod cti {
                 Ctiintack(0)
             }
         }
+        impl core::fmt::Debug for Ctiintack {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiintack")
+                    .field("debugreq", &self.debugreq())
+                    .field("cpurestart", &self.cpurestart())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .field("unused2", &self.unused2())
+                    .field("unused3", &self.unused3())
+                    .field("unused4", &self.unused4())
+                    .field("unused5", &self.unused5())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiintack {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiintack {
+                    debugreq: bool,
+                    cpurestart: bool,
+                    unused0: bool,
+                    unused1: bool,
+                    unused2: bool,
+                    unused3: bool,
+                    unused4: bool,
+                    unused5: bool,
+                }
+                let proxy = Ctiintack {
+                    debugreq: self.debugreq(),
+                    cpurestart: self.cpurestart(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                    unused2: self.unused2(),
+                    unused3: self.unused3(),
+                    unused4: self.unused4(),
+                    unused5: self.unused5(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: CTI Trigger output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2779,6 +3620,35 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Ctiouten {
                 Ctiouten(0)
+            }
+        }
+        impl core::fmt::Debug for Ctiouten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctiouten")
+                    .field("trigouten_0", &self.trigouten_0())
+                    .field("trigouten_1", &self.trigouten_1())
+                    .field("trigouten_2", &self.trigouten_2())
+                    .field("trigouten_3", &self.trigouten_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctiouten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctiouten {
+                    trigouten_0: bool,
+                    trigouten_1: bool,
+                    trigouten_2: bool,
+                    trigouten_3: bool,
+                }
+                let proxy = Ctiouten {
+                    trigouten_0: self.trigouten_0(),
+                    trigouten_1: self.trigouten_1(),
+                    trigouten_2: self.trigouten_2(),
+                    trigouten_3: self.trigouten_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CTI Trigger In Status register"]
@@ -2881,6 +3751,47 @@ pub mod cti {
                 Ctitriginstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctitriginstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctitriginstatus")
+                    .field("cpuhalted", &self.cpuhalted())
+                    .field("dwtcompout0", &self.dwtcompout0())
+                    .field("dwtcompout1", &self.dwtcompout1())
+                    .field("dwtcompout2", &self.dwtcompout2())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .field("unused2", &self.unused2())
+                    .field("unused3", &self.unused3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctitriginstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctitriginstatus {
+                    cpuhalted: bool,
+                    dwtcompout0: bool,
+                    dwtcompout1: bool,
+                    dwtcompout2: bool,
+                    unused0: bool,
+                    unused1: bool,
+                    unused2: bool,
+                    unused3: bool,
+                }
+                let proxy = Ctitriginstatus {
+                    cpuhalted: self.cpuhalted(),
+                    dwtcompout0: self.dwtcompout0(),
+                    dwtcompout1: self.dwtcompout1(),
+                    dwtcompout2: self.dwtcompout2(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                    unused2: self.unused2(),
+                    unused3: self.unused3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTI Trigger Out Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2981,6 +3892,47 @@ pub mod cti {
                 Ctitrigoutstatus(0)
             }
         }
+        impl core::fmt::Debug for Ctitrigoutstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctitrigoutstatus")
+                    .field("debugreq", &self.debugreq())
+                    .field("cpurestart", &self.cpurestart())
+                    .field("unused0", &self.unused0())
+                    .field("unused1", &self.unused1())
+                    .field("unused2", &self.unused2())
+                    .field("unused3", &self.unused3())
+                    .field("unused4", &self.unused4())
+                    .field("unused5", &self.unused5())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctitrigoutstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctitrigoutstatus {
+                    debugreq: bool,
+                    cpurestart: bool,
+                    unused0: bool,
+                    unused1: bool,
+                    unused2: bool,
+                    unused3: bool,
+                    unused4: bool,
+                    unused5: bool,
+                }
+                let proxy = Ctitrigoutstatus {
+                    debugreq: self.debugreq(),
+                    cpurestart: self.cpurestart(),
+                    unused0: self.unused0(),
+                    unused1: self.unused1(),
+                    unused2: self.unused2(),
+                    unused3: self.unused3(),
+                    unused4: self.unused4(),
+                    unused5: self.unused5(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device Architecture register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3002,6 +3954,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Devarch {
                 Devarch(0)
+            }
+        }
+        impl core::fmt::Debug for Devarch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devarch")
+                    .field("architecture", &self.architecture())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devarch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devarch {
+                    architecture: bool,
+                }
+                let proxy = Devarch {
+                    architecture: self.architecture(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device Configuration register"]
@@ -3049,6 +4021,32 @@ pub mod cti {
                 Devid(0)
             }
         }
+        impl core::fmt::Debug for Devid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devid")
+                    .field("extmuxnum", &self.extmuxnum())
+                    .field("numtrig", &self.numtrig())
+                    .field("numch", &self.numch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devid {
+                    extmuxnum: u8,
+                    numtrig: u8,
+                    numch: u8,
+                }
+                let proxy = Devid {
+                    extmuxnum: self.extmuxnum(),
+                    numtrig: self.numtrig(),
+                    numch: self.numch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device Type Identifier register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3083,6 +4081,29 @@ pub mod cti {
                 Devtype(0)
             }
         }
+        impl core::fmt::Debug for Devtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devtype")
+                    .field("major", &self.major())
+                    .field("sub", &self.sub())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devtype {
+                    major: super::vals::Major,
+                    sub: super::vals::Sub,
+                }
+                let proxy = Devtype {
+                    major: self.major(),
+                    sub: self.sub(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral ID0 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3104,6 +4125,26 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr0 {
                 Pidr0(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr0")
+                    .field("part_0", &self.part_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr0 {
+                    part_0: super::vals::Part0,
+                }
+                let proxy = Pidr0 {
+                    part_0: self.part_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID1 Register"]
@@ -3138,6 +4179,29 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr1 {
                 Pidr1(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr1")
+                    .field("part_1", &self.part_1())
+                    .field("des_0", &self.des_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr1 {
+                    part_1: super::vals::Part1,
+                    des_0: super::vals::Des0,
+                }
+                let proxy = Pidr1 {
+                    part_1: self.part_1(),
+                    des_0: self.des_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID2 Register"]
@@ -3185,6 +4249,32 @@ pub mod cti {
                 Pidr2(0)
             }
         }
+        impl core::fmt::Debug for Pidr2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr2")
+                    .field("des_1", &self.des_1())
+                    .field("jedec", &self.jedec())
+                    .field("revision", &self.revision())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr2 {
+                    des_1: super::vals::Des1,
+                    jedec: bool,
+                    revision: super::vals::Revision,
+                }
+                let proxy = Pidr2 {
+                    des_1: self.des_1(),
+                    jedec: self.jedec(),
+                    revision: self.revision(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral ID3 Register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3217,6 +4307,29 @@ pub mod cti {
             #[inline(always)]
             fn default() -> Pidr3 {
                 Pidr3(0)
+            }
+        }
+        impl core::fmt::Debug for Pidr3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr3")
+                    .field("cmod", &self.cmod())
+                    .field("revand", &self.revand())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr3 {
+                    cmod: super::vals::Cmod,
+                    revand: super::vals::Revand,
+                }
+                let proxy = Pidr3 {
+                    cmod: self.cmod(),
+                    revand: self.revand(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Peripheral ID4 Register"]
@@ -3253,10 +4366,34 @@ pub mod cti {
                 Pidr4(0)
             }
         }
+        impl core::fmt::Debug for Pidr4 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pidr4")
+                    .field("des_2", &self.des_2())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pidr4 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pidr4 {
+                    des_2: super::vals::Des2,
+                    size: u8,
+                }
+                let proxy = Pidr4 {
+                    des_2: self.des_2(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset0 {
             #[doc = "Application trigger 0 is inactive."]
             INACTIVE = 0x0,
@@ -3286,7 +4423,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset1 {
             #[doc = "Application trigger 1 is inactive."]
             INACTIVE = 0x0,
@@ -3316,7 +4454,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset2 {
             #[doc = "Application trigger 2 is inactive."]
             INACTIVE = 0x0,
@@ -3346,7 +4485,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Appset3 {
             #[doc = "Application trigger 3 is inactive."]
             INACTIVE = 0x0,
@@ -3376,7 +4516,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Class {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3419,7 +4560,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cmod {
             #[doc = "Indicates that the customer has not modified this component."]
             UNMODIFIED = 0x0,
@@ -3462,7 +4604,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des0 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3505,7 +4648,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des1 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3540,7 +4684,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Des2 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3583,7 +4728,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Major {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3640,6 +4786,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x21 => f.write_str("PARTNUMBER_L"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x21 => defmt::write!(f, "PARTNUMBER_L"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Part0 {
             #[inline(always)]
             fn from(val: u8) -> Part0 {
@@ -3653,7 +4816,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Part1 {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -3710,6 +4874,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0d => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl0 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0d => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl0 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl0 {
@@ -3723,7 +4904,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prmbl1 {
             #[doc = "Bits\\[11:8\\] of the identification code."]
             VALUE = 0x0,
@@ -3780,6 +4962,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x05 => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl2 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x05 => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl2 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl2 {
@@ -3807,6 +5006,23 @@ pub mod cti {
                 self.0
             }
         }
+        impl core::fmt::Debug for Prmbl3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xb1 => f.write_str("VALUE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prmbl3 {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xb1 => defmt::write!(f, "VALUE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Prmbl3 {
             #[inline(always)]
             fn from(val: u8) -> Prmbl3 {
@@ -3820,7 +5036,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Revand {
             #[doc = "Indicates that there are no errata fixes to this component."]
             NO_ERRATA = 0x0,
@@ -3863,7 +5080,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Revision {
             #[doc = "This device is at r0p0"]
             REV0P0 = 0x0,
@@ -3906,7 +5124,8 @@ pub mod cti {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sub {
             _RESERVED_0 = 0x0,
             #[doc = "Indicates that this component is a sub-triggering component."]
@@ -4103,6 +5322,24 @@ pub mod ctrlapperi {
                 ApprotectLock(0)
             }
         }
+        impl core::fmt::Debug for ApprotectLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectLock {
+                    lock: bool,
+                }
+                let proxy = ApprotectLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register locks the ERASEPROTECT.DISABLE register from being written until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4126,6 +5363,24 @@ pub mod ctrlapperi {
                 EraseprotectLock(0)
             }
         }
+        impl core::fmt::Debug for EraseprotectLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectLock {
+                    lock: bool,
+                }
+                let proxy = EraseprotectLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if data sent from the debugger to the CPU has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4147,6 +5402,26 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Rxstatus {
                 Rxstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status bits for CTRL-AP peripheral."]
@@ -4183,6 +5458,29 @@ pub mod ctrlapperi {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("uicrapprotect", &self.uicrapprotect())
+                    .field("dbgifacemode", &self.dbgifacemode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    uicrapprotect: super::vals::Uicrapprotect,
+                    dbgifacemode: bool,
+                }
+                let proxy = Status {
+                    uicrapprotect: self.uicrapprotect(),
+                    dbgifacemode: self.dbgifacemode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if the data sent from the CPU to the debugger has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4206,10 +5504,31 @@ pub mod ctrlapperi {
                 Txstatus(0)
             }
         }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Uicrapprotect {
             #[doc = "APPROTECT was enabled in UICR"]
             ENABLED = 0x0,
@@ -4285,6 +5604,26 @@ pub mod dcnf {
             #[inline(always)]
             fn default() -> Cpuid {
                 Cpuid(0)
+            }
+        }
+        impl core::fmt::Debug for Cpuid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cpuid")
+                    .field("cpuid", &self.cpuid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpuid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cpuid {
+                    cpuid: u8,
+                }
+                let proxy = Cpuid {
+                    cpuid: self.cpuid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4426,6 +5765,95 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4451,6 +5879,95 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                            self.ch(24usize),
+                            self.ch(25usize),
+                            self.ch(26usize),
+                            self.ch(27usize),
+                            self.ch(28usize),
+                            self.ch(29usize),
+                            self.ch(30usize),
+                            self.ch(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 32usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                        self.ch(24usize),
+                        self.ch(25usize),
+                        self.ch(26usize),
+                        self.ch(27usize),
+                        self.ch(28usize),
+                        self.ch(29usize),
+                        self.ch(30usize),
+                        self.ch(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4571,6 +6088,29 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("endecb", &self.endecb())
+                    .field("errorecb", &self.errorecb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    endecb: bool,
+                    errorecb: bool,
+                }
+                let proxy = Int {
+                    endecb: self.endecb(),
+                    errorecb: self.errorecb(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod egu {
@@ -4665,6 +6205,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4845,6 +6442,26 @@ pub mod ficr {
                 Codepagesize(0)
             }
         }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codepagesize")
+                    .field("codepagesize", &self.codepagesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codepagesize {
+                    codepagesize: super::vals::Codepagesize,
+                }
+                let proxy = Codepagesize {
+                    codepagesize: self.codepagesize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Code memory size"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4867,6 +6484,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Codesize {
                 Codesize(0)
+            }
+        }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codesize")
+                    .field("codesize", &self.codesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codesize {
+                    codesize: super::vals::Codesize,
+                }
+                let proxy = Codesize {
+                    codesize: self.codesize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration identifier"]
@@ -4892,6 +6529,24 @@ pub mod ficr {
                 Configid(0)
             }
         }
+        impl core::fmt::Debug for Configid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configid")
+                    .field("hwid", &self.hwid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configid {
+                    hwid: u16,
+                }
+                let proxy = Configid { hwid: self.hwid() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4913,6 +6568,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device type"]
@@ -4939,6 +6614,26 @@ pub mod ficr {
                 Devicetype(0)
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devicetype")
+                    .field("devicetype", &self.devicetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devicetype {
+                    devicetype: super::vals::Devicetype,
+                }
+                let proxy = Devicetype {
+                    devicetype: self.devicetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Flash variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4961,6 +6656,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Flash {
                 Flash(0)
+            }
+        }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Package option"]
@@ -4987,6 +6702,26 @@ pub mod ficr {
                 Package(0)
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part code"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5009,6 +6744,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Part {
                 Part(0)
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -5035,6 +6786,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part Variant, Hardware version and Production configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5059,6 +6826,26 @@ pub mod ficr {
                 Variant(0)
             }
         }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -5074,6 +6861,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800 => f.write_str("K2048"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800 => defmt::write!(f, "K2048"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codepagesize {
@@ -5103,6 +6907,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("P128"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "P128"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Codesize {
             #[inline(always)]
             fn from(val: u32) -> Codesize {
@@ -5116,7 +6937,8 @@ pub mod ficr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -5162,6 +6984,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DIE"),
+                    0xffff_ffff => f.write_str("FPGA"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DIE"),
+                    0xffff_ffff => defmt::write!(f, "FPGA"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Devicetype {
             #[inline(always)]
             fn from(val: u32) -> Devicetype {
@@ -5199,6 +7040,33 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0x0400 => f.write_str("K1024"),
+                    0x0800 => f.write_str("K2048"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0x0400 => defmt::write!(f, "K1024"),
+                    0x0800 => defmt::write!(f, "K2048"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -5230,6 +7098,27 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2000 => f.write_str("QK"),
+                    0x2005 => f.write_str("CL"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2000 => defmt::write!(f, "QK"),
+                    0x2005 => defmt::write!(f, "CL"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -5257,6 +7146,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5340 => f.write_str("N5340"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5340 => defmt::write!(f, "N5340"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Part {
@@ -5298,6 +7206,35 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x10 => f.write_str("K16"),
+                    0x20 => f.write_str("K32"),
+                    0x40 => f.write_str("K64"),
+                    0x80 => f.write_str("K128"),
+                    0x0100 => f.write_str("K256"),
+                    0x0200 => f.write_str("K512"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x10 => defmt::write!(f, "K16"),
+                    0x20 => defmt::write!(f, "K32"),
+                    0x40 => defmt::write!(f, "K64"),
+                    0x80 => defmt::write!(f, "K128"),
+                    0x0100 => defmt::write!(f, "K256"),
+                    0x0200 => defmt::write!(f, "K512"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -5327,6 +7264,27 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x434c_4141 => f.write_str("CLAA"),
+                    0x514b_4141 => f.write_str("QKAA"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x434c_4141 => defmt::write!(f, "CLAA"),
+                    0x514b_4141 => defmt::write!(f, "QKAA"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -5446,6 +7404,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select between default DETECT signal behavior and LDETECT mode (For secure pin only)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5467,6 +7445,26 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> DetectmodeSec {
                 DetectmodeSec(0)
+            }
+        }
+        impl core::fmt::Debug for DetectmodeSec {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DetectmodeSec")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DetectmodeSec {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DetectmodeSec {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = DetectmodeSec {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Direction of GPIO pins"]
@@ -5496,6 +7494,95 @@ pub mod gpio {
                 Dir(0)
             }
         }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR clear register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5521,6 +7608,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirclr {
                 Dirclr(0)
+            }
+        }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR set register"]
@@ -5550,6 +7726,95 @@ pub mod gpio {
                 Dirset(0)
             }
         }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5575,6 +7840,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> In {
                 In(0)
+            }
+        }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
@@ -5604,6 +7958,95 @@ pub mod gpio {
                 Latch(0)
             }
         }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5629,6 +8072,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Out {
                 Out(0)
+            }
+        }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear individual bits in GPIO port"]
@@ -5658,6 +8190,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5683,6 +8304,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -5765,10 +8475,46 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .field("mcusel", &self.mcusel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                    mcusel: super::vals::Mcusel,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                    mcusel: self.mcusel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -5798,7 +8544,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -5828,7 +8575,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -5879,7 +8627,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -5909,7 +8658,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mcusel {
             #[doc = "Application MCU"]
             APP_MCU = 0x0,
@@ -5947,7 +8697,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -5980,7 +8731,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -6195,6 +8947,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: bool,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6233,6 +9017,50 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latency selection for Event mode (MODE=Event) with rising or falling edge detection on the pin."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6256,10 +9084,31 @@ pub mod gpiote {
                 Latency(0)
             }
         }
+        impl core::fmt::Debug for Latency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latency")
+                    .field("latency", &self.latency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latency {
+                    latency: super::vals::Latency,
+                }
+                let proxy = Latency {
+                    latency: self.latency(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Latency {
             #[doc = "Low power setting, for signals with minimum hold time tGPIOTE,HOLD,LP; refer to Electrical specification section"]
             LOW_POWER = 0x0,
@@ -6289,7 +9138,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -6322,7 +9172,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -6352,7 +9203,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -6668,6 +9520,71 @@ pub mod ipc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("receive0", &self.receive0())
+                    .field("receive1", &self.receive1())
+                    .field("receive2", &self.receive2())
+                    .field("receive3", &self.receive3())
+                    .field("receive4", &self.receive4())
+                    .field("receive5", &self.receive5())
+                    .field("receive6", &self.receive6())
+                    .field("receive7", &self.receive7())
+                    .field("receive8", &self.receive8())
+                    .field("receive9", &self.receive9())
+                    .field("receive10", &self.receive10())
+                    .field("receive11", &self.receive11())
+                    .field("receive12", &self.receive12())
+                    .field("receive13", &self.receive13())
+                    .field("receive14", &self.receive14())
+                    .field("receive15", &self.receive15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    receive0: bool,
+                    receive1: bool,
+                    receive2: bool,
+                    receive3: bool,
+                    receive4: bool,
+                    receive5: bool,
+                    receive6: bool,
+                    receive7: bool,
+                    receive8: bool,
+                    receive9: bool,
+                    receive10: bool,
+                    receive11: bool,
+                    receive12: bool,
+                    receive13: bool,
+                    receive14: bool,
+                    receive15: bool,
+                }
+                let proxy = Int {
+                    receive0: self.receive0(),
+                    receive1: self.receive1(),
+                    receive2: self.receive2(),
+                    receive3: self.receive3(),
+                    receive4: self.receive4(),
+                    receive5: self.receive5(),
+                    receive6: self.receive6(),
+                    receive7: self.receive7(),
+                    receive8: self.receive8(),
+                    receive9: self.receive9(),
+                    receive10: self.receive10(),
+                    receive11: self.receive11(),
+                    receive12: self.receive12(),
+                    receive13: self.receive13(),
+                    receive14: self.receive14(),
+                    receive15: self.receive15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Receive event configuration for EVENTS_RECEIVE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6854,6 +9771,71 @@ pub mod ipc {
             #[inline(always)]
             fn default() -> ReceiveCnf {
                 ReceiveCnf(0)
+            }
+        }
+        impl core::fmt::Debug for ReceiveCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReceiveCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .field("chen8", &self.chen8())
+                    .field("chen9", &self.chen9())
+                    .field("chen10", &self.chen10())
+                    .field("chen11", &self.chen11())
+                    .field("chen12", &self.chen12())
+                    .field("chen13", &self.chen13())
+                    .field("chen14", &self.chen14())
+                    .field("chen15", &self.chen15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReceiveCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReceiveCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                    chen8: bool,
+                    chen9: bool,
+                    chen10: bool,
+                    chen11: bool,
+                    chen12: bool,
+                    chen13: bool,
+                    chen14: bool,
+                    chen15: bool,
+                }
+                let proxy = ReceiveCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                    chen8: self.chen8(),
+                    chen9: self.chen9(),
+                    chen10: self.chen10(),
+                    chen11: self.chen11(),
+                    chen12: self.chen12(),
+                    chen13: self.chen13(),
+                    chen14: self.chen14(),
+                    chen15: self.chen15(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Send event configuration for TASKS_SEND\\[n\\]"]
@@ -7044,6 +10026,71 @@ pub mod ipc {
                 SendCnf(0)
             }
         }
+        impl core::fmt::Debug for SendCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SendCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .field("chen8", &self.chen8())
+                    .field("chen9", &self.chen9())
+                    .field("chen10", &self.chen10())
+                    .field("chen11", &self.chen11())
+                    .field("chen12", &self.chen12())
+                    .field("chen13", &self.chen13())
+                    .field("chen14", &self.chen14())
+                    .field("chen15", &self.chen15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SendCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SendCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                    chen8: bool,
+                    chen9: bool,
+                    chen10: bool,
+                    chen11: bool,
+                    chen12: bool,
+                    chen13: bool,
+                    chen14: bool,
+                    chen15: bool,
+                }
+                let proxy = SendCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                    chen8: self.chen8(),
+                    chen9: self.chen9(),
+                    chen10: self.chen10(),
+                    chen11: self.chen11(),
+                    chen12: self.chen12(),
+                    chen13: self.chen13(),
+                    chen14: self.chen14(),
+                    chen15: self.chen15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod mutex {
@@ -7092,6 +10139,26 @@ pub mod mutex {
             #[inline(always)]
             fn default() -> Mutex {
                 Mutex(0)
+            }
+        }
+        impl core::fmt::Debug for Mutex {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mutex")
+                    .field("mutex", &self.mutex())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mutex {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mutex {
+                    mutex: bool,
+                }
+                let proxy = Mutex {
+                    mutex: self.mutex(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7180,6 +10247,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for erasing all non-volatile user memory"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7203,6 +10286,26 @@ pub mod nvmc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for partial erase configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7224,6 +10327,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Erasepagepartialcfg {
                 Erasepagepartialcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-code cache configuration register"]
@@ -7260,6 +10383,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7281,6 +10427,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Ready {
                 Ready(0)
+            }
+        }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Ready flag"]
@@ -7306,10 +10472,31 @@ pub mod nvmc {
                 Readynext(0)
             }
         }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -7474,6 +10661,26 @@ pub mod power {
                 Gpregret(0)
             }
         }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7517,6 +10724,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8318,6 +11551,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8374,6 +11627,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear the GPIO pattern array for antenna control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8395,6 +11677,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC configuration"]
@@ -8431,6 +11733,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8453,6 +11778,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -8479,6 +11824,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8500,6 +11865,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -8604,6 +11989,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8647,6 +12073,32 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ctestatus {
                 Ctestatus(0)
+            }
+        }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -8837,6 +12289,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8858,6 +12375,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dai {
                 Dai(0)
+            }
+        }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Device address prefix n"]
@@ -8883,6 +12416,22 @@ pub mod radio {
                 Dap(0)
             }
         }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data whitening initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8904,6 +12453,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhiteiv {
                 Datawhiteiv(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhiteiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhiteiv")
+                    .field("datawhiteiv", &self.datawhiteiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhiteiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhiteiv {
+                    datawhiteiv: u8,
+                }
+                let proxy = Datawhiteiv {
+                    datawhiteiv: self.datawhiteiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -9010,6 +12579,47 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("repeatpattern", &self.repeatpattern())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    repeatpattern: super::vals::Repeatpattern,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    repeatpattern: self.repeatpattern(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9044,6 +12654,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9065,6 +12698,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -9101,6 +12754,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect loop count"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9125,6 +12801,26 @@ pub mod radio {
                 Edcnt(0)
             }
         }
+        impl core::fmt::Debug for Edcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edcnt")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edcnt {
+                    edcnt: u32,
+                }
+                let proxy = Edcnt {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect level"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9146,6 +12842,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edsample {
                 Edsample(0)
+            }
+        }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -9180,6 +12896,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: super::vals::Map,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -9458,6 +13197,95 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("address", &self.address())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("rssiend", &self.rssiend())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("framestart", &self.framestart())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("phyend", &self.phyend())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    address: bool,
+                    payload: bool,
+                    end: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    rssiend: bool,
+                    bcmatch: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    framestart: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    txready: bool,
+                    rxready: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    phyend: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    address: self.address(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    rssiend: self.rssiend(),
+                    bcmatch: self.bcmatch(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    framestart: self.framestart(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    phyend: self.phyend(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9481,6 +13309,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9502,6 +13350,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Radio mode configuration register 0"]
@@ -9536,6 +13400,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Modecnf0 {
                 Modecnf0(0)
+            }
+        }
+        impl core::fmt::Debug for Modecnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modecnf0")
+                    .field("ru", &self.ru())
+                    .field("dtx", &self.dtx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modecnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modecnf0 {
+                    ru: super::vals::Ru,
+                    dtx: super::vals::Dtx,
+                }
+                let proxy = Modecnf0 {
+                    ru: self.ru(),
+                    dtx: self.dtx(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -9641,6 +13528,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9709,6 +13637,38 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9743,6 +13703,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Peripheral power control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9764,6 +13747,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("power", &self.power())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    power: bool,
+                }
+                let proxy = Power {
+                    power: self.power(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -9822,6 +13825,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9878,6 +13910,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9899,6 +13960,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -10001,6 +14082,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10023,6 +14145,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -10048,6 +14190,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10069,6 +14231,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -10292,6 +14470,80 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("end_disable", &self.end_disable())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("disabled_rssistop", &self.disabled_rssistop())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    end_disable: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    disabled_rssistop: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    end_disable: self.end_disable(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    disabled_rssistop: self.disabled_rssistop(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10313,6 +14565,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -10338,6 +14610,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10359,6 +14651,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmit address select"]
@@ -10384,6 +14692,26 @@ pub mod radio {
                 Txaddress(0)
             }
         }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output power"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10407,10 +14735,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -10449,7 +14798,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -10481,7 +14831,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -10511,7 +14862,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -10541,7 +14893,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10581,7 +14934,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -10621,7 +14975,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8 us unit (default) Set to 20 if parsed CTETime is larger than 20"]
             _20 = 0x0,
@@ -10654,7 +15009,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -10684,7 +15040,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -10717,7 +15074,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dtx {
             #[doc = "Transmit '1'"]
             B1 = 0x0,
@@ -10750,7 +15108,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -10780,7 +15139,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -10814,7 +15174,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Map {
             #[doc = "Channel map between 2400 MHz and 2500 MHz"]
             DEFAULT = 0x0,
@@ -10844,7 +15205,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -10893,7 +15255,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -10923,7 +15286,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -10957,7 +15321,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Repeatpattern {
             #[doc = "Do not repeat (1 time in total)"]
             NO_REPEAT = 0x0,
@@ -11000,7 +15365,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Default ramp-up time (tRXEN and tTXEN), compatible with firmware written for nRF51"]
             DEFAULT = 0x0,
@@ -11030,7 +15396,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -11060,7 +15427,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -11090,7 +15458,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -11120,7 +15489,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -11153,7 +15523,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the Disabled state"]
             DISABLED = 0x0,
@@ -11204,7 +15575,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -11244,7 +15616,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11284,7 +15657,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11324,7 +15698,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4 us"]
@@ -11361,7 +15736,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Txpower {
             #[doc = "0 dBm"]
             _0_DBM = 0x0,
@@ -11870,6 +16246,71 @@ pub mod reset {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog0", &self.dog0())
+                    .field("ctrlap", &self.ctrlap())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("lsreq", &self.lsreq())
+                    .field("llockup", &self.llockup())
+                    .field("ldog", &self.ldog())
+                    .field("mforceoff", &self.mforceoff())
+                    .field("nfc", &self.nfc())
+                    .field("dog1", &self.dog1())
+                    .field("vbus", &self.vbus())
+                    .field("lctrlap", &self.lctrlap())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog0: bool,
+                    ctrlap: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    lsreq: bool,
+                    llockup: bool,
+                    ldog: bool,
+                    mforceoff: bool,
+                    nfc: bool,
+                    dog1: bool,
+                    vbus: bool,
+                    lctrlap: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog0: self.dog0(),
+                    ctrlap: self.ctrlap(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    lsreq: self.lsreq(),
+                    llockup: self.llockup(),
+                    ldog: self.ldog(),
+                    mforceoff: self.mforceoff(),
+                    nfc: self.nfc(),
+                    dog1: self.dog1(),
+                    vbus: self.vbus(),
+                    lctrlap: self.lctrlap(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod rng {
@@ -11975,6 +16416,26 @@ pub mod rng {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("dercen", &self.dercen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    dercen: bool,
+                }
+                let proxy = Config {
+                    dercen: self.dercen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11996,6 +16457,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("valrdy", &self.valrdy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    valrdy: bool,
+                }
+                let proxy = Int {
+                    valrdy: self.valrdy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12021,6 +16502,26 @@ pub mod rng {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("valrdy_stop", &self.valrdy_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    valrdy_stop: bool,
+                }
+                let proxy = Shorts {
+                    valrdy_stop: self.valrdy_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Output random number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12042,6 +16543,26 @@ pub mod rng {
             #[inline(always)]
             fn default() -> Value {
                 Value(0)
+            }
+        }
+        impl core::fmt::Debug for Value {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Value")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Value {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Value {
+                    value: u8,
+                }
+                let proxy = Value {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -12237,6 +16758,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12259,6 +16800,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -12310,6 +16871,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12359,6 +16959,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768 / (PRESCALER + 1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12380,6 +17019,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12407,6 +17066,39 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "comparen_clear",
+                        &[
+                            self.comparen_clear(0usize),
+                            self.comparen_clear(1usize),
+                            self.comparen_clear(2usize),
+                            self.comparen_clear(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    comparen_clear: [bool; 4usize],
+                }
+                let proxy = Shorts {
+                    comparen_clear: [
+                        self.comparen_clear(0usize),
+                        self.comparen_clear(1usize),
+                        self.comparen_clear(2usize),
+                        self.comparen_clear(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -12459,6 +17151,32 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: bool,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event END"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12489,6 +17207,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task START"]
@@ -12523,10 +17264,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -12948,6 +17713,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Minimum duration between edge of CSN and edge of SCK. When SHORTS.END_START is used, this is also the minimum duration CSN must stay high between transactions."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12969,6 +17760,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csndur {
                 Csndur(0)
+            }
+        }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Polarity of CSN output"]
@@ -12994,6 +17805,26 @@ pub mod spim {
                 Csnpol(0)
             }
         }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol", &self.csnpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol: super::vals::Csnpol,
+                }
+                let proxy = Csnpol {
+                    csnpol: self.csnpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DCX configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13015,6 +17846,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Dcxcnt {
                 Dcxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable SPIM"]
@@ -13040,6 +17891,26 @@ pub mod spim {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13062,6 +17933,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -13131,6 +18022,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13152,6 +18075,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -13177,6 +18116,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13198,6 +18157,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -13223,6 +18200,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample delay for input serial data on MISO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13246,6 +18243,26 @@ pub mod spim {
                 Rxdelay(0)
             }
         }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13267,6 +18284,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Stall status for EasyDMA RAM accesses. The fields in this register are set to STALL by hardware whenever a stall occurres and can be cleared (set to NOSTALL) by the CPU."]
@@ -13303,6 +18340,29 @@ pub mod spim {
                 Stallstat(0)
             }
         }
+        impl core::fmt::Debug for Stallstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Stallstat")
+                    .field("tx", &self.tx())
+                    .field("rx", &self.rx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Stallstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Stallstat {
+                    tx: bool,
+                    rx: bool,
+                }
+                let proxy = Stallstat {
+                    tx: self.tx(),
+                    rx: self.rx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13324,6 +18384,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13349,6 +18429,24 @@ pub mod spim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13372,10 +18470,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -13405,7 +18524,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -13435,7 +18555,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -13465,7 +18586,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -13539,6 +18661,39 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x0a00_0000 => f.write_str("M16"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x1400_0000 => f.write_str("M32"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x0a00_0000 => defmt::write!(f, "M16"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x1400_0000 => defmt::write!(f, "M32"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -13552,7 +18707,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -13582,7 +18738,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13614,7 +18771,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13946,6 +19104,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13969,6 +19153,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13990,6 +19190,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -14037,6 +19257,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14058,6 +19304,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -14083,6 +19345,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14104,6 +19386,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -14129,6 +19429,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14152,6 +19472,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14173,6 +19513,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -14209,6 +19569,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14230,6 +19613,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14255,6 +19658,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14278,10 +19699,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -14311,7 +19753,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -14341,7 +19784,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -14385,7 +19829,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -14415,7 +19860,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14447,7 +19893,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -14481,7 +19928,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14647,6 +20095,26 @@ pub mod temp {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14833,6 +20301,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14860,6 +20348,47 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                            self.compare(6usize),
+                            self.compare(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 8usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                        self.compare(6usize),
+                        self.compare(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14881,6 +20410,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -14906,6 +20451,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14927,6 +20492,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14971,10 +20556,76 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                            self.compare_clear(6usize),
+                            self.compare_clear(7usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                            self.compare_stop(6usize),
+                            self.compare_stop(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 8usize],
+                    compare_stop: [bool; 8usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                        self.compare_clear(6usize),
+                        self.compare_clear(7usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                        self.compare_stop(6usize),
+                        self.compare_stop(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -15008,7 +20659,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -15384,6 +21036,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15405,6 +21077,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -15452,6 +21144,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15474,6 +21192,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15565,6 +21303,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15586,6 +21362,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15611,6 +21407,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15632,6 +21446,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15701,6 +21535,38 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15722,6 +21588,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -15747,6 +21633,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15770,10 +21674,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -15837,6 +21762,29 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    0x0ff0_0000 => f.write_str("K1000"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    0x0ff0_0000 => defmt::write!(f, "K1000"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -15850,7 +21798,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15886,7 +21835,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -16267,6 +22217,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16301,6 +22271,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16322,6 +22315,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -16367,6 +22380,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16447,6 +22486,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16468,6 +22542,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -16493,6 +22587,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16514,6 +22624,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -16539,6 +22669,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16560,6 +22708,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -16596,6 +22764,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16617,6 +22808,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -16642,6 +22853,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16665,10 +22894,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -16712,7 +22962,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -16744,7 +22995,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -17168,6 +23420,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17224,6 +23496,35 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                    paritytype: super::vals::Paritytype,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17245,6 +23546,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -17301,6 +23622,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17436,6 +23786,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17459,6 +23859,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17480,6 +23900,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -17516,6 +23956,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17539,6 +24002,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17560,6 +24043,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -17613,6 +24116,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -17626,7 +24180,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -17662,7 +24217,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -17706,7 +24262,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -17736,7 +24293,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -17834,6 +24392,24 @@ pub mod uicr {
                 Approtect(0)
             }
         }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::ApprotectPall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17858,6 +24434,24 @@ pub mod uicr {
                 Eraseprotect(0)
             }
         }
+        impl core::fmt::Debug for Eraseprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseprotect {
+                    pall: super::vals::EraseprotectPall,
+                }
+                let proxy = Eraseprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -17875,6 +24469,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0x50fa_50fa => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0x50fa_50fa => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectPall {
@@ -17904,6 +24517,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for EraseprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for EraseprotectPall {
@@ -18019,6 +24651,55 @@ pub mod vmc {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "spower",
+                        &[
+                            self.spower(0usize),
+                            self.spower(1usize),
+                            self.spower(2usize),
+                            self.spower(3usize),
+                        ],
+                    )
+                    .field(
+                        "sretention",
+                        &[
+                            self.sretention(0usize),
+                            self.sretention(1usize),
+                            self.sretention(2usize),
+                            self.sretention(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    spower: [bool; 4usize],
+                    sretention: [bool; 4usize],
+                }
+                let proxy = Power {
+                    spower: [
+                        self.spower(0usize),
+                        self.spower(1usize),
+                        self.spower(2usize),
+                        self.spower(3usize),
+                    ],
+                    sretention: [
+                        self.sretention(0usize),
+                        self.sretention(1usize),
+                        self.sretention(2usize),
+                        self.sretention(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod vreqctrl {
@@ -18095,6 +24776,26 @@ pub mod vreqctrl {
                 Vreqh(0)
             }
         }
+        impl core::fmt::Debug for Vreqh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Vreqh")
+                    .field("vreqh", &self.vreqh())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Vreqh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Vreqh {
+                    vreqh: bool,
+                }
+                let proxy = Vreqh {
+                    vreqh: self.vreqh(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "High voltage on RADIO is ready"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18116,6 +24817,26 @@ pub mod vreqctrl {
             #[inline(always)]
             fn default() -> Vreqhready {
                 Vreqhready(0)
+            }
+        }
+        impl core::fmt::Debug for Vreqhready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Vreqhready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Vreqhready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Vreqhready {
+                    ready: bool,
+                }
+                let proxy = Vreqhready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -18288,6 +25009,32 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .field("stopen", &self.stopen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                    stopen: bool,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                    stopen: self.stopen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18320,6 +25067,29 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -18356,6 +25126,29 @@ pub mod wdt {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Nmi {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Request status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18383,6 +25176,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18405,6 +25239,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -18434,6 +25284,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18455,6 +25346,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Runstatus {
                 Runstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Task stop enable"]
@@ -18481,10 +25392,27 @@ pub mod wdt {
                 Tsen(0)
             }
         }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tsen").field("tsen", &self.tsen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tsen {
+                    tsen: super::vals::Tsen,
+                }
+                let proxy = Tsen { tsen: self.tsen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause WDT while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -18528,6 +25456,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -18541,7 +25486,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause WDT while the CPU is sleeping"]
             PAUSE = 0x0,
@@ -18583,6 +25529,23 @@ pub mod wdt {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("ENABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "ENABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Tsen {

--- a/src/chips/nrf54l15-app/pac.rs
+++ b/src/chips/nrf54l15-app/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "28 - SWI00"]
     SWI00 = 28,
@@ -490,7 +491,8 @@ pub const ICACHEDATA_S: cachedata::Cachedata =
 pub const ICACHEINFO_S: cacheinfo::Cacheinfo =
     unsafe { cacheinfo::Cacheinfo::from_ptr(0x12f1_0000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 0"]
-pub const DPPIC00_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4004_2000usize as _) };
+pub const DPPIC00_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4004_2000usize as _) };
 #[doc = "PPIB APB registers 0"]
 pub const PPIB00_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4004_3000usize as _) };
 #[doc = "PPIB APB registers 2"]
@@ -506,7 +508,8 @@ pub const SPIM00_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x4004_a000usize
 #[doc = "SPI Slave 0"]
 pub const SPIS00_NS: spis::Spis = unsafe { spis::Spis::from_ptr(0x4004_a000usize as _) };
 #[doc = "UART with EasyDMA 0"]
-pub const UARTE00_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x4004_a000usize as _) };
+pub const UARTE00_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x4004_a000usize as _) };
 #[doc = "VPR peripheral registers 0"]
 pub const VPR00_NS: vpr::Vpr = unsafe { vpr::Vpr::from_ptr(0x4004_c000usize as _) };
 #[doc = "GPIO Port 0"]
@@ -517,15 +520,18 @@ pub const CTRLAP_NS: ctrlapperi::Ctrlapperi =
 #[doc = "Trace and debug control 0"]
 pub const TAD_NS: tad::Tad = unsafe { tad::Tad::from_ptr(0x4005_3000usize as _) };
 #[doc = "Timer/Counter 0"]
-pub const TIMER00_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x4005_5000usize as _) };
+pub const TIMER00_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x4005_5000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 2"]
-pub const DPPIC10_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4008_2000usize as _) };
+pub const DPPIC10_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4008_2000usize as _) };
 #[doc = "PPIB APB registers 4"]
 pub const PPIB10_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4008_3000usize as _) };
 #[doc = "PPIB APB registers 6"]
 pub const PPIB11_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4008_4000usize as _) };
 #[doc = "Timer/Counter 2"]
-pub const TIMER10_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x4008_5000usize as _) };
+pub const TIMER10_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x4008_5000usize as _) };
 #[doc = "Real-time counter 0"]
 pub const RTC10_NS: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x4008_6000usize as _) };
 #[doc = "Event generator unit 0"]
@@ -533,7 +539,8 @@ pub const EGU10_NS: egu::Egu = unsafe { egu::Egu::from_ptr(0x4008_7000usize as _
 #[doc = "2.4 GHz radio 0"]
 pub const RADIO_NS: radio::Radio = unsafe { radio::Radio::from_ptr(0x4008_a000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 4"]
-pub const DPPIC20_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x400c_2000usize as _) };
+pub const DPPIC20_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x400c_2000usize as _) };
 #[doc = "PPIB APB registers 8"]
 pub const PPIB20_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x400c_3000usize as _) };
 #[doc = "PPIB APB registers 10"]
@@ -549,7 +556,8 @@ pub const TWIM20_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_6000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 0"]
 pub const TWIS20_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_6000usize as _) };
 #[doc = "UART with EasyDMA 2"]
-pub const UARTE20_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_6000usize as _) };
+pub const UARTE20_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_6000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 4"]
 pub const SPIM21_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x400c_7000usize as _) };
 #[doc = "SPI Slave 4"]
@@ -559,7 +567,8 @@ pub const TWIM21_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_7000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 2"]
 pub const TWIS21_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_7000usize as _) };
 #[doc = "UART with EasyDMA 4"]
-pub const UARTE21_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_7000usize as _) };
+pub const UARTE21_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_7000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 6"]
 pub const SPIM22_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x400c_8000usize as _) };
 #[doc = "SPI Slave 6"]
@@ -569,19 +578,25 @@ pub const TWIM22_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_8000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 4"]
 pub const TWIS22_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_8000usize as _) };
 #[doc = "UART with EasyDMA 6"]
-pub const UARTE22_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_8000usize as _) };
+pub const UARTE22_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_8000usize as _) };
 #[doc = "Event generator unit 2"]
 pub const EGU20_NS: egu::Egu = unsafe { egu::Egu::from_ptr(0x400c_9000usize as _) };
 #[doc = "Timer/Counter 4"]
-pub const TIMER20_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_a000usize as _) };
+pub const TIMER20_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_a000usize as _) };
 #[doc = "Timer/Counter 6"]
-pub const TIMER21_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_b000usize as _) };
+pub const TIMER21_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_b000usize as _) };
 #[doc = "Timer/Counter 8"]
-pub const TIMER22_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_c000usize as _) };
+pub const TIMER22_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_c000usize as _) };
 #[doc = "Timer/Counter 10"]
-pub const TIMER23_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_d000usize as _) };
+pub const TIMER23_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_d000usize as _) };
 #[doc = "Timer/Counter 12"]
-pub const TIMER24_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_e000usize as _) };
+pub const TIMER24_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_e000usize as _) };
 #[doc = "Memory configuration 0"]
 pub const MEMCONF_NS: memconf::Memconf =
     unsafe { memconf::Memconf::from_ptr(0x400c_f000usize as _) };
@@ -604,7 +619,8 @@ pub const TEMP_NS: temp::Temp = unsafe { temp::Temp::from_ptr(0x400d_7000usize a
 #[doc = "GPIO Port 2"]
 pub const P1_NS: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x400d_8200usize as _) };
 #[doc = "GPIO Tasks and Events 0"]
-pub const GPIOTE20_NS: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x400d_a000usize as _) };
+pub const GPIOTE20_NS: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x400d_a000usize as _) };
 #[doc = "Inter-IC Sound 0"]
 pub const I2S20_NS: i2s::I2s = unsafe { i2s::I2s::from_ptr(0x400d_d000usize as _) };
 #[doc = "Quadrature Decoder 0"]
@@ -614,7 +630,8 @@ pub const QDEC21_NS: qdec::Qdec = unsafe { qdec::Qdec::from_ptr(0x400e_1000usize
 #[doc = "Global Real-time counter 0"]
 pub const GRTC_NS: grtc::Grtc = unsafe { grtc::Grtc::from_ptr(0x400e_2000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 6"]
-pub const DPPIC30_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4010_2000usize as _) };
+pub const DPPIC30_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4010_2000usize as _) };
 #[doc = "PPIB APB registers 14"]
 pub const PPIB30_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4010_3000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 8"]
@@ -626,19 +643,22 @@ pub const TWIM30_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x4010_4000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 6"]
 pub const TWIS30_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x4010_4000usize as _) };
 #[doc = "UART with EasyDMA 8"]
-pub const UARTE30_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x4010_4000usize as _) };
+pub const UARTE30_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x4010_4000usize as _) };
 #[doc = "Real-time counter 2"]
 pub const RTC30_NS: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x4010_5000usize as _) };
 #[doc = "Comparator 0"]
 pub const COMP_NS: comp::Comp = unsafe { comp::Comp::from_ptr(0x4010_6000usize as _) };
 #[doc = "Low-power comparator 0"]
-pub const LPCOMP_NS: lpcomp::Lpcomp = unsafe { lpcomp::Lpcomp::from_ptr(0x4010_6000usize as _) };
+pub const LPCOMP_NS: lpcomp::Lpcomp =
+    unsafe { lpcomp::Lpcomp::from_ptr(0x4010_6000usize as _) };
 #[doc = "Watchdog Timer 1"]
 pub const WDT31_NS: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x4010_9000usize as _) };
 #[doc = "GPIO Port 4"]
 pub const P0_NS: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x4010_a000usize as _) };
 #[doc = "GPIO Tasks and Events 2"]
-pub const GPIOTE30_NS: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x4010_c000usize as _) };
+pub const GPIOTE30_NS: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x4010_c000usize as _) };
 #[doc = "Clock management 0"]
 pub const CLOCK_NS: clock::Clock = unsafe { clock::Clock::from_ptr(0x4010_e000usize as _) };
 #[doc = "Power control 0"]
@@ -678,7 +698,8 @@ pub const CCM00_S: ccm::Ccm = unsafe { ccm::Ccm::from_ptr(0x5004_6000usize as _)
 #[doc = "AES ECB Mode Encryption 1"]
 pub const ECB00_S: ecb::Ecb = unsafe { ecb::Ecb::from_ptr(0x5004_7000usize as _) };
 #[doc = "CRACEN"]
-pub const CRACEN_S: cracen::Cracen = unsafe { cracen::Cracen::from_ptr(0x5004_8000usize as _) };
+pub const CRACEN_S: cracen::Cracen =
+    unsafe { cracen::Cracen::from_ptr(0x5004_8000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 1"]
 pub const SPIM00_S: spim::Spim = unsafe { spim::Spim::from_ptr(0x5004_a000usize as _) };
 #[doc = "SPI Slave 1"]
@@ -791,7 +812,8 @@ pub const TEMP_S: temp::Temp = unsafe { temp::Temp::from_ptr(0x500d_7000usize as
 #[doc = "GPIO Port 3"]
 pub const P1_S: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x500d_8200usize as _) };
 #[doc = "GPIO Tasks and Events 1"]
-pub const GPIOTE20_S: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x500d_a000usize as _) };
+pub const GPIOTE20_S: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x500d_a000usize as _) };
 #[doc = "Tamper controller"]
 pub const TAMPC_S: tampc::Tampc = unsafe { tampc::Tampc::from_ptr(0x500d_c000usize as _) };
 #[doc = "Inter-IC Sound 1"]
@@ -823,7 +845,8 @@ pub const RTC30_S: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x5010_5000usize as _)
 #[doc = "Comparator 1"]
 pub const COMP_S: comp::Comp = unsafe { comp::Comp::from_ptr(0x5010_6000usize as _) };
 #[doc = "Low-power comparator 1"]
-pub const LPCOMP_S: lpcomp::Lpcomp = unsafe { lpcomp::Lpcomp::from_ptr(0x5010_6000usize as _) };
+pub const LPCOMP_S: lpcomp::Lpcomp =
+    unsafe { lpcomp::Lpcomp::from_ptr(0x5010_6000usize as _) };
 #[doc = "Watchdog Timer 0"]
 pub const WDT30_S: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x5010_8000usize as _) };
 #[doc = "Watchdog Timer 2"]
@@ -831,7 +854,8 @@ pub const WDT31_S: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x5010_9000usize as _)
 #[doc = "GPIO Port 5"]
 pub const P0_S: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x5010_a000usize as _) };
 #[doc = "GPIO Tasks and Events 3"]
-pub const GPIOTE30_S: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x5010_c000usize as _) };
+pub const GPIOTE30_S: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x5010_c000usize as _) };
 #[doc = "Clock management 1"]
 pub const CLOCK_S: clock::Clock = unsafe { clock::Clock::from_ptr(0x5010_e000usize as _) };
 #[doc = "Power control 1"]
@@ -1060,6 +1084,26 @@ pub mod aar {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u8,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable AAR"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1083,6 +1127,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Error status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1104,6 +1168,26 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1162,6 +1246,35 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of IRKs to resolve"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1185,10 +1298,31 @@ pub mod aar {
                 Maxresolved(0)
             }
         }
+        impl core::fmt::Debug for Maxresolved {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxresolved")
+                    .field("maxresolved", &self.maxresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxresolved {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxresolved {
+                    maxresolved: u16,
+                }
+                let proxy = Maxresolved {
+                    maxresolved: self.maxresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1220,7 +1354,8 @@ pub mod aar {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -1403,6 +1538,26 @@ pub mod cache {
                 CacheEnable(0)
             }
         }
+        impl core::fmt::Debug for CacheEnable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CacheEnable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CacheEnable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CacheEnable {
+                    enable: bool,
+                }
+                let proxy = CacheEnable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear the profiling counters."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1426,6 +1581,26 @@ pub mod cache {
                 Clear(0)
             }
         }
+        impl core::fmt::Debug for Clear {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clear")
+                    .field("clear", &self.clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clear {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clear {
+                    clear: bool,
+                }
+                let proxy = Clear {
+                    clear: self.clear(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock debug mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1447,6 +1622,26 @@ pub mod cache {
             #[inline(always)]
             fn default() -> Debuglock {
                 Debuglock(0)
+            }
+        }
+        impl core::fmt::Debug for Debuglock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Debuglock")
+                    .field("debuglock", &self.debuglock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Debuglock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Debuglock {
+                    debuglock: bool,
+                }
+                let proxy = Debuglock {
+                    debuglock: self.debuglock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Cache mode."]
@@ -1483,6 +1678,29 @@ pub mod cache {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("ramsize", &self.ramsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    ramsize: super::vals::Ramsize,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    ramsize: self.ramsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the profiling counters."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1504,6 +1722,26 @@ pub mod cache {
             #[inline(always)]
             fn default() -> ProfilingEnable {
                 ProfilingEnable(0)
+            }
+        }
+        impl core::fmt::Debug for ProfilingEnable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ProfilingEnable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ProfilingEnable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ProfilingEnable {
+                    enable: bool,
+                }
+                let proxy = ProfilingEnable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status of the cache activities."]
@@ -1529,6 +1767,26 @@ pub mod cache {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    ready: bool,
+                }
+                let proxy = Status {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock cache updates."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1552,10 +1810,31 @@ pub mod cache {
                 Writelock(0)
             }
         }
+        impl core::fmt::Debug for Writelock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writelock")
+                    .field("writelock", &self.writelock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writelock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writelock {
+                    writelock: bool,
+                }
+                let proxy = Writelock {
+                    writelock: self.writelock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Cache mode"]
             CACHE = 0x0,
@@ -1585,7 +1864,8 @@ pub mod cache {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ramsize {
             #[doc = "All RAM is used for cache memory"]
             ALL = 0x0,
@@ -1875,10 +2155,49 @@ pub mod cacheinfo {
                 Info(0)
             }
         }
+        impl core::fmt::Debug for Info {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Info")
+                    .field("tag", &self.tag())
+                    .field("duv_0", &self.duv_0())
+                    .field("duv_1", &self.duv_1())
+                    .field("duv_2", &self.duv_2())
+                    .field("duv_3", &self.duv_3())
+                    .field("v", &self.v())
+                    .field("mru", &self.mru())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Info {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Info {
+                    tag: u32,
+                    duv_0: bool,
+                    duv_1: bool,
+                    duv_2: bool,
+                    duv_3: bool,
+                    v: bool,
+                    mru: super::vals::Mru,
+                }
+                let proxy = Info {
+                    tag: self.tag(),
+                    duv_0: self.duv_0(),
+                    duv_1: self.duv_1(),
+                    duv_2: self.duv_2(),
+                    duv_3: self.duv_3(),
+                    v: self.v(),
+                    mru: self.mru(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mru {
             #[doc = "Way0 was most recently used"]
             WAY0 = 0x0,
@@ -2163,6 +2482,26 @@ pub mod ccm {
                 Adatamask(0)
             }
         }
+        impl core::fmt::Debug for Adatamask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Adatamask")
+                    .field("adatamask", &self.adatamask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Adatamask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Adatamask {
+                    adatamask: u8,
+                }
+                let proxy = Adatamask {
+                    adatamask: self.adatamask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2186,6 +2525,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Error status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2207,6 +2566,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -2243,6 +2622,29 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MAC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2264,6 +2666,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Macstatus {
                 Macstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Macstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Macstatus")
+                    .field("macstatus", &self.macstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Macstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Macstatus {
+                    macstatus: super::vals::Macstatus,
+                }
+                let proxy = Macstatus {
+                    macstatus: self.macstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -2324,6 +2746,35 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("protocol", &self.protocol())
+                    .field("datarate", &self.datarate())
+                    .field("maclen", &self.maclen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    protocol: super::vals::Protocol,
+                    datarate: super::vals::Datarate,
+                    maclen: super::vals::Maclen,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    protocol: self.protocol(),
+                    datarate: self.datarate(),
+                    maclen: self.maclen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2347,10 +2798,31 @@ pub mod ccm {
                 Rateoverride(0)
             }
         }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "125 Kbps"]
             _125KBIT = 0x0,
@@ -2390,7 +2862,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -2422,7 +2895,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -2461,7 +2935,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Maclen {
             #[doc = "M = 0 This is a special case for CCM* where encryption is required but not authentication"]
             M0 = 0x0,
@@ -2503,7 +2978,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Macstatus {
             #[doc = "MAC check failed"]
             CHECK_FAILED = 0x0,
@@ -2533,7 +3009,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -2566,7 +3043,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protocol {
             #[doc = "Bluetooth Low Energy packet format"]
             BLE = 0x0,
@@ -2598,7 +3076,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "125 Kbps"]
             _125KBIT = 0x0,
@@ -3069,6 +3548,44 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("xostarted", &self.xostarted())
+                    .field("pllstarted", &self.pllstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("xotuned", &self.xotuned())
+                    .field("xotuneerror", &self.xotuneerror())
+                    .field("xotunefailed", &self.xotunefailed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    xostarted: bool,
+                    pllstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    xotuned: bool,
+                    xotuneerror: bool,
+                    xotunefailed: bool,
+                }
+                let proxy = Int {
+                    xostarted: self.xostarted(),
+                    pllstarted: self.pllstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    xotuned: self.xotuned(),
+                    xotuneerror: self.xotuneerror(),
+                    xotunefailed: self.xotunefailed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3090,6 +3607,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> LfclkRun {
                 LfclkRun(0)
+            }
+        }
+        impl core::fmt::Debug for LfclkRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("LfclkRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LfclkRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct LfclkRun {
+                    status: bool,
+                }
+                let proxy = LfclkRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Copy of LFCLK.SRCCOPY register, set when LFCLKSTARTED event is triggered."]
@@ -3137,6 +3674,32 @@ pub mod clock {
                 LfclkStat(0)
             }
         }
+        impl core::fmt::Debug for LfclkStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("LfclkStat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LfclkStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct LfclkStat {
+                    src: super::vals::Lfclksrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = LfclkStat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that PLLSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3158,6 +3721,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> PllRun {
                 PllRun(0)
+            }
+        }
+        impl core::fmt::Debug for PllRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PllRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PllRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PllRun {
+                    status: bool,
+                }
+                let proxy = PllRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Which PLL settings were selected when triggering START task"]
@@ -3183,6 +3766,26 @@ pub mod clock {
                 PllStat(0)
             }
         }
+        impl core::fmt::Debug for PllStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PllStat")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PllStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PllStat {
+                    state: bool,
+                }
+                let proxy = PllStat {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3204,6 +3807,22 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Src {
                 Src(0)
+            }
+        }
+        impl core::fmt::Debug for Src {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Src").field("src", &self.src()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Src {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Src {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Src { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Copy of LFCLK.SRC register, set when LFCLKSTART task is triggered"]
@@ -3229,6 +3848,22 @@ pub mod clock {
                 Srccopy(0)
             }
         }
+        impl core::fmt::Debug for Srccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Srccopy").field("src", &self.src()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Srccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Srccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Srccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that XOSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3250,6 +3885,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> XoRun {
                 XoRun(0)
+            }
+        }
+        impl core::fmt::Debug for XoRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("XoRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for XoRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct XoRun {
+                    status: bool,
+                }
+                let proxy = XoRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "XO status"]
@@ -3275,10 +3930,31 @@ pub mod clock {
                 XoStat(0)
             }
         }
+        impl core::fmt::Debug for XoStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("XoStat")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for XoStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct XoStat {
+                    state: bool,
+                }
+                let proxy = XoStat {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             LFRC = 0x0,
@@ -3585,6 +4261,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3619,6 +4315,29 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Extrefsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3640,6 +4359,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -3698,6 +4433,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current source select on analog input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3719,6 +4483,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Isource {
                 Isource(0)
+            }
+        }
+        impl core::fmt::Debug for Isource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isource")
+                    .field("isource", &self.isource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isource {
+                    isource: super::vals::Isource,
+                }
+                let proxy = Isource {
+                    isource: self.isource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mode configuration"]
@@ -3755,6 +4539,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3789,6 +4596,29 @@ pub mod comp {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reference source select for single-ended mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3812,6 +4642,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3833,6 +4683,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -3902,6 +4772,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3936,10 +4838,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -3971,7 +4897,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -4001,7 +4928,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Isource {
             #[doc = "Current source disabled"]
             OFF = 0x0,
@@ -4035,7 +4963,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -4065,7 +4994,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference"]
             INT1V2 = 0x0,
@@ -4102,7 +5032,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -4132,7 +5063,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -4318,6 +5250,41 @@ pub mod cpuc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("fpuioc", &self.fpuioc())
+                    .field("fpudzc", &self.fpudzc())
+                    .field("fpuofc", &self.fpuofc())
+                    .field("fpuufc", &self.fpuufc())
+                    .field("fpuixc", &self.fpuixc())
+                    .field("fpuidc", &self.fpuidc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    fpuioc: bool,
+                    fpudzc: bool,
+                    fpuofc: bool,
+                    fpuufc: bool,
+                    fpuixc: bool,
+                    fpuidc: bool,
+                }
+                let proxy = Int {
+                    fpuioc: self.fpuioc(),
+                    fpudzc: self.fpudzc(),
+                    fpuofc: self.fpuofc(),
+                    fpuufc: self.fpuufc(),
+                    fpuixc: self.fpuixc(),
+                    fpuidc: self.fpuidc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register to lock the certain parts of the CPU from being modified."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4383,6 +5350,38 @@ pub mod cpuc {
             #[inline(always)]
             fn default() -> Lock {
                 Lock(0)
+            }
+        }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock")
+                    .field("lockvtoraircrs", &self.lockvtoraircrs())
+                    .field("lockvtorns", &self.lockvtorns())
+                    .field("lockmpus", &self.lockmpus())
+                    .field("lockmpuns", &self.lockmpuns())
+                    .field("locksau", &self.locksau())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lockvtoraircrs: bool,
+                    lockvtorns: bool,
+                    lockmpus: bool,
+                    lockmpuns: bool,
+                    locksau: bool,
+                }
+                let proxy = Lock {
+                    lockvtoraircrs: self.lockvtoraircrs(),
+                    lockvtorns: self.lockvtorns(),
+                    lockmpus: self.lockmpus(),
+                    lockmpuns: self.lockmpuns(),
+                    locksau: self.locksau(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4514,6 +5513,32 @@ pub mod cracen {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("cryptomaster", &self.cryptomaster())
+                    .field("rng", &self.rng())
+                    .field("pkeikg", &self.pkeikg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    cryptomaster: bool,
+                    rng: bool,
+                    pkeikg: bool,
+                }
+                let proxy = Enable {
+                    cryptomaster: self.cryptomaster(),
+                    rng: self.rng(),
+                    pkeikg: self.pkeikg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4559,6 +5584,32 @@ pub mod cracen {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cryptomaster", &self.cryptomaster())
+                    .field("rng", &self.rng())
+                    .field("pkeikg", &self.pkeikg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cryptomaster: bool,
+                    rng: bool,
+                    pkeikg: bool,
+                }
+                let proxy = Int {
+                    cryptomaster: self.cryptomaster(),
+                    rng: self.rng(),
+                    pkeikg: self.pkeikg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock the access to the protected RAM."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4580,6 +5631,26 @@ pub mod cracen {
             #[inline(always)]
             fn default() -> Protectedramlock {
                 Protectedramlock(0)
+            }
+        }
+        impl core::fmt::Debug for Protectedramlock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Protectedramlock")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Protectedramlock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Protectedramlock {
+                    enable: bool,
+                }
+                let proxy = Protectedramlock {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Lock the access to the SEED register."]
@@ -4605,6 +5676,26 @@ pub mod cracen {
                 Seedlock(0)
             }
         }
+        impl core::fmt::Debug for Seedlock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seedlock")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seedlock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seedlock {
+                    enable: bool,
+                }
+                let proxy = Seedlock {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Marks the SEED register as valid"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4626,6 +5717,26 @@ pub mod cracen {
             #[inline(always)]
             fn default() -> Seedvalid {
                 Seedvalid(0)
+            }
+        }
+        impl core::fmt::Debug for Seedvalid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seedvalid")
+                    .field("valid", &self.valid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seedvalid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seedvalid {
+                    valid: bool,
+                }
+                let proxy = Seedvalid {
+                    valid: self.valid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -5143,6 +6254,29 @@ pub mod cracencore {
                 Ais31conf0(0)
             }
         }
+        impl core::fmt::Debug for Ais31conf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf0")
+                    .field("startupthreshold", &self.startupthreshold())
+                    .field("onlinethreshold", &self.onlinethreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf0 {
+                    startupthreshold: u16,
+                    onlinethreshold: u16,
+                }
+                let proxy = Ais31conf0 {
+                    startupthreshold: self.startupthreshold(),
+                    onlinethreshold: self.onlinethreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "AIS31 configuration register 1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5177,6 +6311,29 @@ pub mod cracencore {
                 Ais31conf1(0)
             }
         }
+        impl core::fmt::Debug for Ais31conf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf1")
+                    .field("onlinerepthreshold", &self.onlinerepthreshold())
+                    .field("hexpectedvalue", &self.hexpectedvalue())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf1 {
+                    onlinerepthreshold: u16,
+                    hexpectedvalue: u16,
+                }
+                let proxy = Ais31conf1 {
+                    onlinerepthreshold: self.onlinerepthreshold(),
+                    hexpectedvalue: self.hexpectedvalue(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "AIS31 configuration register 2."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5209,6 +6366,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ais31conf2 {
                 Ais31conf2(0)
+            }
+        }
+        impl core::fmt::Debug for Ais31conf2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf2")
+                    .field("hmin", &self.hmin())
+                    .field("hmax", &self.hmax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf2 {
+                    hmin: u16,
+                    hmax: u16,
+                }
+                let proxy = Ais31conf2 {
+                    hmin: self.hmin(),
+                    hmax: self.hmax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "AIS31 status register."]
@@ -5254,6 +6434,32 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ais31status {
                 Ais31status(0)
+            }
+        }
+        impl core::fmt::Debug for Ais31status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31status")
+                    .field("numprelimalarms", &self.numprelimalarms())
+                    .field("prelimnoisealarmrng", &self.prelimnoisealarmrng())
+                    .field("prelimnoisealarmrep", &self.prelimnoisealarmrep())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31status {
+                    numprelimalarms: u16,
+                    prelimnoisealarmrng: bool,
+                    prelimnoisealarmrep: bool,
+                }
+                let proxy = Ais31status {
+                    numprelimalarms: self.numprelimalarms(),
+                    prelimnoisealarmrng: self.prelimnoisealarmrng(),
+                    prelimnoisealarmrep: self.prelimnoisealarmrep(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_AesModesPoss value."]
@@ -5312,6 +6518,35 @@ pub mod cracencore {
                 Ba411eaeshwcfg1(0)
             }
         }
+        impl core::fmt::Debug for Ba411eaeshwcfg1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba411eaeshwcfg1")
+                    .field("ba411eaeshwcfgmode", &self.ba411eaeshwcfgmode())
+                    .field("ba411eaeshwcfgcs", &self.ba411eaeshwcfgcs())
+                    .field("ba411eaeshwcfgmasking", &self.ba411eaeshwcfgmasking())
+                    .field("ba411eaeshwcfgkeysize", &self.ba411eaeshwcfgkeysize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba411eaeshwcfg1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba411eaeshwcfg1 {
+                    ba411eaeshwcfgmode: u16,
+                    ba411eaeshwcfgcs: bool,
+                    ba411eaeshwcfgmasking: bool,
+                    ba411eaeshwcfgkeysize: u8,
+                }
+                let proxy = Ba411eaeshwcfg1 {
+                    ba411eaeshwcfgmode: self.ba411eaeshwcfgmode(),
+                    ba411eaeshwcfgcs: self.ba411eaeshwcfgcs(),
+                    ba411eaeshwcfgmasking: self.ba411eaeshwcfgmasking(),
+                    ba411eaeshwcfgkeysize: self.ba411eaeshwcfgkeysize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_CtrSize value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5333,6 +6568,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ba411eaeshwcfg2 {
                 Ba411eaeshwcfg2(0)
+            }
+        }
+        impl core::fmt::Debug for Ba411eaeshwcfg2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba411eaeshwcfg2")
+                    .field("ba411eaeshwcfg2", &self.ba411eaeshwcfg2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba411eaeshwcfg2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba411eaeshwcfg2 {
+                    ba411eaeshwcfg2: u16,
+                }
+                let proxy = Ba411eaeshwcfg2 {
+                    ba411eaeshwcfg2: self.ba411eaeshwcfg2(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_Hash value"]
@@ -5391,6 +6646,38 @@ pub mod cracencore {
                 Ba413hashhwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba413hashhwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba413hashhwcfg")
+                    .field("ba413hashhwcfgmask", &self.ba413hashhwcfgmask())
+                    .field("ba413hashhwcfgpadding", &self.ba413hashhwcfgpadding())
+                    .field("ba413hashhwcfghmac", &self.ba413hashhwcfghmac())
+                    .field(
+                        "ba413hashhwcfgverifydigest",
+                        &self.ba413hashhwcfgverifydigest(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba413hashhwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba413hashhwcfg {
+                    ba413hashhwcfgmask: u8,
+                    ba413hashhwcfgpadding: bool,
+                    ba413hashhwcfghmac: bool,
+                    ba413hashhwcfgverifydigest: bool,
+                }
+                let proxy = Ba413hashhwcfg {
+                    ba413hashhwcfgmask: self.ba413hashhwcfgmask(),
+                    ba413hashhwcfgpadding: self.ba413hashhwcfgpadding(),
+                    ba413hashhwcfghmac: self.ba413hashhwcfghmac(),
+                    ba413hashhwcfgverifydigest: self.ba413hashhwcfgverifydigest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_Sha3CtxtEn value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5412,6 +6699,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ba418sha3hwcfg {
                 Ba418sha3hwcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Ba418sha3hwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba418sha3hwcfg")
+                    .field("ba418sha3hwcfg", &self.ba418sha3hwcfg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba418sha3hwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba418sha3hwcfg {
+                    ba418sha3hwcfg: bool,
+                }
+                let proxy = Ba418sha3hwcfg {
+                    ba418sha3hwcfg: self.ba418sha3hwcfg(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_SM4ModesPoss value."]
@@ -5448,6 +6755,29 @@ pub mod cracencore {
                 Ba419sm4hwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba419sm4hwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba419sm4hwcfg")
+                    .field("ba419sm4hwcfg", &self.ba419sm4hwcfg())
+                    .field("usemasking", &self.usemasking())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba419sm4hwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba419sm4hwcfg {
+                    ba419sm4hwcfg: u16,
+                    usemasking: bool,
+                }
+                let proxy = Ba419sm4hwcfg {
+                    ba419sm4hwcfg: self.ba419sm4hwcfg(),
+                    usemasking: self.usemasking(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_aria_modePoss value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5471,6 +6801,26 @@ pub mod cracencore {
                 Ba424ariahwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba424ariahwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba424ariahwcfg")
+                    .field("ba424ariahwcfg", &self.ba424ariahwcfg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba424ariahwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba424ariahwcfg {
+                    ba424ariahwcfg: u16,
+                }
+                let proxy = Ba424ariahwcfg {
+                    ba424ariahwcfg: self.ba424ariahwcfg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample clock divider."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5492,6 +6842,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Clkdiv {
                 Clkdiv(0)
+            }
+        }
+        impl core::fmt::Debug for Clkdiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkdiv")
+                    .field("clkdiv", &self.clkdiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkdiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkdiv {
+                    clkdiv: u8,
+                }
+                let proxy = Clkdiv {
+                    clkdiv: self.clkdiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Command register."]
@@ -5641,6 +7011,59 @@ pub mod cracencore {
                 Command(0)
             }
         }
+        impl core::fmt::Debug for Command {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Command")
+                    .field("opeaddr", &self.opeaddr())
+                    .field("fieldf", &self.fieldf())
+                    .field("opbytesm1", &self.opbytesm1())
+                    .field("randmod", &self.randmod())
+                    .field("selcurve", &self.selcurve())
+                    .field("randke", &self.randke())
+                    .field("randproj", &self.randproj())
+                    .field("edwards", &self.edwards())
+                    .field("swapbytes", &self.swapbytes())
+                    .field("flaga", &self.flaga())
+                    .field("flagb", &self.flagb())
+                    .field("calcr2", &self.calcr2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Command {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Command {
+                    opeaddr: u8,
+                    fieldf: bool,
+                    opbytesm1: u16,
+                    randmod: bool,
+                    selcurve: super::vals::Selcurve,
+                    randke: bool,
+                    randproj: bool,
+                    edwards: bool,
+                    swapbytes: super::vals::Swapbytes,
+                    flaga: bool,
+                    flagb: bool,
+                    calcr2: super::vals::Calcr2,
+                }
+                let proxy = Command {
+                    opeaddr: self.opeaddr(),
+                    fieldf: self.fieldf(),
+                    opbytesm1: self.opbytesm1(),
+                    randmod: self.randmod(),
+                    selcurve: self.selcurve(),
+                    randke: self.randke(),
+                    randproj: self.randproj(),
+                    edwards: self.edwards(),
+                    swapbytes: self.swapbytes(),
+                    flaga: self.flaga(),
+                    flagb: self.flagb(),
+                    calcr2: self.calcr2(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5698,6 +7121,38 @@ pub mod cracencore {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("fetchctrlindirect", &self.fetchctrlindirect())
+                    .field("pushctrlindirect", &self.pushctrlindirect())
+                    .field("fetchstop", &self.fetchstop())
+                    .field("pushstop", &self.pushstop())
+                    .field("softrst", &self.softrst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    fetchctrlindirect: bool,
+                    pushctrlindirect: bool,
+                    fetchstop: bool,
+                    pushstop: bool,
+                    softrst: bool,
+                }
+                let proxy = Config {
+                    fetchctrlindirect: self.fetchctrlindirect(),
+                    pushctrlindirect: self.pushctrlindirect(),
+                    fetchstop: self.fetchstop(),
+                    pushstop: self.pushstop(),
+                    softrst: self.softrst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5726,6 +7181,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> CryptmstrdmaStart {
                 CryptmstrdmaStart(0)
+            }
+        }
+        impl core::fmt::Debug for CryptmstrdmaStart {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptmstrdmaStart")
+                    .field("startfetch", &self.startfetch())
+                    .field("startpush", &self.startpush())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptmstrdmaStart {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptmstrdmaStart {
+                    startfetch: bool,
+                    startpush: bool,
+                }
+                let proxy = CryptmstrdmaStart {
+                    startfetch: self.startfetch(),
+                    startpush: self.startpush(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status"]
@@ -5794,6 +7272,41 @@ pub mod cracencore {
                 CryptmstrdmaStatus(0)
             }
         }
+        impl core::fmt::Debug for CryptmstrdmaStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptmstrdmaStatus")
+                    .field("fetchbusy", &self.fetchbusy())
+                    .field("pushbusy", &self.pushbusy())
+                    .field("fetchnotempty", &self.fetchnotempty())
+                    .field("pushwaitingfifo", &self.pushwaitingfifo())
+                    .field("softrstbusy", &self.softrstbusy())
+                    .field("pushnbdata", &self.pushnbdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptmstrdmaStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptmstrdmaStatus {
+                    fetchbusy: bool,
+                    pushbusy: bool,
+                    fetchnotempty: bool,
+                    pushwaitingfifo: bool,
+                    softrstbusy: bool,
+                    pushnbdata: u16,
+                }
+                let proxy = CryptmstrdmaStatus {
+                    fetchbusy: self.fetchbusy(),
+                    pushbusy: self.pushbusy(),
+                    fetchnotempty: self.fetchnotempty(),
+                    pushwaitingfifo: self.pushwaitingfifo(),
+                    softrstbusy: self.softrstbusy(),
+                    pushnbdata: self.pushnbdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Fetch Length"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5843,6 +7356,35 @@ pub mod cracencore {
                 Fetchlen(0)
             }
         }
+        impl core::fmt::Debug for Fetchlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fetchlen")
+                    .field("fetchlen", &self.fetchlen())
+                    .field("fetchcstaddr", &self.fetchcstaddr())
+                    .field("fetchrealign", &self.fetchrealign())
+                    .field("fetchzpadding", &self.fetchzpadding())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fetchlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fetchlen {
+                    fetchlen: u32,
+                    fetchcstaddr: bool,
+                    fetchrealign: bool,
+                    fetchzpadding: bool,
+                }
+                let proxy = Fetchlen {
+                    fetchlen: self.fetchlen(),
+                    fetchcstaddr: self.fetchcstaddr(),
+                    fetchrealign: self.fetchrealign(),
+                    fetchzpadding: self.fetchzpadding(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FIFO threshold register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5864,6 +7406,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Fifothreshold {
                 Fifothreshold(0)
+            }
+        }
+        impl core::fmt::Debug for Fifothreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fifothreshold")
+                    .field("fifothreshold", &self.fifothreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fifothreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fifothreshold {
+                    fifothreshold: u8,
+                }
+                let proxy = Fifothreshold {
+                    fifothreshold: self.fifothreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HwConfig register."]
@@ -6001,6 +7563,59 @@ pub mod cracencore {
                 IkgHwconfig(0)
             }
         }
+        impl core::fmt::Debug for IkgHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgHwconfig")
+                    .field("nbsymkeys", &self.nbsymkeys())
+                    .field("nbprivkeys", &self.nbprivkeys())
+                    .field("ikgcm", &self.ikgcm())
+                    .field("hwhealthtest", &self.hwhealthtest())
+                    .field("curve", &self.curve())
+                    .field("df", &self.df())
+                    .field("keysize", &self.keysize())
+                    .field("entropyinputlength", &self.entropyinputlength())
+                    .field("noncelength", &self.noncelength())
+                    .field(
+                        "personalizationstringlength",
+                        &self.personalizationstringlength(),
+                    )
+                    .field("additionalinputlength", &self.additionalinputlength())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgHwconfig {
+                    nbsymkeys: u8,
+                    nbprivkeys: u8,
+                    ikgcm: bool,
+                    hwhealthtest: bool,
+                    curve: super::vals::Curve,
+                    df: bool,
+                    keysize: super::vals::Keysize,
+                    entropyinputlength: u8,
+                    noncelength: u8,
+                    personalizationstringlength: u8,
+                    additionalinputlength: u8,
+                }
+                let proxy = IkgHwconfig {
+                    nbsymkeys: self.nbsymkeys(),
+                    nbprivkeys: self.nbprivkeys(),
+                    ikgcm: self.ikgcm(),
+                    hwhealthtest: self.hwhealthtest(),
+                    curve: self.curve(),
+                    df: self.df(),
+                    keysize: self.keysize(),
+                    entropyinputlength: self.entropyinputlength(),
+                    noncelength: self.noncelength(),
+                    personalizationstringlength: self.personalizationstringlength(),
+                    additionalinputlength: self.additionalinputlength(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6022,6 +7637,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> IkgStart {
                 IkgStart(0)
+            }
+        }
+        impl core::fmt::Debug for IkgStart {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgStart")
+                    .field("start", &self.start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgStart {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgStart {
+                    start: bool,
+                }
+                let proxy = IkgStart {
+                    start: self.start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -6111,6 +7746,44 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> IkgStatus {
                 IkgStatus(0)
+            }
+        }
+        impl core::fmt::Debug for IkgStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgStatus")
+                    .field("seederror", &self.seederror())
+                    .field("entropyerror", &self.entropyerror())
+                    .field("okay", &self.okay())
+                    .field("ctrdrbgbusy", &self.ctrdrbgbusy())
+                    .field("catastrophicerror", &self.catastrophicerror())
+                    .field("symkeystored", &self.symkeystored())
+                    .field("privkeystored", &self.privkeystored())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgStatus {
+                    seederror: bool,
+                    entropyerror: bool,
+                    okay: bool,
+                    ctrdrbgbusy: bool,
+                    catastrophicerror: bool,
+                    symkeystored: bool,
+                    privkeystored: bool,
+                }
+                let proxy = IkgStatus {
+                    seederror: self.seederror(),
+                    entropyerror: self.entropyerror(),
+                    okay: self.okay(),
+                    ctrdrbgbusy: self.ctrdrbgbusy(),
+                    catastrophicerror: self.catastrophicerror(),
+                    symkeystored: self.symkeystored(),
+                    privkeystored: self.privkeystored(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Incuded IPs Hardware configuration"]
@@ -6279,6 +7952,68 @@ pub mod cracencore {
                 Inclipshwcfg(0)
             }
         }
+        impl core::fmt::Debug for Inclipshwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Inclipshwcfg")
+                    .field("ba411aesincluded", &self.ba411aesincluded())
+                    .field("ba415hpaesgcmincluded", &self.ba415hpaesgcmincluded())
+                    .field("ba416hpaesxtsincluded", &self.ba416hpaesxtsincluded())
+                    .field("ba412desincluded", &self.ba412desincluded())
+                    .field("ba413hashincluded", &self.ba413hashincluded())
+                    .field("ba417chachapolyincluded", &self.ba417chachapolyincluded())
+                    .field("ba418sha3included", &self.ba418sha3included())
+                    .field("ba421zucincluded", &self.ba421zucincluded())
+                    .field("ba419sm4included", &self.ba419sm4included())
+                    .field("ba414eppkeincluded", &self.ba414eppkeincluded())
+                    .field("ba431ndrngincluded", &self.ba431ndrngincluded())
+                    .field(
+                        "ba420hpchachapolyincluded",
+                        &self.ba420hpchachapolyincluded(),
+                    )
+                    .field("ba423snow3gincluded", &self.ba423snow3gincluded())
+                    .field("ba422kasumiincluded", &self.ba422kasumiincluded())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Inclipshwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Inclipshwcfg {
+                    ba411aesincluded: bool,
+                    ba415hpaesgcmincluded: bool,
+                    ba416hpaesxtsincluded: bool,
+                    ba412desincluded: bool,
+                    ba413hashincluded: bool,
+                    ba417chachapolyincluded: bool,
+                    ba418sha3included: bool,
+                    ba421zucincluded: bool,
+                    ba419sm4included: bool,
+                    ba414eppkeincluded: bool,
+                    ba431ndrngincluded: bool,
+                    ba420hpchachapolyincluded: bool,
+                    ba423snow3gincluded: bool,
+                    ba422kasumiincluded: bool,
+                }
+                let proxy = Inclipshwcfg {
+                    ba411aesincluded: self.ba411aesincluded(),
+                    ba415hpaesgcmincluded: self.ba415hpaesgcmincluded(),
+                    ba416hpaesxtsincluded: self.ba416hpaesxtsincluded(),
+                    ba412desincluded: self.ba412desincluded(),
+                    ba413hashincluded: self.ba413hashincluded(),
+                    ba417chachapolyincluded: self.ba417chachapolyincluded(),
+                    ba418sha3included: self.ba418sha3included(),
+                    ba421zucincluded: self.ba421zucincluded(),
+                    ba419sm4included: self.ba419sm4included(),
+                    ba414eppkeincluded: self.ba414eppkeincluded(),
+                    ba431ndrngincluded: self.ba431ndrngincluded(),
+                    ba420hpchachapolyincluded: self.ba420hpchachapolyincluded(),
+                    ba423snow3gincluded: self.ba423snow3gincluded(),
+                    ba422kasumiincluded: self.ba422kasumiincluded(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "InitData register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6300,6 +8035,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Initdata {
                 Initdata(0)
+            }
+        }
+        impl core::fmt::Debug for Initdata {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Initdata")
+                    .field("initdata", &self.initdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Initdata {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Initdata {
+                    initdata: bool,
+                }
+                let proxy = Initdata {
+                    initdata: self.initdata(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Initial wait counter value."]
@@ -6325,6 +8080,26 @@ pub mod cracencore {
                 Initwaitval(0)
             }
         }
+        impl core::fmt::Debug for Initwaitval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Initwaitval")
+                    .field("initwaitval", &self.initwaitval())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Initwaitval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Initwaitval {
+                    initwaitval: u16,
+                }
+                let proxy = Initwaitval {
+                    initwaitval: self.initwaitval(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt Enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6344,6 +8119,22 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("int", &self.int()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    int: u8,
+                }
+                let proxy = Int { int: self.int() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operand size register."]
@@ -6368,6 +8159,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Opsize {
                 Opsize(0)
+            }
+        }
+        impl core::fmt::Debug for Opsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Opsize")
+                    .field("opsize", &self.opsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Opsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Opsize {
+                    opsize: super::vals::Opsize,
+                }
+                let proxy = Opsize {
+                    opsize: self.opsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Command register."]
@@ -6402,6 +8213,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> PkControl {
                 PkControl(0)
+            }
+        }
+        impl core::fmt::Debug for PkControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkControl")
+                    .field("start", &self.start())
+                    .field("clearirq", &self.clearirq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkControl {
+                    start: bool,
+                    clearirq: bool,
+                }
+                let proxy = PkControl {
+                    start: self.start(),
+                    clearirq: self.clearirq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration register."]
@@ -6572,6 +8406,65 @@ pub mod cracencore {
                 PkHwconfig(0)
             }
         }
+        impl core::fmt::Debug for PkHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkHwconfig")
+                    .field("maxopsize", &self.maxopsize())
+                    .field("nbmult", &self.nbmult())
+                    .field("primefield", &self.primefield())
+                    .field("binaryfield", &self.binaryfield())
+                    .field("ecc", &self.ecc())
+                    .field("p256", &self.p256())
+                    .field("p384", &self.p384())
+                    .field("p521", &self.p521())
+                    .field("p192", &self.p192())
+                    .field("x25519", &self.x25519())
+                    .field("ahbmaster", &self.ahbmaster())
+                    .field("disablesmx", &self.disablesmx())
+                    .field("disableclrmem", &self.disableclrmem())
+                    .field("disablecm", &self.disablecm())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkHwconfig {
+                    maxopsize: u16,
+                    nbmult: super::vals::Nbmult,
+                    primefield: bool,
+                    binaryfield: bool,
+                    ecc: bool,
+                    p256: bool,
+                    p384: bool,
+                    p521: bool,
+                    p192: bool,
+                    x25519: bool,
+                    ahbmaster: super::vals::Ahbmaster,
+                    disablesmx: bool,
+                    disableclrmem: bool,
+                    disablecm: bool,
+                }
+                let proxy = PkHwconfig {
+                    maxopsize: self.maxopsize(),
+                    nbmult: self.nbmult(),
+                    primefield: self.primefield(),
+                    binaryfield: self.binaryfield(),
+                    ecc: self.ecc(),
+                    p256: self.p256(),
+                    p384: self.p384(),
+                    p521: self.p521(),
+                    p192: self.p192(),
+                    x25519: self.x25519(),
+                    ahbmaster: self.ahbmaster(),
+                    disablesmx: self.disablesmx(),
+                    disableclrmem: self.disableclrmem(),
+                    disablecm: self.disablecm(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6628,6 +8521,35 @@ pub mod cracencore {
                 PkStatus(0)
             }
         }
+        impl core::fmt::Debug for PkStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkStatus")
+                    .field("errorflags", &self.errorflags())
+                    .field("pkbusy", &self.pkbusy())
+                    .field("intrptstatus", &self.intrptstatus())
+                    .field("failptr", &self.failptr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkStatus {
+                    errorflags: u16,
+                    pkbusy: bool,
+                    intrptstatus: bool,
+                    failptr: u8,
+                }
+                let proxy = PkStatus {
+                    errorflags: self.errorflags(),
+                    pkbusy: self.pkbusy(),
+                    intrptstatus: self.intrptstatus(),
+                    failptr: self.failptr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PKE Command register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6673,6 +8595,32 @@ pub mod cracencore {
                 Pkecommand(0)
             }
         }
+        impl core::fmt::Debug for Pkecommand {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkecommand")
+                    .field("securemode", &self.securemode())
+                    .field("selectedkey", &self.selectedkey())
+                    .field("opsel", &self.opsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkecommand {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkecommand {
+                    securemode: bool,
+                    selectedkey: u8,
+                    opsel: super::vals::Opsel,
+                }
+                let proxy = Pkecommand {
+                    securemode: self.securemode(),
+                    selectedkey: self.selectedkey(),
+                    opsel: self.opsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PKE Control register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6705,6 +8653,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Pkecontrol {
                 Pkecontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Pkecontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkecontrol")
+                    .field("pkestart", &self.pkestart())
+                    .field("clearirq", &self.clearirq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkecontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkecontrol {
+                    pkestart: bool,
+                    clearirq: bool,
+                }
+                let proxy = Pkecontrol {
+                    pkestart: self.pkestart(),
+                    clearirq: self.clearirq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "PKE Status register."]
@@ -6774,6 +8745,38 @@ pub mod cracencore {
                 Pkestatus(0)
             }
         }
+        impl core::fmt::Debug for Pkestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkestatus")
+                    .field("error", &self.error())
+                    .field("starterror", &self.starterror())
+                    .field("ikgpkbusy", &self.ikgpkbusy())
+                    .field("irqstatus", &self.irqstatus())
+                    .field("erasebusy", &self.erasebusy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkestatus {
+                    error: bool,
+                    starterror: bool,
+                    ikgpkbusy: bool,
+                    irqstatus: bool,
+                    erasebusy: bool,
+                }
+                let proxy = Pkestatus {
+                    error: self.error(),
+                    starterror: self.starterror(),
+                    ikgpkbusy: self.ikgpkbusy(),
+                    irqstatus: self.irqstatus(),
+                    erasebusy: self.erasebusy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pointers register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6830,6 +8833,35 @@ pub mod cracencore {
                 Pointers(0)
             }
         }
+        impl core::fmt::Debug for Pointers {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pointers")
+                    .field("opptra", &self.opptra())
+                    .field("opptrb", &self.opptrb())
+                    .field("opptrc", &self.opptrc())
+                    .field("opptrn", &self.opptrn())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pointers {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pointers {
+                    opptra: u8,
+                    opptrb: u8,
+                    opptrc: u8,
+                    opptrn: u8,
+                }
+                let proxy = Pointers {
+                    opptra: self.opptra(),
+                    opptrb: self.opptrb(),
+                    opptrc: self.opptrc(),
+                    opptrn: self.opptrn(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Adaptive Proportion Test (1024-sample window) Cut-Off value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6851,6 +8883,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Propthreshold {
                 Propthreshold(0)
+            }
+        }
+        impl core::fmt::Debug for Propthreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Propthreshold")
+                    .field("propthreshold", &self.propthreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Propthreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Propthreshold {
+                    propthreshold: u16,
+                }
+                let proxy = Propthreshold {
+                    propthreshold: self.propthreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Push Length"]
@@ -6902,6 +8954,35 @@ pub mod cracencore {
                 Pushlen(0)
             }
         }
+        impl core::fmt::Debug for Pushlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pushlen")
+                    .field("pushlen", &self.pushlen())
+                    .field("pushcstaddr", &self.pushcstaddr())
+                    .field("pushrealign", &self.pushrealign())
+                    .field("pushdiscard", &self.pushdiscard())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pushlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pushlen {
+                    pushlen: u32,
+                    pushcstaddr: bool,
+                    pushrealign: bool,
+                    pushdiscard: bool,
+                }
+                let proxy = Pushlen {
+                    pushlen: self.pushlen(),
+                    pushcstaddr: self.pushcstaddr(),
+                    pushrealign: self.pushrealign(),
+                    pushdiscard: self.pushdiscard(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM error injection register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6934,6 +9015,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ramerrorinject {
                 Ramerrorinject(0)
+            }
+        }
+        impl core::fmt::Debug for Ramerrorinject {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramerrorinject")
+                    .field("biterror1", &self.biterror1())
+                    .field("biterror2", &self.biterror2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramerrorinject {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramerrorinject {
+                    biterror1: u16,
+                    biterror2: u16,
+                }
+                let proxy = Ramerrorinject {
+                    biterror1: self.biterror1(),
+                    biterror2: self.biterror2(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM error status register."]
@@ -6970,6 +9074,29 @@ pub mod cracencore {
                 Ramerrorstatus(0)
             }
         }
+        impl core::fmt::Debug for Ramerrorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramerrorstatus")
+                    .field("ramcorrection", &self.ramcorrection())
+                    .field("ramfailure", &self.ramfailure())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramerrorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramerrorstatus {
+                    ramcorrection: bool,
+                    ramfailure: bool,
+                }
+                let proxy = Ramerrorstatus {
+                    ramcorrection: self.ramcorrection(),
+                    ramfailure: self.ramfailure(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Repetition Test Count Cut-Off value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6993,6 +9120,26 @@ pub mod cracencore {
                 Repeatthreshold(0)
             }
         }
+        impl core::fmt::Debug for Repeatthreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Repeatthreshold")
+                    .field("repeatthreshold", &self.repeatthreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Repeatthreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Repeatthreshold {
+                    repeatthreshold: u8,
+                }
+                let proxy = Repeatthreshold {
+                    repeatthreshold: self.repeatthreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reseed Interval MSB register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7014,6 +9161,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Reseedintervalmsb {
                 Reseedintervalmsb(0)
+            }
+        }
+        impl core::fmt::Debug for Reseedintervalmsb {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reseedintervalmsb")
+                    .field("reseedintervalmsb", &self.reseedintervalmsb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reseedintervalmsb {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reseedintervalmsb {
+                    reseedintervalmsb: u16,
+                }
+                let proxy = Reseedintervalmsb {
+                    reseedintervalmsb: self.reseedintervalmsb(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register"]
@@ -7217,6 +9384,74 @@ pub mod cracencore {
                 RngcontrolControl(0)
             }
         }
+        impl core::fmt::Debug for RngcontrolControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolControl")
+                    .field("enable", &self.enable())
+                    .field("lfsren", &self.lfsren())
+                    .field("testen", &self.testen())
+                    .field("condbypass", &self.condbypass())
+                    .field("intenrep", &self.intenrep())
+                    .field("intenprop", &self.intenprop())
+                    .field("intenfull", &self.intenfull())
+                    .field("softrst", &self.softrst())
+                    .field("intenpre", &self.intenpre())
+                    .field("intenalm", &self.intenalm())
+                    .field("forceactiveros", &self.forceactiveros())
+                    .field("healthtestbypass", &self.healthtestbypass())
+                    .field("ais31bypass", &self.ais31bypass())
+                    .field("healthtestsel", &self.healthtestsel())
+                    .field("ais31testsel", &self.ais31testsel())
+                    .field("nb128bitblocks", &self.nb128bitblocks())
+                    .field("fifowritestartup", &self.fifowritestartup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolControl {
+                    enable: bool,
+                    lfsren: bool,
+                    testen: super::vals::Testen,
+                    condbypass: super::vals::Condbypass,
+                    intenrep: bool,
+                    intenprop: bool,
+                    intenfull: bool,
+                    softrst: super::vals::ControlSoftrst,
+                    intenpre: bool,
+                    intenalm: bool,
+                    forceactiveros: bool,
+                    healthtestbypass: bool,
+                    ais31bypass: bool,
+                    healthtestsel: super::vals::Healthtestsel,
+                    ais31testsel: super::vals::Ais31testsel,
+                    nb128bitblocks: u8,
+                    fifowritestartup: bool,
+                }
+                let proxy = RngcontrolControl {
+                    enable: self.enable(),
+                    lfsren: self.lfsren(),
+                    testen: self.testen(),
+                    condbypass: self.condbypass(),
+                    intenrep: self.intenrep(),
+                    intenprop: self.intenprop(),
+                    intenfull: self.intenfull(),
+                    softrst: self.softrst(),
+                    intenpre: self.intenpre(),
+                    intenalm: self.intenalm(),
+                    forceactiveros: self.forceactiveros(),
+                    healthtestbypass: self.healthtestbypass(),
+                    ais31bypass: self.ais31bypass(),
+                    healthtestsel: self.healthtestsel(),
+                    ais31testsel: self.ais31testsel(),
+                    nb128bitblocks: self.nb128bitblocks(),
+                    fifowritestartup: self.fifowritestartup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hardware configuration register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7260,6 +9495,32 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> RngcontrolHwconfig {
                 RngcontrolHwconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RngcontrolHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolHwconfig")
+                    .field("numbofrings", &self.numbofrings())
+                    .field("ais31", &self.ais31())
+                    .field("ais31full", &self.ais31full())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolHwconfig {
+                    numbofrings: u8,
+                    ais31: bool,
+                    ais31full: bool,
+                }
+                let proxy = RngcontrolHwconfig {
+                    numbofrings: self.numbofrings(),
+                    ais31: self.ais31(),
+                    ais31full: self.ais31full(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -7373,6 +9634,50 @@ pub mod cracencore {
                 RngcontrolStatus(0)
             }
         }
+        impl core::fmt::Debug for RngcontrolStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolStatus")
+                    .field("testdatabusy", &self.testdatabusy())
+                    .field("state", &self.state())
+                    .field("repfail", &self.repfail())
+                    .field("propfail", &self.propfail())
+                    .field("fullint", &self.fullint())
+                    .field("preint", &self.preint())
+                    .field("almint", &self.almint())
+                    .field("startupfail", &self.startupfail())
+                    .field("fifoaccfail", &self.fifoaccfail())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolStatus {
+                    testdatabusy: bool,
+                    state: super::vals::State,
+                    repfail: bool,
+                    propfail: bool,
+                    fullint: bool,
+                    preint: bool,
+                    almint: bool,
+                    startupfail: bool,
+                    fifoaccfail: bool,
+                }
+                let proxy = RngcontrolStatus {
+                    testdatabusy: self.testdatabusy(),
+                    state: self.state(),
+                    repfail: self.repfail(),
+                    propfail: self.propfail(),
+                    fullint: self.fullint(),
+                    preint: self.preint(),
+                    almint: self.almint(),
+                    startupfail: self.startupfail(),
+                    fifoaccfail: self.fifoaccfail(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SoftRst register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7394,6 +9699,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Softrst {
                 Softrst(0)
+            }
+        }
+        impl core::fmt::Debug for Softrst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Softrst")
+                    .field("softrst", &self.softrst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Softrst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Softrst {
+                    softrst: super::vals::SoftrstSoftrst,
+                }
+                let proxy = Softrst {
+                    softrst: self.softrst(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Switch off timer value."]
@@ -7419,10 +9744,31 @@ pub mod cracencore {
                 Swofftmrval(0)
             }
         }
+        impl core::fmt::Debug for Swofftmrval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swofftmrval")
+                    .field("swofftmrval", &self.swofftmrval())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swofftmrval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swofftmrval {
+                    swofftmrval: u16,
+                }
+                let proxy = Swofftmrval {
+                    swofftmrval: self.swofftmrval(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ahbmaster {
             #[doc = "Memory access through AHB Slave and internally in the PKE."]
             SLAVE = 0x0,
@@ -7452,7 +9798,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ais31testsel {
             #[doc = "Before conditioning."]
             BEFORE = 0x0,
@@ -7482,7 +9829,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Calcr2 {
             #[doc = "don't recalculate R² mod N"]
             NRECALCULATE = 0x0,
@@ -7512,7 +9860,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Condbypass {
             #[doc = "the conditioning function is used (normal mode)."]
             NORMAL = 0x0,
@@ -7542,7 +9891,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ControlSoftrst {
             #[doc = "Normal mode."]
             NORMAL = 0x0,
@@ -7572,7 +9922,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Curve {
             #[doc = "P256."]
             P256 = 0x0,
@@ -7605,7 +9956,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Healthtestsel {
             #[doc = "Before conditioning."]
             BEFORE = 0x0,
@@ -7635,7 +9987,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Keysize {
             _RESERVED_0 = 0x0,
             #[doc = "supports AES128"]
@@ -7672,7 +10025,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nbmult {
             #[doc = "1 multiplier"]
             MULT1 = 0x0,
@@ -7719,7 +10073,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Opsel {
             #[doc = "Public Key Generation"]
             PUBKEY = 0x0,
@@ -7774,6 +10129,31 @@ pub mod cracencore {
                 self.0
             }
         }
+        impl core::fmt::Debug for Opsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("OPSIZE256"),
+                    0x0209 => f.write_str("OPSIZE521"),
+                    0x0800 => f.write_str("OPSIZE2048"),
+                    0x0c00 => f.write_str("OPSIZE3072"),
+                    0x1000 => f.write_str("OPSIZE4096"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Opsize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "OPSIZE256"),
+                    0x0209 => defmt::write!(f, "OPSIZE521"),
+                    0x0800 => defmt::write!(f, "OPSIZE2048"),
+                    0x0c00 => defmt::write!(f, "OPSIZE3072"),
+                    0x1000 => defmt::write!(f, "OPSIZE4096"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Opsize {
             #[inline(always)]
             fn from(val: u16) -> Opsize {
@@ -7787,7 +10167,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Selcurve {
             #[doc = "Unspecified"]
             NOACCEL = 0x0,
@@ -7828,7 +10209,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SoftrstSoftrst {
             #[doc = "Normal mode."]
             NORMAL = 0x0,
@@ -7858,7 +10240,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Reset"]
             RESET = 0x0,
@@ -7898,7 +10281,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swapbytes {
             #[doc = "Native format (little endian)."]
             NATIVE = 0x0,
@@ -7928,7 +10312,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Testen {
             #[doc = "Noise source (normal mode)."]
             NORMAL = 0x0,
@@ -8121,6 +10506,29 @@ pub mod ctrlapperi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxready", &self.rxready())
+                    .field("txdone", &self.txdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxready: bool,
+                    txdone: bool,
+                }
+                let proxy = Int {
+                    rxready: self.rxready(),
+                    txdone: self.txdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register locks the ERASEPROTECT.DISABLE register from being written until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8142,6 +10550,22 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Lock {
                 Lock(0)
+            }
+        }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System reset request."]
@@ -8167,6 +10591,26 @@ pub mod ctrlapperi {
                 Reset(0)
             }
         }
+        impl core::fmt::Debug for Reset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reset {
+                    reset: super::vals::Reset,
+                }
+                let proxy = Reset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status to indicate if data sent from the debugger to the CPU has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8188,6 +10632,26 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Rxstatus {
                 Rxstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status to indicate if data sent from the CPU to the debugger has been read."]
@@ -8213,10 +10677,31 @@ pub mod ctrlapperi {
                 Txstatus(0)
             }
         }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reset {
             #[doc = "No reset is generated"]
             NO_RESET = 0x0,
@@ -8392,6 +10877,79 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 24usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8417,6 +10975,79 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 24usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8608,6 +11239,26 @@ pub mod ecb {
                 Errorstatus(0)
             }
         }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8642,10 +11293,34 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -8777,6 +11452,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -9120,6 +11852,35 @@ pub mod etm {
                 Trcauthstatus(0)
             }
         }
+        impl core::fmt::Debug for Trcauthstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcauthstatus")
+                    .field("nsid", &self.nsid())
+                    .field("nsnid", &self.nsnid())
+                    .field("sid", &self.sid())
+                    .field("snid", &self.snid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcauthstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcauthstatus {
+                    nsid: super::vals::Nsid,
+                    nsnid: super::vals::Nsnid,
+                    sid: super::vals::Sid,
+                    snid: super::vals::Snid,
+                }
+                let proxy = Trcauthstatus {
+                    nsid: self.nsid(),
+                    nsnid: self.nsnid(),
+                    sid: self.sid(),
+                    snid: self.snid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls which regions in the memory map are enabled to use branch broadcasting. Might ignore writes when the trace unit is enabled or not idle. Must be programmed if TRCCONFIGR.BB == 1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9220,6 +11981,47 @@ pub mod etm {
                 Trcbbctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcbbctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcbbctlr")
+                    .field("range_0", &self.range_0())
+                    .field("range_1", &self.range_1())
+                    .field("range_2", &self.range_2())
+                    .field("range_3", &self.range_3())
+                    .field("range_4", &self.range_4())
+                    .field("range_5", &self.range_5())
+                    .field("range_6", &self.range_6())
+                    .field("range_7", &self.range_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcbbctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcbbctlr {
+                    range_0: bool,
+                    range_1: bool,
+                    range_2: bool,
+                    range_3: bool,
+                    range_4: bool,
+                    range_5: bool,
+                    range_6: bool,
+                    range_7: bool,
+                }
+                let proxy = Trcbbctlr {
+                    range_0: self.range_0(),
+                    range_1: self.range_1(),
+                    range_2: self.range_2(),
+                    range_3: self.range_3(),
+                    range_4: self.range_4(),
+                    range_5: self.range_5(),
+                    range_6: self.range_6(),
+                    range_7: self.range_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sets the threshold value for cycle counting. Might ignore writes when the trace unit is enabled or not idle. Must be programmed if TRCCONFIGR.CCI==1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9241,6 +12043,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcccctlr {
                 Trcccctlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcccctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcccctlr")
+                    .field("threshold", &self.threshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcccctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcccctlr {
+                    threshold: u16,
+                }
+                let proxy = Trcccctlr {
+                    threshold: self.threshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clears bits in the claim tag and determines the current value of the claim tag."]
@@ -9299,6 +12121,35 @@ pub mod etm {
                 Trcclaimclr(0)
             }
         }
+        impl core::fmt::Debug for Trcclaimclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcclaimclr")
+                    .field("clr_0", &self.clr_0())
+                    .field("clr_1", &self.clr_1())
+                    .field("clr_2", &self.clr_2())
+                    .field("clr_3", &self.clr_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcclaimclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcclaimclr {
+                    clr_0: super::vals::Clr0,
+                    clr_1: super::vals::Clr1,
+                    clr_2: super::vals::Clr2,
+                    clr_3: super::vals::Clr3,
+                }
+                let proxy = Trcclaimclr {
+                    clr_0: self.clr_0(),
+                    clr_1: self.clr_1(),
+                    clr_2: self.clr_2(),
+                    clr_3: self.clr_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sets bits in the claim tag and determines the number of claim tag bits implemented."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9353,6 +12204,35 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcclaimset {
                 Trcclaimset(0)
+            }
+        }
+        impl core::fmt::Debug for Trcclaimset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcclaimset")
+                    .field("set_0", &self.set_0())
+                    .field("set_1", &self.set_1())
+                    .field("set_2", &self.set_2())
+                    .field("set_3", &self.set_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcclaimset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcclaimset {
+                    set_0: super::vals::Set0,
+                    set_1: super::vals::Set1,
+                    set_2: super::vals::Set2,
+                    set_3: super::vals::Set3,
+                }
+                let proxy = Trcclaimset {
+                    set_0: self.set_0(),
+                    set_1: self.set_1(),
+                    set_2: self.set_2(),
+                    set_3: self.set_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Controls the operation of counter n. Might ignore writes when the trace unit is enabled or not idle."]
@@ -9411,6 +12291,35 @@ pub mod etm {
                 Trccntctlr(0)
             }
         }
+        impl core::fmt::Debug for Trccntctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trccntctlr")
+                    .field("cntevent", &self.cntevent())
+                    .field("rldevent", &self.rldevent())
+                    .field("rldself", &self.rldself())
+                    .field("cntchain", &self.cntchain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trccntctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trccntctlr {
+                    cntevent: u8,
+                    rldevent: u8,
+                    rldself: bool,
+                    cntchain: bool,
+                }
+                let proxy = Trccntctlr {
+                    cntevent: self.cntevent(),
+                    rldevent: self.rldevent(),
+                    rldself: self.rldself(),
+                    cntchain: self.cntchain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: This sets or returns the reload count value for counter n. Might ignore writes when the trace unit is enabled or not idle."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9434,6 +12343,26 @@ pub mod etm {
                 Trccntrldvr(0)
             }
         }
+        impl core::fmt::Debug for Trccntrldvr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trccntrldvr")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trccntrldvr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trccntrldvr {
+                    value: u16,
+                }
+                let proxy = Trccntrldvr {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: This sets or returns the value of counter n. The count value is only stable when TRCSTATR.PMSTABLE == 1. If software uses counter n then it must write to this register to set the initial counter value. Might ignore writes when the trace unit is enabled or not idle."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9455,6 +12384,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trccntvr {
                 Trccntvr(0)
+            }
+        }
+        impl core::fmt::Debug for Trccntvr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trccntvr")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trccntvr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trccntvr {
+                    value: u16,
+                }
+                let proxy = Trccntvr {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the tracing options This register must always be programmed as part of trace unit initialization. Might ignore writes when the trace unit is enabled or not idle."]
@@ -9614,6 +12563,62 @@ pub mod etm {
                 Trcconfigr(0)
             }
         }
+        impl core::fmt::Debug for Trcconfigr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcconfigr")
+                    .field("loadasp0inst", &self.loadasp0inst())
+                    .field("storeasp0inst", &self.storeasp0inst())
+                    .field("bb", &self.bb())
+                    .field("cci", &self.cci())
+                    .field("cid", &self.cid())
+                    .field("vmid", &self.vmid())
+                    .field("cond", &self.cond())
+                    .field("ts", &self.ts())
+                    .field("rs", &self.rs())
+                    .field("qe", &self.qe())
+                    .field("vmidopt", &self.vmidopt())
+                    .field("da", &self.da())
+                    .field("dv", &self.dv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcconfigr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcconfigr {
+                    loadasp0inst: bool,
+                    storeasp0inst: bool,
+                    bb: bool,
+                    cci: bool,
+                    cid: bool,
+                    vmid: bool,
+                    cond: super::vals::Cond,
+                    ts: bool,
+                    rs: bool,
+                    qe: super::vals::Qe,
+                    vmidopt: super::vals::Vmidopt,
+                    da: bool,
+                    dv: bool,
+                }
+                let proxy = Trcconfigr {
+                    loadasp0inst: self.loadasp0inst(),
+                    storeasp0inst: self.storeasp0inst(),
+                    bb: self.bb(),
+                    cci: self.cci(),
+                    cid: self.cid(),
+                    vmid: self.vmid(),
+                    cond: self.cond(),
+                    ts: self.ts(),
+                    rs: self.rs(),
+                    qe: self.qe(),
+                    vmidopt: self.vmidopt(),
+                    da: self.da(),
+                    dv: self.dv(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The TRCDEVARCH identifies ETM-M33 as an ETMv4.2 component"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9674,6 +12679,35 @@ pub mod etm {
                 Trcdevarch(0)
             }
         }
+        impl core::fmt::Debug for Trcdevarch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcdevarch")
+                    .field("archid", &self.archid())
+                    .field("revision", &self.revision())
+                    .field("present", &self.present())
+                    .field("architect", &self.architect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcdevarch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcdevarch {
+                    archid: super::vals::Archid,
+                    revision: super::vals::Revision,
+                    present: super::vals::Present,
+                    architect: super::vals::Architect,
+                }
+                let proxy = Trcdevarch {
+                    archid: self.archid(),
+                    revision: self.revision(),
+                    present: self.present(),
+                    architect: self.architect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the single-shot comparator."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9708,6 +12742,29 @@ pub mod etm {
                 Trcdevtype(0)
             }
         }
+        impl core::fmt::Debug for Trcdevtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcdevtype")
+                    .field("major", &self.major())
+                    .field("sub", &self.sub())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcdevtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcdevtype {
+                    major: super::vals::Major,
+                    sub: super::vals::Sub,
+                }
+                let proxy = Trcdevtype {
+                    major: self.major(),
+                    sub: self.sub(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the tracing of arbitrary events. If the selected event occurs a trace element is generated in the trace stream according to the settings in TRCEVENTCTL1R.DATAEN and TRCEVENTCTL1R.INSTEN."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9729,6 +12786,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trceventctl0r {
                 Trceventctl0r(0)
+            }
+        }
+        impl core::fmt::Debug for Trceventctl0r {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trceventctl0r")
+                    .field("event", &self.event())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trceventctl0r {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trceventctl0r {
+                    event: u8,
+                }
+                let proxy = Trceventctl0r {
+                    event: self.event(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls the behavior of the events that TRCEVENTCTL0R selects. This register must always be programmed as part of trace unit initialization. Might ignore writes when the trace unit is enabled or not idle."]
@@ -9820,6 +12897,44 @@ pub mod etm {
                 Trceventctl1r(0)
             }
         }
+        impl core::fmt::Debug for Trceventctl1r {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trceventctl1r")
+                    .field("insten_0", &self.insten_0())
+                    .field("insten_1", &self.insten_1())
+                    .field("insten_2", &self.insten_2())
+                    .field("insten_3", &self.insten_3())
+                    .field("dataen", &self.dataen())
+                    .field("atb", &self.atb())
+                    .field("lpoverride", &self.lpoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trceventctl1r {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trceventctl1r {
+                    insten_0: bool,
+                    insten_1: bool,
+                    insten_2: bool,
+                    insten_3: bool,
+                    dataen: bool,
+                    atb: bool,
+                    lpoverride: bool,
+                }
+                let proxy = Trceventctl1r {
+                    insten_0: self.insten_0(),
+                    insten_1: self.insten_1(),
+                    insten_2: self.insten_2(),
+                    insten_3: self.insten_3(),
+                    dataen: self.dataen(),
+                    atb: self.atb(),
+                    lpoverride: self.lpoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Use this to set, or read, which external inputs are resources to the trace unit. Might ignore writes when the trace unit is enabled or not idle. Only returns stable data when TRCSTATR.PMSTABLE == 1. When the sequencer is used, all sequencer state transitions must be programmed with a valid event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9874,6 +12989,35 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcextinselr {
                 Trcextinselr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcextinselr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcextinselr")
+                    .field("sel_0", &self.sel_0())
+                    .field("sel_1", &self.sel_1())
+                    .field("sel_2", &self.sel_2())
+                    .field("sel_3", &self.sel_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcextinselr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcextinselr {
+                    sel_0: u8,
+                    sel_1: u8,
+                    sel_2: u8,
+                    sel_3: u8,
+                }
+                let proxy = Trcextinselr {
+                    sel_0: self.sel_0(),
+                    sel_1: self.sel_1(),
+                    sel_2: self.sel_2(),
+                    sel_3: self.sel_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sets the state of output pins."]
@@ -9965,6 +13109,44 @@ pub mod etm {
                 Trcitatbidr(0)
             }
         }
+        impl core::fmt::Debug for Trcitatbidr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcitatbidr")
+                    .field("id_0", &self.id_0())
+                    .field("id_1", &self.id_1())
+                    .field("id_2", &self.id_2())
+                    .field("id_3", &self.id_3())
+                    .field("id_4", &self.id_4())
+                    .field("id_5", &self.id_5())
+                    .field("id_6", &self.id_6())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcitatbidr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcitatbidr {
+                    id_0: bool,
+                    id_1: bool,
+                    id_2: bool,
+                    id_3: bool,
+                    id_4: bool,
+                    id_5: bool,
+                    id_6: bool,
+                }
+                let proxy = Trcitatbidr {
+                    id_0: self.id_0(),
+                    id_1: self.id_1(),
+                    id_2: self.id_2(),
+                    id_3: self.id_3(),
+                    id_4: self.id_4(),
+                    id_5: self.id_5(),
+                    id_6: self.id_6(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables topology detection or integration testing, by putting ETM-M33 into integration mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9986,6 +13168,24 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcitctrl {
                 Trcitctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Trcitctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcitctrl")
+                    .field("ime", &self.ime())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcitctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcitctrl {
+                    ime: bool,
+                }
+                let proxy = Trcitctrl { ime: self.ime() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reads the state of the input pins."]
@@ -10022,6 +13222,29 @@ pub mod etm {
                 Trcitiatbinr(0)
             }
         }
+        impl core::fmt::Debug for Trcitiatbinr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcitiatbinr")
+                    .field("atvalid", &self.atvalid())
+                    .field("afready", &self.afready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcitiatbinr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcitiatbinr {
+                    atvalid: bool,
+                    afready: bool,
+                }
+                let proxy = Trcitiatbinr {
+                    atvalid: self.atvalid(),
+                    afready: self.afready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sets the state of the output pins."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10056,6 +13279,29 @@ pub mod etm {
                 Trcitiatboutr(0)
             }
         }
+        impl core::fmt::Debug for Trcitiatboutr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcitiatboutr")
+                    .field("atvalid", &self.atvalid())
+                    .field("afready", &self.afready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcitiatboutr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcitiatboutr {
+                    atvalid: bool,
+                    afready: bool,
+                }
+                let proxy = Trcitiatboutr {
+                    atvalid: self.atvalid(),
+                    afready: self.afready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the single-shot comparator."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10077,6 +13323,22 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcpdcr {
                 Trcpdcr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcpdcr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcpdcr").field("pu", &self.pu()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcpdcr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcpdcr {
+                    pu: bool,
+                }
+                let proxy = Trcpdcr { pu: self.pu() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the power down status of the ETM."]
@@ -10113,6 +13375,29 @@ pub mod etm {
                 Trcpdsr(0)
             }
         }
+        impl core::fmt::Debug for Trcpdsr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcpdsr")
+                    .field("power", &self.power())
+                    .field("stickypd", &self.stickypd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcpdsr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcpdsr {
+                    power: bool,
+                    stickypd: bool,
+                }
+                let proxy = Trcpdsr {
+                    power: self.power(),
+                    stickypd: self.stickypd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables the trace unit."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10136,6 +13421,24 @@ pub mod etm {
                 Trcprgctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcprgctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcprgctlr")
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcprgctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcprgctlr {
+                    en: bool,
+                }
+                let proxy = Trcprgctlr { en: self.en() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls which PE to trace. Might ignore writes when the trace unit is enabled or not idle. Before writing to this register, ensure that TRCSTATR.IDLE == 1 so that the trace unit can synchronize with the chosen PE. Implemented if TRCIDR3.NUMPROC is greater than zero."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10157,6 +13460,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcprocselr {
                 Trcprocselr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcprocselr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcprocselr")
+                    .field("procsel", &self.procsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcprocselr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcprocselr {
+                    procsel: u8,
+                }
+                let proxy = Trcprocselr {
+                    procsel: self.procsel(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls when Q elements are enabled. Might ignore writes when the trace unit is enabled or not idle. This register must be programmed if it is implemented and TRCCONFIGR.QE is set to any value other than 0b00."]
@@ -10270,6 +13593,50 @@ pub mod etm {
                 Trcqctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcqctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcqctlr")
+                    .field("range_0", &self.range_0())
+                    .field("range_1", &self.range_1())
+                    .field("range_2", &self.range_2())
+                    .field("range_3", &self.range_3())
+                    .field("range_4", &self.range_4())
+                    .field("range_5", &self.range_5())
+                    .field("range_6", &self.range_6())
+                    .field("range_7", &self.range_7())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcqctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcqctlr {
+                    range_0: bool,
+                    range_1: bool,
+                    range_2: bool,
+                    range_3: bool,
+                    range_4: bool,
+                    range_5: bool,
+                    range_6: bool,
+                    range_7: bool,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Trcqctlr {
+                    range_0: self.range_0(),
+                    range_1: self.range_1(),
+                    range_2: self.range_2(),
+                    range_3: self.range_3(),
+                    range_4: self.range_4(),
+                    range_5: self.range_5(),
+                    range_6: self.range_6(),
+                    range_7: self.range_7(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Controls the selection of the resources in the trace unit. Might ignore writes when the trace unit is enabled or not idle. If software selects a non-implemented resource then CONSTRAINED UNPREDICTABLE behavior of the resource selector occurs, so the resource selector might fire unexpectedly or might not fire. Reads of the TRCRSCTLRn might return UNKNOWN."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10291,6 +13658,22 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcrsctlr {
                 Trcrsctlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcrsctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcrsctlr").field("en", &self.en()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcrsctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcrsctlr {
+                    en: bool,
+                }
+                let proxy = Trcrsctlr { en: self.en() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Moves the sequencer state according to programmed events. Might ignore writes when the trace unit is enabled or not idle. When the sequencer is used, all sequencer state transitions must be programmed with a valid event."]
@@ -10481,6 +13864,71 @@ pub mod etm {
                 Trcseqevr(0)
             }
         }
+        impl core::fmt::Debug for Trcseqevr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcseqevr")
+                    .field("f_0", &self.f_0())
+                    .field("f_1", &self.f_1())
+                    .field("f_2", &self.f_2())
+                    .field("f_3", &self.f_3())
+                    .field("f_4", &self.f_4())
+                    .field("f_5", &self.f_5())
+                    .field("f_6", &self.f_6())
+                    .field("f_7", &self.f_7())
+                    .field("b_0", &self.b_0())
+                    .field("b_1", &self.b_1())
+                    .field("b_2", &self.b_2())
+                    .field("b_3", &self.b_3())
+                    .field("b_4", &self.b_4())
+                    .field("b_5", &self.b_5())
+                    .field("b_6", &self.b_6())
+                    .field("b_7", &self.b_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcseqevr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcseqevr {
+                    f_0: bool,
+                    f_1: bool,
+                    f_2: bool,
+                    f_3: bool,
+                    f_4: bool,
+                    f_5: bool,
+                    f_6: bool,
+                    f_7: bool,
+                    b_0: bool,
+                    b_1: bool,
+                    b_2: bool,
+                    b_3: bool,
+                    b_4: bool,
+                    b_5: bool,
+                    b_6: bool,
+                    b_7: bool,
+                }
+                let proxy = Trcseqevr {
+                    f_0: self.f_0(),
+                    f_1: self.f_1(),
+                    f_2: self.f_2(),
+                    f_3: self.f_3(),
+                    f_4: self.f_4(),
+                    f_5: self.f_5(),
+                    f_6: self.f_6(),
+                    f_7: self.f_7(),
+                    b_0: self.b_0(),
+                    b_1: self.b_1(),
+                    b_2: self.b_2(),
+                    b_3: self.b_3(),
+                    b_4: self.b_4(),
+                    b_5: self.b_5(),
+                    b_6: self.b_6(),
+                    b_7: self.b_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Moves the sequencer to state 0 when a programmed event occurs. Might ignore writes when the trace unit is enabled or not idle. When the sequencer is used, all sequencer state transitions must be programmed with a valid event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10502,6 +13950,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcseqrstevr {
                 Trcseqrstevr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcseqrstevr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcseqrstevr")
+                    .field("event", &self.event())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcseqrstevr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcseqrstevr {
+                    event: u8,
+                }
+                let proxy = Trcseqrstevr {
+                    event: self.event(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Use this to set, or read, the sequencer state. Might ignore writes when the trace unit is enabled or not idle. Only returns stable data when TRCSTATR.PMSTABLE == 1. When the sequencer is used, all sequencer state transitions must be programmed with a valid event."]
@@ -10527,6 +13995,26 @@ pub mod etm {
                 Trcseqstr(0)
             }
         }
+        impl core::fmt::Debug for Trcseqstr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcseqstr")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcseqstr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcseqstr {
+                    state: super::vals::State,
+                }
+                let proxy = Trcseqstr {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the single-shot comparator."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10548,6 +14036,24 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcssccr0 {
                 Trcssccr0(0)
+            }
+        }
+        impl core::fmt::Debug for Trcssccr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcssccr0")
+                    .field("rst", &self.rst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcssccr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcssccr0 {
+                    rst: bool,
+                }
+                let proxy = Trcssccr0 { rst: self.rst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the status of the single-shot comparators. TRCSSCSR0 is sensitive toinstruction addresses."]
@@ -10617,6 +14123,38 @@ pub mod etm {
                 Trcsscsr0(0)
             }
         }
+        impl core::fmt::Debug for Trcsscsr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcsscsr0")
+                    .field("inst", &self.inst())
+                    .field("da", &self.da())
+                    .field("dv", &self.dv())
+                    .field("pc", &self.pc())
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcsscsr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcsscsr0 {
+                    inst: bool,
+                    da: bool,
+                    dv: bool,
+                    pc: bool,
+                    status: bool,
+                }
+                let proxy = Trcsscsr0 {
+                    inst: self.inst(),
+                    da: self.da(),
+                    dv: self.dv(),
+                    pc: self.pc(),
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Selects the processor comparator inputs for Single-shot control."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10671,6 +14209,35 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcsspcicr0 {
                 Trcsspcicr0(0)
+            }
+        }
+        impl core::fmt::Debug for Trcsspcicr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcsspcicr0")
+                    .field("pc_0", &self.pc_0())
+                    .field("pc_1", &self.pc_1())
+                    .field("pc_2", &self.pc_2())
+                    .field("pc_3", &self.pc_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcsspcicr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcsspcicr0 {
+                    pc_0: bool,
+                    pc_1: bool,
+                    pc_2: bool,
+                    pc_3: bool,
+                }
+                let proxy = Trcsspcicr0 {
+                    pc_0: self.pc_0(),
+                    pc_1: self.pc_1(),
+                    pc_2: self.pc_2(),
+                    pc_3: self.pc_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enables trace unit functionality that prevents trace unit buffer overflows. Might ignore writes when the trace unit is enabled or not idle. Must be programmed if TRCIDR3.STALLCTL == 1."]
@@ -10762,6 +14329,44 @@ pub mod etm {
                 Trcstallctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcstallctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcstallctlr")
+                    .field("level", &self.level())
+                    .field("istall", &self.istall())
+                    .field("dstall", &self.dstall())
+                    .field("instpriority", &self.instpriority())
+                    .field("datadiscardload", &self.datadiscardload())
+                    .field("datadiscardstore", &self.datadiscardstore())
+                    .field("nooverflow", &self.nooverflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcstallctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcstallctlr {
+                    level: super::vals::Level,
+                    istall: bool,
+                    dstall: bool,
+                    instpriority: bool,
+                    datadiscardload: bool,
+                    datadiscardstore: bool,
+                    nooverflow: bool,
+                }
+                let proxy = Trcstallctlr {
+                    level: self.level(),
+                    istall: self.istall(),
+                    dstall: self.dstall(),
+                    instpriority: self.instpriority(),
+                    datadiscardload: self.datadiscardload(),
+                    datadiscardstore: self.datadiscardstore(),
+                    nooverflow: self.nooverflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Idle status bit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10796,6 +14401,29 @@ pub mod etm {
                 Trcstatr(0)
             }
         }
+        impl core::fmt::Debug for Trcstatr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcstatr")
+                    .field("idle", &self.idle())
+                    .field("pmstable", &self.pmstable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcstatr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcstatr {
+                    idle: bool,
+                    pmstable: bool,
+                }
+                let proxy = Trcstatr {
+                    idle: self.idle(),
+                    pmstable: self.pmstable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls how often trace synchronization requests occur. Might ignore writes when the trace unit is enabled or not idle. If writes are permitted then the register must be programmed."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10817,6 +14445,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcsyncpr {
                 Trcsyncpr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcsyncpr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcsyncpr")
+                    .field("period", &self.period())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcsyncpr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcsyncpr {
+                    period: super::vals::Period,
+                }
+                let proxy = Trcsyncpr {
+                    period: self.period(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sets the trace ID for instruction trace. If data trace is enabled then it also sets the trace ID for data trace, to (trace ID for instruction trace) + 1. This register must always be programmed as part of trace unit initialization. Might ignore writes when the trace unit is enabled or not idle."]
@@ -10842,6 +14490,26 @@ pub mod etm {
                 Trctraceidr(0)
             }
         }
+        impl core::fmt::Debug for Trctraceidr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trctraceidr")
+                    .field("traceid", &self.traceid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trctraceidr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trctraceidr {
+                    traceid: u8,
+                }
+                let proxy = Trctraceidr {
+                    traceid: self.traceid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls the insertion of global timestamps in the trace streams. When the selected event is triggered, the trace unit inserts a global timestamp into the trace streams. Might ignore writes when the trace unit is enabled or not idle. Must be programmed if TRCCONFIGR.TS == 1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10863,6 +14531,26 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trctsctlr {
                 Trctsctlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trctsctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trctsctlr")
+                    .field("event", &self.event())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trctsctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trctsctlr {
+                    event: u8,
+                }
+                let proxy = Trctsctlr {
+                    event: self.event(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "ViewData include / exclude control. Might ignore writes when the trace unit is enabled or not idle. This register must be programmed when one or more address comparators are implemented."]
@@ -11053,6 +14741,71 @@ pub mod etm {
                 Trcvdarcctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcvdarcctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvdarcctlr")
+                    .field("include_0", &self.include_0())
+                    .field("include_1", &self.include_1())
+                    .field("include_2", &self.include_2())
+                    .field("include_3", &self.include_3())
+                    .field("include_4", &self.include_4())
+                    .field("include_5", &self.include_5())
+                    .field("include_6", &self.include_6())
+                    .field("include_7", &self.include_7())
+                    .field("exclude_0", &self.exclude_0())
+                    .field("exclude_1", &self.exclude_1())
+                    .field("exclude_2", &self.exclude_2())
+                    .field("exclude_3", &self.exclude_3())
+                    .field("exclude_4", &self.exclude_4())
+                    .field("exclude_5", &self.exclude_5())
+                    .field("exclude_6", &self.exclude_6())
+                    .field("exclude_7", &self.exclude_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvdarcctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvdarcctlr {
+                    include_0: bool,
+                    include_1: bool,
+                    include_2: bool,
+                    include_3: bool,
+                    include_4: bool,
+                    include_5: bool,
+                    include_6: bool,
+                    include_7: bool,
+                    exclude_0: bool,
+                    exclude_1: bool,
+                    exclude_2: bool,
+                    exclude_3: bool,
+                    exclude_4: bool,
+                    exclude_5: bool,
+                    exclude_6: bool,
+                    exclude_7: bool,
+                }
+                let proxy = Trcvdarcctlr {
+                    include_0: self.include_0(),
+                    include_1: self.include_1(),
+                    include_2: self.include_2(),
+                    include_3: self.include_3(),
+                    include_4: self.include_4(),
+                    include_5: self.include_5(),
+                    include_6: self.include_6(),
+                    include_7: self.include_7(),
+                    exclude_0: self.exclude_0(),
+                    exclude_1: self.exclude_1(),
+                    exclude_2: self.exclude_2(),
+                    exclude_3: self.exclude_3(),
+                    exclude_4: self.exclude_4(),
+                    exclude_5: self.exclude_5(),
+                    exclude_6: self.exclude_6(),
+                    exclude_7: self.exclude_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls data trace filtering. Might ignore writes when the trace unit is enabled or not idle. This register must be programmed when data tracing is enabled, that is, when either TRCCONFIGR.DA == 1 or TRCCONFIGR.DV == 1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11197,6 +14950,59 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcvdctlr {
                 Trcvdctlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcvdctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvdctlr")
+                    .field("event_0", &self.event_0())
+                    .field("event_1", &self.event_1())
+                    .field("event_2", &self.event_2())
+                    .field("event_3", &self.event_3())
+                    .field("event_4", &self.event_4())
+                    .field("event_5", &self.event_5())
+                    .field("event_6", &self.event_6())
+                    .field("event_7", &self.event_7())
+                    .field("sprel", &self.sprel())
+                    .field("pcrel", &self.pcrel())
+                    .field("tbi", &self.tbi())
+                    .field("trcexdata", &self.trcexdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvdctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvdctlr {
+                    event_0: bool,
+                    event_1: bool,
+                    event_2: bool,
+                    event_3: bool,
+                    event_4: bool,
+                    event_5: bool,
+                    event_6: bool,
+                    event_7: bool,
+                    sprel: super::vals::Sprel,
+                    pcrel: super::vals::Pcrel,
+                    tbi: super::vals::Tbi,
+                    trcexdata: bool,
+                }
+                let proxy = Trcvdctlr {
+                    event_0: self.event_0(),
+                    event_1: self.event_1(),
+                    event_2: self.event_2(),
+                    event_3: self.event_3(),
+                    event_4: self.event_4(),
+                    event_5: self.event_5(),
+                    event_6: self.event_6(),
+                    event_7: self.event_7(),
+                    sprel: self.sprel(),
+                    pcrel: self.pcrel(),
+                    tbi: self.tbi(),
+                    trcexdata: self.trcexdata(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "ViewData include / exclude control. Might ignore writes when the trace unit is enabled or not idle. This register must be programmed when one or more address comparators are implemented."]
@@ -11387,6 +15193,71 @@ pub mod etm {
                 Trcvdsacctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcvdsacctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvdsacctlr")
+                    .field("include_0", &self.include_0())
+                    .field("include_1", &self.include_1())
+                    .field("include_2", &self.include_2())
+                    .field("include_3", &self.include_3())
+                    .field("include_4", &self.include_4())
+                    .field("include_5", &self.include_5())
+                    .field("include_6", &self.include_6())
+                    .field("include_7", &self.include_7())
+                    .field("exclude_0", &self.exclude_0())
+                    .field("exclude_1", &self.exclude_1())
+                    .field("exclude_2", &self.exclude_2())
+                    .field("exclude_3", &self.exclude_3())
+                    .field("exclude_4", &self.exclude_4())
+                    .field("exclude_5", &self.exclude_5())
+                    .field("exclude_6", &self.exclude_6())
+                    .field("exclude_7", &self.exclude_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvdsacctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvdsacctlr {
+                    include_0: bool,
+                    include_1: bool,
+                    include_2: bool,
+                    include_3: bool,
+                    include_4: bool,
+                    include_5: bool,
+                    include_6: bool,
+                    include_7: bool,
+                    exclude_0: bool,
+                    exclude_1: bool,
+                    exclude_2: bool,
+                    exclude_3: bool,
+                    exclude_4: bool,
+                    exclude_5: bool,
+                    exclude_6: bool,
+                    exclude_7: bool,
+                }
+                let proxy = Trcvdsacctlr {
+                    include_0: self.include_0(),
+                    include_1: self.include_1(),
+                    include_2: self.include_2(),
+                    include_3: self.include_3(),
+                    include_4: self.include_4(),
+                    include_5: self.include_5(),
+                    include_6: self.include_6(),
+                    include_7: self.include_7(),
+                    exclude_0: self.exclude_0(),
+                    exclude_1: self.exclude_1(),
+                    exclude_2: self.exclude_2(),
+                    exclude_3: self.exclude_3(),
+                    exclude_4: self.exclude_4(),
+                    exclude_5: self.exclude_5(),
+                    exclude_6: self.exclude_6(),
+                    exclude_7: self.exclude_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Controls instruction trace filtering. Might ignore writes when the trace unit is enabled or not idle. Only returns stable data when TRCSTATR.PMSTABLE == 1. Must be programmed, particularly to set the value of the SSSTATUS bit, which sets the state of the start/stop logic."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11537,6 +15408,59 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcvictlr {
                 Trcvictlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcvictlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvictlr")
+                    .field("event_sel", &self.event_sel())
+                    .field("ssstatus", &self.ssstatus())
+                    .field("trcreset", &self.trcreset())
+                    .field("trcerr", &self.trcerr())
+                    .field("exlevel0_s", &self.exlevel0_s())
+                    .field("exlevel1_s", &self.exlevel1_s())
+                    .field("exlevel2_s", &self.exlevel2_s())
+                    .field("exlevel3_s", &self.exlevel3_s())
+                    .field("exlevel0_ns", &self.exlevel0_ns())
+                    .field("exlevel1_ns", &self.exlevel1_ns())
+                    .field("exlevel2_ns", &self.exlevel2_ns())
+                    .field("exlevel3_ns", &self.exlevel3_ns())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvictlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvictlr {
+                    event_sel: super::vals::EventSel,
+                    ssstatus: super::vals::Ssstatus,
+                    trcreset: bool,
+                    trcerr: bool,
+                    exlevel0_s: super::vals::Exlevel0S,
+                    exlevel1_s: super::vals::Exlevel1S,
+                    exlevel2_s: super::vals::Exlevel2S,
+                    exlevel3_s: super::vals::Exlevel3S,
+                    exlevel0_ns: super::vals::Exlevel0Ns,
+                    exlevel1_ns: super::vals::Exlevel1Ns,
+                    exlevel2_ns: super::vals::Exlevel2Ns,
+                    exlevel3_ns: super::vals::Exlevel3Ns,
+                }
+                let proxy = Trcvictlr {
+                    event_sel: self.event_sel(),
+                    ssstatus: self.ssstatus(),
+                    trcreset: self.trcreset(),
+                    trcerr: self.trcerr(),
+                    exlevel0_s: self.exlevel0_s(),
+                    exlevel1_s: self.exlevel1_s(),
+                    exlevel2_s: self.exlevel2_s(),
+                    exlevel3_s: self.exlevel3_s(),
+                    exlevel0_ns: self.exlevel0_ns(),
+                    exlevel1_ns: self.exlevel1_ns(),
+                    exlevel2_ns: self.exlevel2_ns(),
+                    exlevel3_ns: self.exlevel3_ns(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "ViewInst exclude control. Might ignore writes when the trace unit is enabled or not idle. This register must be programmed when one or more address comparators are implemented."]
@@ -11727,6 +15651,71 @@ pub mod etm {
                 Trcviiectlr(0)
             }
         }
+        impl core::fmt::Debug for Trcviiectlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcviiectlr")
+                    .field("include_0", &self.include_0())
+                    .field("include_1", &self.include_1())
+                    .field("include_2", &self.include_2())
+                    .field("include_3", &self.include_3())
+                    .field("include_4", &self.include_4())
+                    .field("include_5", &self.include_5())
+                    .field("include_6", &self.include_6())
+                    .field("include_7", &self.include_7())
+                    .field("exclude_0", &self.exclude_0())
+                    .field("exclude_1", &self.exclude_1())
+                    .field("exclude_2", &self.exclude_2())
+                    .field("exclude_3", &self.exclude_3())
+                    .field("exclude_4", &self.exclude_4())
+                    .field("exclude_5", &self.exclude_5())
+                    .field("exclude_6", &self.exclude_6())
+                    .field("exclude_7", &self.exclude_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcviiectlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcviiectlr {
+                    include_0: bool,
+                    include_1: bool,
+                    include_2: bool,
+                    include_3: bool,
+                    include_4: bool,
+                    include_5: bool,
+                    include_6: bool,
+                    include_7: bool,
+                    exclude_0: bool,
+                    exclude_1: bool,
+                    exclude_2: bool,
+                    exclude_3: bool,
+                    exclude_4: bool,
+                    exclude_5: bool,
+                    exclude_6: bool,
+                    exclude_7: bool,
+                }
+                let proxy = Trcviiectlr {
+                    include_0: self.include_0(),
+                    include_1: self.include_1(),
+                    include_2: self.include_2(),
+                    include_3: self.include_3(),
+                    include_4: self.include_4(),
+                    include_5: self.include_5(),
+                    include_6: self.include_6(),
+                    include_7: self.include_7(),
+                    exclude_0: self.exclude_0(),
+                    exclude_1: self.exclude_1(),
+                    exclude_2: self.exclude_2(),
+                    exclude_3: self.exclude_3(),
+                    exclude_4: self.exclude_4(),
+                    exclude_5: self.exclude_5(),
+                    exclude_6: self.exclude_6(),
+                    exclude_7: self.exclude_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Use this to set, or read, which PE comparator inputs can control the ViewInst start/stop logic. Might ignore writes when the trace unit is enabled or not idle. If implemented then this register must be programmed."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11913,6 +15902,71 @@ pub mod etm {
             #[inline(always)]
             fn default() -> Trcvipcssctlr {
                 Trcvipcssctlr(0)
+            }
+        }
+        impl core::fmt::Debug for Trcvipcssctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvipcssctlr")
+                    .field("start_0", &self.start_0())
+                    .field("start_1", &self.start_1())
+                    .field("start_2", &self.start_2())
+                    .field("start_3", &self.start_3())
+                    .field("start_4", &self.start_4())
+                    .field("start_5", &self.start_5())
+                    .field("start_6", &self.start_6())
+                    .field("start_7", &self.start_7())
+                    .field("stop_0", &self.stop_0())
+                    .field("stop_1", &self.stop_1())
+                    .field("stop_2", &self.stop_2())
+                    .field("stop_3", &self.stop_3())
+                    .field("stop_4", &self.stop_4())
+                    .field("stop_5", &self.stop_5())
+                    .field("stop_6", &self.stop_6())
+                    .field("stop_7", &self.stop_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvipcssctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvipcssctlr {
+                    start_0: bool,
+                    start_1: bool,
+                    start_2: bool,
+                    start_3: bool,
+                    start_4: bool,
+                    start_5: bool,
+                    start_6: bool,
+                    start_7: bool,
+                    stop_0: bool,
+                    stop_1: bool,
+                    stop_2: bool,
+                    stop_3: bool,
+                    stop_4: bool,
+                    stop_5: bool,
+                    stop_6: bool,
+                    stop_7: bool,
+                }
+                let proxy = Trcvipcssctlr {
+                    start_0: self.start_0(),
+                    start_1: self.start_1(),
+                    start_2: self.start_2(),
+                    start_3: self.start_3(),
+                    start_4: self.start_4(),
+                    start_5: self.start_5(),
+                    start_6: self.start_6(),
+                    start_7: self.start_7(),
+                    stop_0: self.stop_0(),
+                    stop_1: self.stop_1(),
+                    stop_2: self.stop_2(),
+                    stop_3: self.stop_3(),
+                    stop_4: self.stop_4(),
+                    stop_5: self.stop_5(),
+                    stop_6: self.stop_6(),
+                    stop_7: self.stop_7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Use this to set, or read, the single address comparators that control the ViewInst start/stop logic. The start/stop logic is active for an instruction which causes a start and remains active up to and including an instruction which causes a stop, and then the start/stop logic becomes inactive. Might ignore writes when the trace unit is enabled or not idle. If implemented then this register must be programmed."]
@@ -12103,6 +16157,71 @@ pub mod etm {
                 Trcvissctlr(0)
             }
         }
+        impl core::fmt::Debug for Trcvissctlr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Trcvissctlr")
+                    .field("start_0", &self.start_0())
+                    .field("start_1", &self.start_1())
+                    .field("start_2", &self.start_2())
+                    .field("start_3", &self.start_3())
+                    .field("start_4", &self.start_4())
+                    .field("start_5", &self.start_5())
+                    .field("start_6", &self.start_6())
+                    .field("start_7", &self.start_7())
+                    .field("stop_0", &self.stop_0())
+                    .field("stop_1", &self.stop_1())
+                    .field("stop_2", &self.stop_2())
+                    .field("stop_3", &self.stop_3())
+                    .field("stop_4", &self.stop_4())
+                    .field("stop_5", &self.stop_5())
+                    .field("stop_6", &self.stop_6())
+                    .field("stop_7", &self.stop_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Trcvissctlr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Trcvissctlr {
+                    start_0: bool,
+                    start_1: bool,
+                    start_2: bool,
+                    start_3: bool,
+                    start_4: bool,
+                    start_5: bool,
+                    start_6: bool,
+                    start_7: bool,
+                    stop_0: bool,
+                    stop_1: bool,
+                    stop_2: bool,
+                    stop_3: bool,
+                    stop_4: bool,
+                    stop_5: bool,
+                    stop_6: bool,
+                    stop_7: bool,
+                }
+                let proxy = Trcvissctlr {
+                    start_0: self.start_0(),
+                    start_1: self.start_1(),
+                    start_2: self.start_2(),
+                    start_3: self.start_3(),
+                    start_4: self.start_4(),
+                    start_5: self.start_5(),
+                    start_6: self.start_6(),
+                    start_7: self.start_7(),
+                    stop_0: self.stop_0(),
+                    stop_1: self.stop_1(),
+                    stop_2: self.stop_2(),
+                    stop_3: self.stop_3(),
+                    stop_4: self.stop_4(),
+                    stop_5: self.stop_5(),
+                    stop_6: self.stop_6(),
+                    stop_7: self.stop_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -12118,6 +16237,23 @@ pub mod etm {
             }
             pub const fn to_bits(self) -> u16 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Archid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4a13 => f.write_str("ETMV42"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Archid {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4a13 => defmt::write!(f, "ETMV42"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u16> for Archid {
@@ -12147,6 +16283,23 @@ pub mod etm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Architect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x023b => f.write_str("ARM"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Architect {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x023b => defmt::write!(f, "ARM"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Architect {
             #[inline(always)]
             fn from(val: u16) -> Architect {
@@ -12160,7 +16313,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clr0 {
             #[doc = "Claim tag 0 is not set."]
             NOT_SET = 0x0,
@@ -12190,7 +16344,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clr1 {
             #[doc = "Claim tag 1 is not set."]
             NOT_SET = 0x0,
@@ -12220,7 +16375,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clr2 {
             #[doc = "Claim tag 2 is not set."]
             NOT_SET = 0x0,
@@ -12250,7 +16406,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clr3 {
             #[doc = "Claim tag 3 is not set."]
             NOT_SET = 0x0,
@@ -12280,7 +16437,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cond {
             #[doc = "Conditional instruction tracing is disabled."]
             DISABLED = 0x0,
@@ -12335,6 +16493,25 @@ pub mod etm {
                 self.0
             }
         }
+        impl core::fmt::Debug for EventSel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    0x01 => f.write_str("ENABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EventSel {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    0x01 => defmt::write!(f, "ENABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for EventSel {
             #[inline(always)]
             fn from(val: u8) -> EventSel {
@@ -12348,7 +16525,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel0Ns {
             #[doc = "The trace unit generates instruction trace, in Non-secure state, for Exception level 0."]
             ENABLED = 0x0,
@@ -12378,7 +16556,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel0S {
             #[doc = "The trace unit generates instruction trace, in Secure state, for Exception level 0."]
             ENABLED = 0x0,
@@ -12408,7 +16587,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel1Ns {
             #[doc = "The trace unit generates instruction trace, in Non-secure state, for Exception level 1."]
             ENABLED = 0x0,
@@ -12438,7 +16618,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel1S {
             #[doc = "The trace unit generates instruction trace, in Secure state, for Exception level 1."]
             ENABLED = 0x0,
@@ -12468,7 +16649,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel2Ns {
             #[doc = "The trace unit generates instruction trace, in Non-secure state, for Exception level 2."]
             ENABLED = 0x0,
@@ -12498,7 +16680,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel2S {
             #[doc = "The trace unit generates instruction trace, in Secure state, for Exception level 2."]
             ENABLED = 0x0,
@@ -12528,7 +16711,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel3Ns {
             #[doc = "The trace unit generates instruction trace, in Non-secure state, for Exception level 3."]
             ENABLED = 0x0,
@@ -12558,7 +16742,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Exlevel3S {
             #[doc = "The trace unit generates instruction trace, in Secure state, for Exception level 3."]
             ENABLED = 0x0,
@@ -12588,7 +16773,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Level {
             #[doc = "Zero invasion. This setting has a greater risk of a FIFO overflow"]
             MIN = 0x0,
@@ -12632,7 +16818,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Major {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -12675,7 +16862,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Exclude mode. The address range comparators selected by the RANGE field indicate address ranges where the trace unit cannot generate Q elements. If no ranges are selected, Q elements are permitted across the entire memory map."]
             EXCLUDE = 0x0,
@@ -12705,7 +16893,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nsid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -12737,7 +16926,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nsnid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -12769,7 +16959,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pcrel {
             #[doc = "The trace unit does not affect the tracing of PC-relative transfers."]
             ENABLED = 0x0,
@@ -12813,6 +17004,23 @@ pub mod etm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Period {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Period {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Period {
             #[inline(always)]
             fn from(val: u8) -> Period {
@@ -12826,7 +17034,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "The register is not implemented."]
             ABSENT = 0x0,
@@ -12856,7 +17065,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Qe {
             #[doc = "Q elements are disabled."]
             DISABLED = 0x0,
@@ -12889,7 +17099,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Revision {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -12932,7 +17143,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Set0 {
             #[doc = "Claim tag 0 is not set."]
             NOT_SET = 0x0,
@@ -12962,7 +17174,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Set1 {
             #[doc = "Claim tag 1 is not set."]
             NOT_SET = 0x0,
@@ -12992,7 +17205,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Set2 {
             #[doc = "Claim tag 2 is not set."]
             NOT_SET = 0x0,
@@ -13022,7 +17236,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Set3 {
             #[doc = "Claim tag 3 is not set."]
             NOT_SET = 0x0,
@@ -13052,7 +17267,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -13084,7 +17300,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Snid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -13116,7 +17333,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sprel {
             #[doc = "The trace unit does not affect the tracing of SP-relative transfers."]
             ENABLED = 0x0,
@@ -13149,7 +17367,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ssstatus {
             #[doc = "The start/stop logic is in the stopped state."]
             STOPPED = 0x0,
@@ -13179,7 +17398,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "The sequencer is in state 0."]
             STATE0 = 0x0,
@@ -13213,7 +17433,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sub {
             _RESERVED_0 = 0x0,
             #[doc = "Peripheral is a processor trace source."]
@@ -13256,7 +17477,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tbi {
             #[doc = "The trace unit assigns bits\\[63:56\\] to have the same value as bit\\[55\\] of the data address, that is, it sign-extends the value."]
             SIGN_EXTEND = 0x0,
@@ -13286,7 +17508,8 @@ pub mod etm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Vmidopt {
             #[doc = "VTTBR_EL2.VMID is used. If the trace unit supports a Virtual context identifier larger than the VTTBR_EL2.VMID, the upper unused bits are always zero. If the trace unit supports a Virtual context identifier larger than 8 bits and if the VTCR_EL2.VS bit forces use of an 8-bit Virtual context identifier, bits \\[15:8\\] of the trace unit Virtual context identifier are always zero."]
             VTTBR_EL2 = 0x0,
@@ -13533,6 +17756,24 @@ pub mod ficr {
                 Configid(0)
             }
         }
+        impl core::fmt::Debug for Configid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configid")
+                    .field("hwid", &self.hwid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configid {
+                    hwid: u16,
+                }
+                let proxy = Configid { hwid: self.hwid() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13554,6 +17795,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Package option"]
@@ -13580,6 +17841,26 @@ pub mod ficr {
                 Package(0)
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part code"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13602,6 +17883,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Part {
                 Part(0)
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM size (KB)"]
@@ -13628,6 +17925,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RRAM size (KB)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13650,6 +17963,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Rram {
                 Rram(0)
+            }
+        }
+        impl core::fmt::Debug for Rram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rram").field("rram", &self.rram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rram {
+                    rram: super::vals::Rram,
+                }
+                let proxy = Rram { rram: self.rram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -13708,6 +18037,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13762,6 +18120,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -13820,6 +18207,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13876,6 +18292,35 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part Variant, Hardware version and Production configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13898,6 +18343,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Variant {
                 Variant(0)
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "XOSC32K capacitor selection trim values"]
@@ -13934,6 +18399,29 @@ pub mod ficr {
                 Xosc32ktrim(0)
             }
         }
+        impl core::fmt::Debug for Xosc32ktrim {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32ktrim")
+                    .field("slope", &self.slope())
+                    .field("offset", &self.offset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32ktrim {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32ktrim {
+                    slope: u16,
+                    offset: u16,
+                }
+                let proxy = Xosc32ktrim {
+                    slope: self.slope(),
+                    offset: self.offset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "XOSC32M capacitor selection trim values"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13968,10 +18456,34 @@ pub mod ficr {
                 Xosc32mtrim(0)
             }
         }
+        impl core::fmt::Debug for Xosc32mtrim {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32mtrim")
+                    .field("slope", &self.slope())
+                    .field("offset", &self.offset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32mtrim {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32mtrim {
+                    slope: u16,
+                    offset: u16,
+                }
+                let proxy = Xosc32mtrim {
+                    slope: self.slope(),
+                    offset: self.offset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -14015,6 +18527,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -14042,6 +18571,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_4b15 => f.write_str("N54L15"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_4b15 => defmt::write!(f, "N54L15"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Part {
@@ -14073,6 +18621,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -14102,6 +18669,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x05f4 => f.write_str("K1524"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x05f4 => defmt::write!(f, "K1524"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rram {
             #[inline(always)]
             fn from(val: u32) -> Rram {
@@ -14127,6 +18713,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -14201,10 +18804,34 @@ pub mod glitchdet {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("enable", &self.enable())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    enable: bool,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Config {
+                    enable: self.enable(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "High pass filter mode"]
             HIGH_PASS_FILTER = 0x0,
@@ -14331,6 +18958,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14356,6 +19003,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -14385,6 +19121,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14410,6 +19235,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -14439,6 +19353,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14464,6 +19467,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -14493,6 +19585,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14520,6 +19701,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14545,6 +19815,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Pin n configuration of GPIO pin"]
@@ -14639,10 +19998,49 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive0", &self.drive0())
+                    .field("drive1", &self.drive1())
+                    .field("sense", &self.sense())
+                    .field("ctrlsel", &self.ctrlsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive0: super::vals::Drive,
+                    drive1: super::vals::Drive,
+                    sense: super::vals::Sense,
+                    ctrlsel: super::vals::Ctrlsel,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive0: self.drive0(),
+                    drive1: self.drive1(),
+                    sense: self.sense(),
+                    ctrlsel: self.ctrlsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctrlsel {
             #[doc = "GPIO or peripherals with PSEL registers"]
             GPIO = 0x0,
@@ -14679,7 +20077,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -14709,7 +20108,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -14739,7 +20139,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0'"]
             S = 0x0,
@@ -14773,7 +20174,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -14803,7 +20205,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -14836,7 +20239,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -15106,6 +20510,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15155,10 +20591,58 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port0nonsecure", &self.port0nonsecure())
+                    .field("port0secure", &self.port0secure())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port0nonsecure: bool,
+                    port0secure: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port0nonsecure: self.port0nonsecure(),
+                    port0secure: self.port0secure(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -15191,7 +20675,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -15221,7 +20706,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -15523,6 +21009,26 @@ pub mod grtc {
                 Active(0)
             }
         }
+        impl core::fmt::Debug for Active {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Active")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Active {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Active {
+                    active: bool,
+                }
+                let proxy = Active {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Count to add to CC\\[n\\] when this register is written."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15559,6 +21065,29 @@ pub mod grtc {
                 Ccadd(0)
             }
         }
+        impl core::fmt::Debug for Ccadd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccadd")
+                    .field("value", &self.value())
+                    .field("reference", &self.reference())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccadd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccadd {
+                    value: u32,
+                    reference: super::vals::Reference,
+                }
+                let proxy = Ccadd {
+                    value: self.value(),
+                    reference: self.reference(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Configure Capture/Compare register CC\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15580,6 +21109,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Ccen {
                 Ccen(0)
+            }
+        }
+        impl core::fmt::Debug for Ccen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccen")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccen {
+                    active: bool,
+                }
+                let proxy = Ccen {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: The higher 32-bits of Capture/Compare register CC\\[n\\]"]
@@ -15604,6 +21153,22 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Cch {
                 Cch(0)
+            }
+        }
+        impl core::fmt::Debug for Cch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cch").field("cch", &self.cch()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cch {
+                    cch: u32,
+                }
+                let proxy = Cch { cch: self.cch() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock Configuration"]
@@ -15641,6 +21206,29 @@ pub mod grtc {
                 Clkcfg(0)
             }
         }
+        impl core::fmt::Debug for Clkcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkcfg")
+                    .field("clkfastdiv", &self.clkfastdiv())
+                    .field("clksel", &self.clksel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkcfg {
+                    clkfastdiv: u8,
+                    clksel: super::vals::Clksel,
+                }
+                let proxy = Clkcfg {
+                    clkfastdiv: self.clkfastdiv(),
+                    clksel: self.clksel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of clock output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15675,6 +21263,29 @@ pub mod grtc {
                 Clkout(0)
             }
         }
+        impl core::fmt::Debug for Clkout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkout")
+                    .field("clkout32k", &self.clkout32k())
+                    .field("clkoutfast", &self.clkoutfast())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkout {
+                    clkout32k: bool,
+                    clkoutfast: bool,
+                }
+                let proxy = Clkout {
+                    clkout32k: self.clkout32k(),
+                    clkoutfast: self.clkoutfast(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable event routing"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15696,6 +21307,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Evt {
                 Evt(0)
+            }
+        }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    pwmperiodend: bool,
+                }
+                let proxy = Evt {
+                    pwmperiodend: self.pwmperiodend(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15864,6 +21495,65 @@ pub mod grtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("compare0", &self.compare0())
+                    .field("compare1", &self.compare1())
+                    .field("compare2", &self.compare2())
+                    .field("compare3", &self.compare3())
+                    .field("compare4", &self.compare4())
+                    .field("compare5", &self.compare5())
+                    .field("compare6", &self.compare6())
+                    .field("compare7", &self.compare7())
+                    .field("compare8", &self.compare8())
+                    .field("compare9", &self.compare9())
+                    .field("compare10", &self.compare10())
+                    .field("compare11", &self.compare11())
+                    .field("rtcomparesync", &self.rtcomparesync())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare0: bool,
+                    compare1: bool,
+                    compare2: bool,
+                    compare3: bool,
+                    compare4: bool,
+                    compare5: bool,
+                    compare6: bool,
+                    compare7: bool,
+                    compare8: bool,
+                    compare9: bool,
+                    compare10: bool,
+                    compare11: bool,
+                    rtcomparesync: bool,
+                    pwmperiodend: bool,
+                }
+                let proxy = Int {
+                    compare0: self.compare0(),
+                    compare1: self.compare1(),
+                    compare2: self.compare2(),
+                    compare3: self.compare3(),
+                    compare4: self.compare4(),
+                    compare5: self.compare5(),
+                    compare6: self.compare6(),
+                    compare7: self.compare7(),
+                    compare8: self.compare8(),
+                    compare9: self.compare9(),
+                    compare10: self.compare10(),
+                    compare11: self.compare11(),
+                    rtcomparesync: self.rtcomparesync(),
+                    pwmperiodend: self.pwmperiodend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Count to add to CC\\[0\\] when the event EVENTS_COMPARE\\[0\\] triggers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15885,6 +21575,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Interval {
                 Interval(0)
+            }
+        }
+        impl core::fmt::Debug for Interval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Interval")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Interval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Interval {
+                    value: u16,
+                }
+                let proxy = Interval {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Counter mode selection"]
@@ -15921,6 +21631,29 @@ pub mod grtc {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("autoen", &self.autoen())
+                    .field("syscounteren", &self.syscounteren())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    autoen: super::vals::Autoen,
+                    syscounteren: bool,
+                }
+                let proxy = Mode {
+                    autoen: self.autoen(),
+                    syscounteren: self.syscounteren(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15944,6 +21677,26 @@ pub mod grtc {
                 Pwmconfig(0)
             }
         }
+        impl core::fmt::Debug for Pwmconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pwmconfig")
+                    .field("comparevalue", &self.comparevalue())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pwmconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pwmconfig {
+                    comparevalue: u8,
+                }
+                let proxy = Pwmconfig {
+                    comparevalue: self.comparevalue(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15965,6 +21718,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("rtcompare_clear", &self.rtcompare_clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    rtcompare_clear: bool,
+                }
+                let proxy = Shorts {
+                    rtcompare_clear: self.rtcompare_clear(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: The higher 20-bits of the SYSCOUNTER for index \\[n\\]"]
@@ -16014,6 +21787,32 @@ pub mod grtc {
                 Syscounterh(0)
             }
         }
+        impl core::fmt::Debug for Syscounterh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syscounterh")
+                    .field("value", &self.value())
+                    .field("busy", &self.busy())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syscounterh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syscounterh {
+                    value: u32,
+                    busy: super::vals::Busy,
+                    overflow: bool,
+                }
+                let proxy = Syscounterh {
+                    value: self.value(),
+                    busy: self.busy(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timeout after all CPUs gone into sleep state to stop the SYSCOUNTER"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16035,6 +21834,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Timeout {
                 Timeout(0)
+            }
+        }
+        impl core::fmt::Debug for Timeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Timeout")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Timeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Timeout {
+                    value: u16,
+                }
+                let proxy = Timeout {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GRTC wake up time."]
@@ -16060,10 +21879,31 @@ pub mod grtc {
                 Waketime(0)
             }
         }
+        impl core::fmt::Debug for Waketime {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Waketime")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Waketime {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Waketime {
+                    value: u8,
+                }
+                let proxy = Waketime {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Autoen {
             #[doc = "Default configuration to keep the SYSCOUNTER active."]
             DEFAULT = 0x0,
@@ -16093,7 +21933,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Busy {
             #[doc = "SYSCOUNTER is ready for read"]
             READY = 0x0,
@@ -16123,7 +21964,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clksel {
             #[doc = "GRTC LFCLK clock source is LFXO"]
             LFXO = 0x0,
@@ -16156,7 +21998,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reference {
             #[doc = "Adds SYSCOUNTER value."]
             SYSCOUNTER = 0x0,
@@ -16562,6 +22405,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16583,6 +22446,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module"]
@@ -16608,6 +22491,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16629,6 +22532,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16687,6 +22610,35 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .field("framestart", &self.framestart())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                    framestart: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                    framestart: self.framestart(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16710,6 +22662,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16731,6 +22703,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I2S clock generator control"]
@@ -16757,6 +22749,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16778,6 +22790,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio"]
@@ -16803,6 +22831,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16824,6 +22872,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width"]
@@ -16849,6 +22913,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16868,6 +22952,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Terminateonbuserror {
                 Terminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmission (TX) enable"]
@@ -16893,10 +22997,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -16926,7 +23047,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -16959,7 +23081,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -17037,6 +23160,57 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    0x2800_0000 => f.write_str("_32MDIV6"),
+                    0x3000_0000 => f.write_str("_32MDIV5"),
+                    0x4000_0000 => f.write_str("_32MDIV4"),
+                    0x5000_0000 => f.write_str("_32MDIV3"),
+                    0x8000_0000 => f.write_str("_32MDIV2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    0x2800_0000 => defmt::write!(f, "_32MDIV6"),
+                    0x3000_0000 => defmt::write!(f, "_32MDIV5"),
+                    0x4000_0000 => defmt::write!(f, "_32MDIV4"),
+                    0x5000_0000 => defmt::write!(f, "_32MDIV3"),
+                    0x8000_0000 => defmt::write!(f, "_32MDIV2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -17050,7 +23224,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -17080,7 +23255,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -17131,7 +23307,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit sample."]
             _8BIT = 0x0,
@@ -17291,6 +23468,22 @@ pub mod kmu {
                 Keyslot(0)
             }
         }
+        impl core::fmt::Debug for Keyslot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Keyslot").field("id", &self.id()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Keyslot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Keyslot {
+                    id: u8,
+                }
+                let proxy = Keyslot { id: self.id() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "KMU status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17314,10 +23507,31 @@ pub mod kmu {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "KMU is ready for new operation"]
             READY = 0x0,
@@ -17534,6 +23748,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17555,6 +23789,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -17591,6 +23845,29 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Extrefsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17612,6 +23889,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: bool,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -17670,6 +23963,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17704,6 +24026,29 @@ pub mod lpcomp {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17727,6 +24072,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17748,6 +24113,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -17817,10 +24202,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -17853,7 +24271,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -17885,7 +24304,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -17943,7 +24363,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -18395,6 +24816,119 @@ pub mod memconf {
                 Control(0)
             }
         }
+        impl core::fmt::Debug for Control {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Control")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Control {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Control {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Control {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAM retention for RAM \\[n\\]."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18759,6 +25293,119 @@ pub mod memconf {
                 Ret(0)
             }
         }
+        impl core::fmt::Debug for Ret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ret")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ret {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Ret {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAM retention for the second bank in the RAM block"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19121,6 +25768,119 @@ pub mod memconf {
             #[inline(always)]
             fn default() -> Ret2 {
                 Ret2(0)
+            }
+        }
+        impl core::fmt::Debug for Ret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ret2")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ret2 {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Ret2 {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -19512,6 +26272,68 @@ pub mod mpc {
                 GlobalslaveMasterport(0)
             }
         }
+        impl core::fmt::Debug for GlobalslaveMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlobalslaveMasterport")
+                    .field("connection_0", &self.connection_0())
+                    .field("connection_1", &self.connection_1())
+                    .field("connection_2", &self.connection_2())
+                    .field("connection_3", &self.connection_3())
+                    .field("connection_4", &self.connection_4())
+                    .field("connection_5", &self.connection_5())
+                    .field("connection_6", &self.connection_6())
+                    .field("connection_7", &self.connection_7())
+                    .field("connection_8", &self.connection_8())
+                    .field("connection_9", &self.connection_9())
+                    .field("connection_10", &self.connection_10())
+                    .field("connection_11", &self.connection_11())
+                    .field("connection_12", &self.connection_12())
+                    .field("connection_13", &self.connection_13())
+                    .field("connection_14", &self.connection_14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlobalslaveMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlobalslaveMasterport {
+                    connection_0: bool,
+                    connection_1: bool,
+                    connection_2: bool,
+                    connection_3: bool,
+                    connection_4: bool,
+                    connection_5: bool,
+                    connection_6: bool,
+                    connection_7: bool,
+                    connection_8: bool,
+                    connection_9: bool,
+                    connection_10: bool,
+                    connection_11: bool,
+                    connection_12: bool,
+                    connection_13: bool,
+                    connection_14: bool,
+                }
+                let proxy = GlobalslaveMasterport {
+                    connection_0: self.connection_0(),
+                    connection_1: self.connection_1(),
+                    connection_2: self.connection_2(),
+                    connection_3: self.connection_3(),
+                    connection_4: self.connection_4(),
+                    connection_5: self.connection_5(),
+                    connection_6: self.connection_6(),
+                    connection_7: self.connection_7(),
+                    connection_8: self.connection_8(),
+                    connection_9: self.connection_9(),
+                    connection_10: self.connection_10(),
+                    connection_11: self.connection_11(),
+                    connection_12: self.connection_12(),
+                    connection_13: self.connection_13(),
+                    connection_14: self.connection_14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Access information for the transaction that triggered a memory access error. Register content won't be changed as long as MEMACCERR event is active."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19602,6 +26424,44 @@ pub mod mpc {
                 Info(0)
             }
         }
+        impl core::fmt::Debug for Info {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Info")
+                    .field("ownerid", &self.ownerid())
+                    .field("masterport", &self.masterport())
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("errorsource", &self.errorsource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Info {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Info {
+                    ownerid: u8,
+                    masterport: u8,
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    errorsource: super::vals::Errorsource,
+                }
+                let proxy = Info {
+                    ownerid: self.ownerid(),
+                    masterport: self.masterport(),
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    errorsource: self.errorsource(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19625,6 +26485,26 @@ pub mod mpc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("memaccerr", &self.memaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    memaccerr: bool,
+                }
+                let proxy = Int {
+                    memaccerr: self.memaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock global slave registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19646,6 +26526,22 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Lock {
                 Lock(0)
+            }
+        }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Override region n Configuration register"]
@@ -19702,6 +26598,35 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> OverrideConfig {
                 OverrideConfig(0)
+            }
+        }
+        impl core::fmt::Debug for OverrideConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("OverrideConfig")
+                    .field("slavenumber", &self.slavenumber())
+                    .field("lock", &self.lock())
+                    .field("enable", &self.enable())
+                    .field("securemask", &self.securemask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for OverrideConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct OverrideConfig {
+                    slavenumber: u8,
+                    lock: bool,
+                    enable: bool,
+                    securemask: bool,
+                }
+                let proxy = OverrideConfig {
+                    slavenumber: self.slavenumber(),
+                    lock: self.lock(),
+                    enable: self.enable(),
+                    securemask: self.securemask(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Override region n local master enable"]
@@ -19881,6 +26806,68 @@ pub mod mpc {
                 OverrideMasterport(0)
             }
         }
+        impl core::fmt::Debug for OverrideMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("OverrideMasterport")
+                    .field("enable0", &self.enable0())
+                    .field("enable1", &self.enable1())
+                    .field("enable2", &self.enable2())
+                    .field("enable3", &self.enable3())
+                    .field("enable4", &self.enable4())
+                    .field("enable5", &self.enable5())
+                    .field("enable6", &self.enable6())
+                    .field("enable7", &self.enable7())
+                    .field("enable8", &self.enable8())
+                    .field("enable9", &self.enable9())
+                    .field("enable10", &self.enable10())
+                    .field("enable11", &self.enable11())
+                    .field("enable12", &self.enable12())
+                    .field("enable13", &self.enable13())
+                    .field("enable14", &self.enable14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for OverrideMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct OverrideMasterport {
+                    enable0: bool,
+                    enable1: bool,
+                    enable2: bool,
+                    enable3: bool,
+                    enable4: bool,
+                    enable5: bool,
+                    enable6: bool,
+                    enable7: bool,
+                    enable8: bool,
+                    enable9: bool,
+                    enable10: bool,
+                    enable11: bool,
+                    enable12: bool,
+                    enable13: bool,
+                    enable14: bool,
+                }
+                let proxy = OverrideMasterport {
+                    enable0: self.enable0(),
+                    enable1: self.enable1(),
+                    enable2: self.enable2(),
+                    enable3: self.enable3(),
+                    enable4: self.enable4(),
+                    enable5: self.enable5(),
+                    enable6: self.enable6(),
+                    enable7: self.enable7(),
+                    enable8: self.enable8(),
+                    enable9: self.enable9(),
+                    enable10: self.enable10(),
+                    enable11: self.enable11(),
+                    enable12: self.enable12(),
+                    enable13: self.enable13(),
+                    enable14: self.enable14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Owner for override region"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19902,6 +26889,26 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Owner {
                 Owner(0)
+            }
+        }
+        impl core::fmt::Debug for Owner {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Owner")
+                    .field("ownerid", &self.ownerid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Owner {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Owner {
+                    ownerid: u8,
+                }
+                let proxy = Owner {
+                    ownerid: self.ownerid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Permission settings for override region n"]
@@ -19960,6 +26967,35 @@ pub mod mpc {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secattr: bool,
+                }
+                let proxy = Perm {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Masks permission setting fields from register OVERRIDE.PERM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20014,6 +27050,35 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Permmask {
                 Permmask(0)
+            }
+        }
+        impl core::fmt::Debug for Permmask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Permmask")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Permmask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Permmask {
+                    read: super::vals::PermmaskRead,
+                    write: super::vals::PermmaskWrite,
+                    execute: super::vals::PermmaskExecute,
+                    secattr: super::vals::PermmaskSecattr,
+                }
+                let proxy = Permmask {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Slave region n Configuration register"]
@@ -20114,6 +27179,47 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> RegionConfig {
                 RegionConfig(0)
+            }
+        }
+        impl core::fmt::Debug for RegionConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionConfig")
+                    .field("slavenumber", &self.slavenumber())
+                    .field("lock", &self.lock())
+                    .field("enable", &self.enable())
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .field("ownerid", &self.ownerid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionConfig {
+                    slavenumber: u8,
+                    lock: bool,
+                    enable: bool,
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secattr: bool,
+                    ownerid: u8,
+                }
+                let proxy = RegionConfig {
+                    slavenumber: self.slavenumber(),
+                    lock: self.lock(),
+                    enable: self.enable(),
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                    ownerid: self.ownerid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Region n local master enable"]
@@ -20293,10 +27399,73 @@ pub mod mpc {
                 RegionMasterport(0)
             }
         }
+        impl core::fmt::Debug for RegionMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionMasterport")
+                    .field("enable0", &self.enable0())
+                    .field("enable1", &self.enable1())
+                    .field("enable2", &self.enable2())
+                    .field("enable3", &self.enable3())
+                    .field("enable4", &self.enable4())
+                    .field("enable5", &self.enable5())
+                    .field("enable6", &self.enable6())
+                    .field("enable7", &self.enable7())
+                    .field("enable8", &self.enable8())
+                    .field("enable9", &self.enable9())
+                    .field("enable10", &self.enable10())
+                    .field("enable11", &self.enable11())
+                    .field("enable12", &self.enable12())
+                    .field("enable13", &self.enable13())
+                    .field("enable14", &self.enable14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionMasterport {
+                    enable0: bool,
+                    enable1: bool,
+                    enable2: bool,
+                    enable3: bool,
+                    enable4: bool,
+                    enable5: bool,
+                    enable6: bool,
+                    enable7: bool,
+                    enable8: bool,
+                    enable9: bool,
+                    enable10: bool,
+                    enable11: bool,
+                    enable12: bool,
+                    enable13: bool,
+                    enable14: bool,
+                }
+                let proxy = RegionMasterport {
+                    enable0: self.enable0(),
+                    enable1: self.enable1(),
+                    enable2: self.enable2(),
+                    enable3: self.enable3(),
+                    enable4: self.enable4(),
+                    enable5: self.enable5(),
+                    enable6: self.enable6(),
+                    enable7: self.enable7(),
+                    enable8: self.enable8(),
+                    enable9: self.enable9(),
+                    enable10: self.enable10(),
+                    enable11: self.enable11(),
+                    enable12: self.enable12(),
+                    enable13: self.enable13(),
+                    enable14: self.enable14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorsource {
             #[doc = "Error was triggered by an AXI slave"]
             SLAVE = 0x0,
@@ -20326,7 +27495,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskExecute {
             #[doc = "Permission setting EXECUTE in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -20356,7 +27526,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskRead {
             #[doc = "Permission setting READ in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -20386,7 +27557,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskSecattr {
             #[doc = "Permission setting SECATTR in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -20416,7 +27588,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskWrite {
             #[doc = "Permission setting WRITE in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -21011,6 +28184,24 @@ pub mod nfct {
                 Autocolresconfig(0)
             }
         }
+        impl core::fmt::Debug for Autocolresconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Autocolresconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Autocolresconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Autocolresconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Autocolresconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21032,6 +28223,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the presence or not of a valid field"]
@@ -21068,6 +28279,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21090,6 +28324,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u32,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -21115,6 +28369,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21136,6 +28410,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -21315,6 +28609,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21371,6 +28727,35 @@ pub mod nfct {
                 Last(0)
             }
         }
+        impl core::fmt::Debug for Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Last")
+                    .field("z", &self.z())
+                    .field("y", &self.y())
+                    .field("x", &self.x())
+                    .field("w", &self.w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Last {
+                    z: u8,
+                    y: u8,
+                    x: u8,
+                    w: u8,
+                }
+                let proxy = Last {
+                    z: self.z(),
+                    y: self.y(),
+                    x: self.x(),
+                    w: self.w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of the RAM buffer allocated to TXD and RXD data storage each"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21392,6 +28777,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Maxlen {
                 Maxlen(0)
+            }
+        }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configure EasyDMA mode"]
@@ -21417,6 +28822,22 @@ pub mod nfct {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("lpop", &self.lpop()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    lpop: super::vals::Lpop,
+                }
+                let proxy = Mode { lpop: self.lpop() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables the modulation output to a GPIO pin which can be connected to a second external antenna."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21438,6 +28859,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Modulationctrl {
                 Modulationctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Modulationctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationctrl")
+                    .field("modulationctrl", &self.modulationctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationctrl {
+                    modulationctrl: super::vals::Modulationctrl,
+                }
+                let proxy = Modulationctrl {
+                    modulationctrl: self.modulationctrl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Pin select for Modulation control"]
@@ -21486,6 +28927,32 @@ pub mod nfct {
                 Modulationpsel(0)
             }
         }
+        impl core::fmt::Debug for Modulationpsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationpsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationpsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationpsel {
+                    pin: u8,
+                    port: u8,
+                    connect: super::super::shared::vals::Connect,
+                }
+                let proxy = Modulationpsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current operating state of NFC tag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21509,6 +28976,26 @@ pub mod nfct {
                 Nfctagstate(0)
             }
         }
+        impl core::fmt::Debug for Nfctagstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfctagstate")
+                    .field("nfctagstate", &self.nfctagstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfctagstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfctagstate {
+                    nfctagstate: super::vals::Nfctagstate,
+                }
+                let proxy = Nfctagstate {
+                    nfctagstate: self.nfctagstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC pad configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21530,6 +29017,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Padconfig {
                 Padconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Padconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Padconfig")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Padconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Padconfig {
+                    enable: bool,
+                }
+                let proxy = Padconfig {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of last incoming frame"]
@@ -21577,6 +29084,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21609,6 +29142,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -21656,6 +29212,32 @@ pub mod nfct {
                 RxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21699,6 +29281,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Secondlast {
                 Secondlast(0)
+            }
+        }
+        impl core::fmt::Debug for Secondlast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Secondlast")
+                    .field("v", &self.v())
+                    .field("u", &self.u())
+                    .field("t", &self.t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Secondlast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Secondlast {
+                    v: u8,
+                    u: u8,
+                    t: u8,
+                }
+                let proxy = Secondlast {
+                    v: self.v(),
+                    u: self.u(),
+                    t: self.t(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -21768,6 +29376,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: bool,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21835,6 +29475,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21880,6 +29552,32 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .field("txframeend_enablerxdata", &self.txframeend_enablerxdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                    txframeend_enablerxdata: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                    txframeend_enablerxdata: self.txframeend_enablerxdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sleep state during automatic collision resolution"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21901,6 +29599,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Sleepstate {
                 Sleepstate(0)
+            }
+        }
+        impl core::fmt::Debug for Sleepstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sleepstate")
+                    .field("sleepstate", &self.sleepstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sleepstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sleepstate {
+                    sleepstate: super::vals::Sleepstate,
+                }
+                let proxy = Sleepstate {
+                    sleepstate: self.sleepstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
@@ -21948,6 +29666,32 @@ pub mod nfct {
                 Thirdlast(0)
             }
         }
+        impl core::fmt::Debug for Thirdlast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Thirdlast")
+                    .field("s", &self.s())
+                    .field("r", &self.r())
+                    .field("q", &self.q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Thirdlast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Thirdlast {
+                    s: u8,
+                    r: u8,
+                    q: u8,
+                }
+                let proxy = Thirdlast {
+                    s: self.s(),
+                    r: self.r(),
+                    q: self.q(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of outgoing frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21980,6 +29724,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -22038,10 +29805,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -22105,7 +29902,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits are discarded at end of frame (EoF)"]
             DISCARD_END = 0x0,
@@ -22135,7 +29933,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -22169,7 +29968,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lpop {
             #[doc = "Low-latency operation"]
             LOW_LAT = 0x0,
@@ -22202,7 +30002,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Auto collision resolution enabled"]
             ENABLED = 0x0,
@@ -22232,7 +30033,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Modulationctrl {
             #[doc = "Invalid, defaults to same behaviour as for Internal"]
             INVALID = 0x0,
@@ -22266,7 +30068,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -22299,7 +30102,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfctagstate {
             #[doc = "Disabled or sense"]
             DISABLED = 0x0,
@@ -22339,7 +30143,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleepstate {
             #[doc = "State is IDLE."]
             IDLE = 0x0,
@@ -22520,6 +30325,24 @@ pub mod oscillators {
                 ConfigIntcap(0)
             }
         }
+        impl core::fmt::Debug for ConfigIntcap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ConfigIntcap")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ConfigIntcap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ConfigIntcap {
+                    val: u8,
+                }
+                let proxy = ConfigIntcap { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current speed of MCU power domain, including CPU"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22541,6 +30364,26 @@ pub mod oscillators {
             #[inline(always)]
             fn default() -> Currentfreq {
                 Currentfreq(0)
+            }
+        }
+        impl core::fmt::Debug for Currentfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentfreq")
+                    .field("currentfreq", &self.currentfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentfreq {
+                    currentfreq: super::vals::Currentfreq,
+                }
+                let proxy = Currentfreq {
+                    currentfreq: self.currentfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Set speed of MCU power domain, including CPU"]
@@ -22566,6 +30409,22 @@ pub mod oscillators {
                 Freq(0)
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Freq").field("freq", &self.freq()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Freq {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Freq { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Programmable capacitance of XL1 and XL2"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22589,10 +30448,29 @@ pub mod oscillators {
                 Xosc32kiIntcap(0)
             }
         }
+        impl core::fmt::Debug for Xosc32kiIntcap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32kiIntcap")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32kiIntcap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32kiIntcap {
+                    val: u8,
+                }
+                let proxy = Xosc32kiIntcap { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Currentfreq {
             _RESERVED_0 = 0x0,
             #[doc = "128 MHz"]
@@ -22624,7 +30502,8 @@ pub mod oscillators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Freq {
             _RESERVED_0 = 0x0,
             #[doc = "128 MHz"]
@@ -22968,6 +30847,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22991,6 +30890,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23012,6 +30931,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -23070,6 +31009,35 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .field("dmabuserror", &self.dmabuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                    dmabuserror: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                    dmabuserror: self.dmabuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23091,6 +31059,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphone signals"]
@@ -23127,6 +31115,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Selects the decimation ratio between PDM_CLK and output sample rate. Change PRESCALER accordingly."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23150,6 +31161,26 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23171,10 +31202,31 @@ pub mod pdm {
                 Terminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -23222,6 +31274,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -23235,7 +31308,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -23265,7 +31339,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 32"]
             RATIO32 = 0x0,
@@ -23441,6 +31516,26 @@ pub mod power {
                 Constlatstat(0)
             }
         }
+        impl core::fmt::Debug for Constlatstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Constlatstat")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Constlatstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Constlatstat {
+                    status: bool,
+                }
+                let proxy = Constlatstat {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23462,6 +31557,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret {
                 Gpregret(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -23507,6 +31622,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -23949,6 +32090,119 @@ pub mod ppib {
             #[inline(always)]
             fn default() -> Send {
                 Send(0)
+            }
+        }
+        impl core::fmt::Debug for Send {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Send")
+                    .field("send_0", &self.send_0())
+                    .field("send_1", &self.send_1())
+                    .field("send_2", &self.send_2())
+                    .field("send_3", &self.send_3())
+                    .field("send_4", &self.send_4())
+                    .field("send_5", &self.send_5())
+                    .field("send_6", &self.send_6())
+                    .field("send_7", &self.send_7())
+                    .field("send_8", &self.send_8())
+                    .field("send_9", &self.send_9())
+                    .field("send_10", &self.send_10())
+                    .field("send_11", &self.send_11())
+                    .field("send_12", &self.send_12())
+                    .field("send_13", &self.send_13())
+                    .field("send_14", &self.send_14())
+                    .field("send_15", &self.send_15())
+                    .field("send_16", &self.send_16())
+                    .field("send_17", &self.send_17())
+                    .field("send_18", &self.send_18())
+                    .field("send_19", &self.send_19())
+                    .field("send_20", &self.send_20())
+                    .field("send_21", &self.send_21())
+                    .field("send_22", &self.send_22())
+                    .field("send_23", &self.send_23())
+                    .field("send_24", &self.send_24())
+                    .field("send_25", &self.send_25())
+                    .field("send_26", &self.send_26())
+                    .field("send_27", &self.send_27())
+                    .field("send_28", &self.send_28())
+                    .field("send_29", &self.send_29())
+                    .field("send_30", &self.send_30())
+                    .field("send_31", &self.send_31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Send {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Send {
+                    send_0: bool,
+                    send_1: bool,
+                    send_2: bool,
+                    send_3: bool,
+                    send_4: bool,
+                    send_5: bool,
+                    send_6: bool,
+                    send_7: bool,
+                    send_8: bool,
+                    send_9: bool,
+                    send_10: bool,
+                    send_11: bool,
+                    send_12: bool,
+                    send_13: bool,
+                    send_14: bool,
+                    send_15: bool,
+                    send_16: bool,
+                    send_17: bool,
+                    send_18: bool,
+                    send_19: bool,
+                    send_20: bool,
+                    send_21: bool,
+                    send_22: bool,
+                    send_23: bool,
+                    send_24: bool,
+                    send_25: bool,
+                    send_26: bool,
+                    send_27: bool,
+                    send_28: bool,
+                    send_29: bool,
+                    send_30: bool,
+                    send_31: bool,
+                }
+                let proxy = Send {
+                    send_0: self.send_0(),
+                    send_1: self.send_1(),
+                    send_2: self.send_2(),
+                    send_3: self.send_3(),
+                    send_4: self.send_4(),
+                    send_5: self.send_5(),
+                    send_6: self.send_6(),
+                    send_7: self.send_7(),
+                    send_8: self.send_8(),
+                    send_9: self.send_9(),
+                    send_10: self.send_10(),
+                    send_11: self.send_11(),
+                    send_12: self.send_12(),
+                    send_13: self.send_13(),
+                    send_14: self.send_14(),
+                    send_15: self.send_15(),
+                    send_16: self.send_16(),
+                    send_17: self.send_17(),
+                    send_18: self.send_18(),
+                    send_19: self.send_19(),
+                    send_20: self.send_20(),
+                    send_21: self.send_21(),
+                    send_22: self.send_22(),
+                    send_23: self.send_23(),
+                    send_24: self.send_24(),
+                    send_25: self.send_25(),
+                    send_26: self.send_26(),
+                    send_27: self.send_27(),
+                    send_28: self.send_28(),
+                    send_29: self.send_29(),
+                    send_30: self.send_30(),
+                    send_31: self.send_31(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -24561,6 +32815,26 @@ pub mod pwm {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24584,6 +32858,26 @@ pub mod pwm {
                 Countertop(0)
             }
         }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the current transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24605,6 +32899,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Currentamount {
                 Currentamount(0)
+            }
+        }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -24641,6 +32955,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24662,6 +32999,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -24686,6 +33043,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configure the output value on the PWM channel during idle"]
@@ -24742,6 +33117,35 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Idleout {
                 Idleout(0)
+            }
+        }
+        impl core::fmt::Debug for Idleout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Idleout")
+                    .field("val_0", &self.val_0())
+                    .field("val_1", &self.val_1())
+                    .field("val_2", &self.val_2())
+                    .field("val_3", &self.val_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Idleout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Idleout {
+                    val_0: bool,
+                    val_1: bool,
+                    val_2: bool,
+                    val_3: bool,
+                }
+                let proxy = Idleout {
+                    val_0: self.val_0(),
+                    val_1: self.val_1(),
+                    val_2: self.val_2(),
+                    val_3: self.val_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -24925,6 +33329,81 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .field("ramunderflow", &self.ramunderflow())
+                    .field("dmaseq0end", &self.dmaseq0end())
+                    .field("dmaseq0ready", &self.dmaseq0ready())
+                    .field("dmaseq0buserror", &self.dmaseq0buserror())
+                    .field("dmaseq1end", &self.dmaseq1end())
+                    .field("dmaseq1ready", &self.dmaseq1ready())
+                    .field("dmaseq1buserror", &self.dmaseq1buserror())
+                    .field(
+                        "comparematch",
+                        &[
+                            self.comparematch(0usize),
+                            self.comparematch(1usize),
+                            self.comparematch(2usize),
+                            self.comparematch(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                    ramunderflow: bool,
+                    dmaseq0end: bool,
+                    dmaseq0ready: bool,
+                    dmaseq0buserror: bool,
+                    dmaseq1end: bool,
+                    dmaseq1ready: bool,
+                    dmaseq1buserror: bool,
+                    comparematch: [bool; 4usize],
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                    ramunderflow: self.ramunderflow(),
+                    dmaseq0end: self.dmaseq0end(),
+                    dmaseq0ready: self.dmaseq0ready(),
+                    dmaseq0buserror: self.dmaseq0buserror(),
+                    dmaseq1end: self.dmaseq1end(),
+                    dmaseq1ready: self.dmaseq1ready(),
+                    dmaseq1buserror: self.dmaseq1buserror(),
+                    comparematch: [
+                        self.comparematch(0usize),
+                        self.comparematch(1usize),
+                        self.comparematch(2usize),
+                        self.comparematch(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24947,6 +33426,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Maximum number of bytes in channel buffer"]
@@ -24972,6 +33467,26 @@ pub mod pwm {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Selects operating mode of the wave counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24993,6 +33508,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for PWM_CLK"]
@@ -25018,6 +33553,26 @@ pub mod pwm {
                 Prescaler(0)
             }
         }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25040,6 +33595,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -25142,6 +33713,47 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_dma_seq0_start", &self.loopsdone_dma_seq0_start())
+                    .field("loopsdone_dma_seq1_start", &self.loopsdone_dma_seq1_start())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .field("ramunderflow_stop", &self.ramunderflow_stop())
+                    .field("dma_seq0_buserror_stop", &self.dma_seq0_buserror_stop())
+                    .field("dma_seq1_buserror_stop", &self.dma_seq1_buserror_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_dma_seq0_start: bool,
+                    loopsdone_dma_seq1_start: bool,
+                    loopsdone_stop: bool,
+                    ramunderflow_stop: bool,
+                    dma_seq0_buserror_stop: bool,
+                    dma_seq1_buserror_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_dma_seq0_start: self.loopsdone_dma_seq0_start(),
+                    loopsdone_dma_seq1_start: self.loopsdone_dma_seq1_start(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                    ramunderflow_stop: self.ramunderflow_stop(),
+                    dma_seq0_buserror_stop: self.dma_seq0_buserror_stop(),
+                    dma_seq1_buserror_stop: self.dma_seq1_buserror_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25163,10 +33775,31 @@ pub mod pwm {
                 Terminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -25214,6 +33847,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -25227,7 +33877,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -25257,7 +33908,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -25313,6 +33965,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -25326,7 +33995,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -25626,6 +34296,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25647,6 +34337,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -25672,6 +34382,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25693,6 +34423,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -25762,6 +34512,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25783,6 +34565,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -25808,6 +34610,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25831,6 +34653,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -25852,6 +34694,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -25943,10 +34805,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -25976,7 +34877,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -26027,7 +34929,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -27052,6 +35955,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27108,6 +36031,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Cordic output of CnAcc"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27127,6 +36079,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Cfophase {
                 Cfophase(0)
+            }
+        }
+        impl core::fmt::Debug for Cfophase {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cfophase")
+                    .field("cfophase", &self.cfophase())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cfophase {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cfophase {
+                    cfophase: u16,
+                }
+                let proxy = Cfophase {
+                    cfophase: self.cfophase(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear the GPIO pattern array for antenna control"]
@@ -27150,6 +36122,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output of the autocorrelation of the accumulated IQ signal"]
@@ -27180,6 +36172,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Cnacc {
                 Cnacc(0)
+            }
+        }
+        impl core::fmt::Debug for Cnacc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnacc")
+                    .field("cnacci", &self.cnacci())
+                    .field("cnaccq", &self.cnaccq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnacc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnacc {
+                    cnacci: u16,
+                    cnaccq: u16,
+                }
+                let proxy = Cnacc {
+                    cnacci: self.cnacci(),
+                    cnaccq: self.cnaccq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RTT Config."]
@@ -27249,6 +36264,38 @@ pub mod radio {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("en", &self.en())
+                    .field("enfullaa", &self.enfullaa())
+                    .field("role", &self.role())
+                    .field("numsegments", &self.numsegments())
+                    .field("efsdelay", &self.efsdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    en: bool,
+                    enfullaa: bool,
+                    role: super::vals::Role,
+                    numsegments: u8,
+                    efsdelay: u16,
+                }
+                let proxy = Config {
+                    en: self.en(),
+                    enfullaa: self.enfullaa(),
+                    role: self.role(),
+                    numsegments: self.numsegments(),
+                    efsdelay: self.efsdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27283,6 +36330,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27305,6 +36375,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -27331,6 +36421,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27352,6 +36462,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the mode(s) that are activated on the start signal"]
@@ -27386,6 +36516,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> CstonesMode {
                 CstonesMode(0)
+            }
+        }
+        impl core::fmt::Debug for CstonesMode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CstonesMode")
+                    .field("tpm", &self.tpm())
+                    .field("tfm", &self.tfm())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CstonesMode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CstonesMode {
+                    tpm: bool,
+                    tfm: bool,
+                }
+                let proxy = CstonesMode {
+                    tpm: self.tpm(),
+                    tfm: self.tfm(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -27490,6 +36643,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27535,6 +36729,32 @@ pub mod radio {
                 Ctestatus(0)
             }
         }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the current transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27556,6 +36776,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Currentamount {
                 Currentamount(0)
+            }
+        }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -27746,6 +36986,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27769,6 +37074,22 @@ pub mod radio {
                 Dai(0)
             }
         }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Device address prefix n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27790,6 +37111,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dap {
                 Dap(0)
+            }
+        }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data whitening configuration"]
@@ -27824,6 +37161,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhite {
                 Datawhite(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhite {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhite")
+                    .field("iv", &self.iv())
+                    .field("poly", &self.poly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhite {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhite {
+                    iv: u16,
+                    poly: u16,
+                }
+                let proxy = Datawhite {
+                    iv: self.iv(),
+                    poly: self.poly(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -27930,6 +37290,47 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("repeatpattern", &self.repeatpattern())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    repeatpattern: super::vals::Repeatpattern,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    repeatpattern: self.repeatpattern(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27964,6 +37365,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27985,6 +37409,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -28021,6 +37465,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Turn on/off down sample of input IQ-signals"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28055,6 +37522,29 @@ pub mod radio {
                 Downsample(0)
             }
         }
+        impl core::fmt::Debug for Downsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Downsample")
+                    .field("enablefilter", &self.enablefilter())
+                    .field("rate", &self.rate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Downsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Downsample {
+                    enablefilter: bool,
+                    rate: super::vals::Rate,
+                }
+                let proxy = Downsample {
+                    enablefilter: self.enablefilter(),
+                    rate: self.rate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28077,6 +37567,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edctrl {
                 Edctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Edctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edctrl")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edctrl {
+                    edcnt: u32,
+                }
+                let proxy = Edctrl {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "IEEE 802.15.4 energy detect level"]
@@ -28102,6 +37612,26 @@ pub mod radio {
                 Edsample(0)
             }
         }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FAEPEER (Frequency Actuation Error) of peer if known. Used during Mode 0 steps."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28123,6 +37653,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Faepeer {
                 Faepeer(0)
+            }
+        }
+        impl core::fmt::Debug for Faepeer {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Faepeer")
+                    .field("faepeer", &self.faepeer())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Faepeer {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Faepeer {
+                    faepeer: u8,
+                }
+                let proxy = Faepeer {
+                    faepeer: self.faepeer(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Config register"]
@@ -28148,6 +37698,26 @@ pub mod radio {
                 Feconfig(0)
             }
         }
+        impl core::fmt::Debug for Feconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Feconfig")
+                    .field("scalermode", &self.scalermode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Feconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Feconfig {
+                    scalermode: bool,
+                }
+                let proxy = Feconfig {
+                    scalermode: self.scalermode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FFO estimate"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28169,6 +37739,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ffoest {
                 Ffoest(0)
+            }
+        }
+        impl core::fmt::Debug for Ffoest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffoest")
+                    .field("ffoest", &self.ffoest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffoest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffoest {
+                    ffoest: u16,
+                }
+                let proxy = Ffoest {
+                    ffoest: self.ffoest(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Override value of FFO (Fractional Frequency Offset) if not to be based on the frequency estimate derived from CnAcc (autocorrelation of the scaled input signal) value"]
@@ -28194,6 +37784,26 @@ pub mod radio {
                 Ffoin(0)
             }
         }
+        impl core::fmt::Debug for Ffoin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffoin")
+                    .field("fffin", &self.fffin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffoin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffoin {
+                    fffin: u16,
+                }
+                let proxy = Ffoin {
+                    fffin: self.fffin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Source of FFO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28215,6 +37825,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ffosource {
                 Ffosource(0)
+            }
+        }
+        impl core::fmt::Debug for Ffosource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffosource")
+                    .field("ffosource", &self.ffosource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffosource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffosource {
+                    ffosource: super::vals::Ffosource,
+                }
+                let proxy = Ffosource {
+                    ffosource: self.ffosource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of full ADPLL finetune steps"]
@@ -28240,6 +37870,26 @@ pub mod radio {
                 Finetunenext(0)
             }
         }
+        impl core::fmt::Debug for Finetunenext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Finetunenext")
+                    .field("finetunenext", &self.finetunenext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Finetunenext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Finetunenext {
+                    finetunenext: u16,
+                }
+                let proxy = Finetunenext {
+                    finetunenext: self.finetunenext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frequency offset estimate"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28259,6 +37909,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Freqoffset {
                 Freqoffset(0)
+            }
+        }
+        impl core::fmt::Debug for Freqoffset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Freqoffset")
+                    .field("freqoffset", &self.freqoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freqoffset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Freqoffset {
+                    freqoffset: u16,
+                }
+                let proxy = Freqoffset {
+                    freqoffset: self.freqoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -28293,6 +37963,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: bool,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -28560,6 +38253,92 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("address", &self.address())
+                    .field("framestart", &self.framestart())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("phyend", &self.phyend())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    txready: bool,
+                    rxready: bool,
+                    address: bool,
+                    framestart: bool,
+                    payload: bool,
+                    end: bool,
+                    phyend: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    bcmatch: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    address: self.address(),
+                    framestart: self.framestart(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    phyend: self.phyend(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    bcmatch: self.bcmatch(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mean of IQ values"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28594,6 +38373,29 @@ pub mod radio {
                 Iqrawmean(0)
             }
         }
+        impl core::fmt::Debug for Iqrawmean {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Iqrawmean")
+                    .field("iqrawmeani", &self.iqrawmeani())
+                    .field("iqrawmeanq", &self.iqrawmeanq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Iqrawmean {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Iqrawmean {
+                    iqrawmeani: u16,
+                    iqrawmeanq: u16,
+                }
+                let proxy = Iqrawmean {
+                    iqrawmeani: self.iqrawmeani(),
+                    iqrawmeanq: self.iqrawmeanq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Quantization error between ADPLL frequency and the desired value of FFO * RF Frequency. Values limited to \\[-64,63\\] with units 7.6294 Hz."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28615,6 +38417,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Lfaenext {
                 Lfaenext(0)
+            }
+        }
+        impl core::fmt::Debug for Lfaenext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfaenext")
+                    .field("lfaenext", &self.lfaenext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfaenext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfaenext {
+                    lfaenext: u8,
+                }
+                let proxy = Lfaenext {
+                    lfaenext: self.lfaenext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mean magnitude and phase of the signal before it is converted to PCT16"]
@@ -28651,6 +38473,29 @@ pub mod radio {
                 Magphasemean(0)
             }
         }
+        impl core::fmt::Debug for Magphasemean {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Magphasemean")
+                    .field("phase", &self.phase())
+                    .field("mag", &self.mag())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Magphasemean {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Magphasemean {
+                    phase: u16,
+                    mag: u16,
+                }
+                let proxy = Magphasemean {
+                    phase: self.phase(),
+                    mag: self.mag(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Magnitude standard deviation approximation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28672,6 +38517,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Magstd {
                 Magstd(0)
+            }
+        }
+        impl core::fmt::Debug for Magstd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Magstd")
+                    .field("magstd", &self.magstd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Magstd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Magstd {
+                    magstd: u16,
+                }
+                let proxy = Magstd {
+                    magstd: self.magstd(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -28697,6 +38562,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The value of FREQUENCY that will be used in the next step"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28718,6 +38603,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Nextfrequency {
                 Nextfrequency(0)
+            }
+        }
+        impl core::fmt::Debug for Nextfrequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nextfrequency")
+                    .field("nextfrequency", &self.nextfrequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nextfrequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nextfrequency {
+                    nextfrequency: u8,
+                }
+                let proxy = Nextfrequency {
+                    nextfrequency: self.nextfrequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of input samples at 2MHz sample rate"]
@@ -28743,6 +38648,26 @@ pub mod radio {
                 Numsamples(0)
             }
         }
+        impl core::fmt::Debug for Numsamples {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Numsamples")
+                    .field("numsamples", &self.numsamples())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Numsamples {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Numsamples {
+                    numsamples: u8,
+                }
+                let proxy = Numsamples {
+                    numsamples: self.numsamples(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Parameter used in TPM, provided by software"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28764,6 +38689,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Numsamplescoeff {
                 Numsamplescoeff(0)
+            }
+        }
+        impl core::fmt::Debug for Numsamplescoeff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Numsamplescoeff")
+                    .field("numsamplescoeff", &self.numsamplescoeff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Numsamplescoeff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Numsamplescoeff {
+                    numsamplescoeff: u16,
+                }
+                let proxy = Numsamplescoeff {
+                    numsamplescoeff: self.numsamplescoeff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -28869,6 +38814,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28949,6 +38935,41 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .field("whiteoffset", &self.whiteoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                    whiteoffset: super::vals::Whiteoffset,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                    whiteoffset: self.whiteoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mean magnitude and mean phase converted to IQ. IQ values limited to \\[-1024,1023\\]."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28981,6 +39002,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Pct11 {
                 Pct11(0)
+            }
+        }
+        impl core::fmt::Debug for Pct11 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pct11")
+                    .field("pct11i", &self.pct11i())
+                    .field("pct11q", &self.pct11q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pct11 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pct11 {
+                    pct11i: u16,
+                    pct11q: u16,
+                }
+                let proxy = Pct11 {
+                    pct11i: self.pct11i(),
+                    pct11q: self.pct11q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mean magnitude and mean phase converted to IQ"]
@@ -29017,6 +39061,29 @@ pub mod radio {
                 Pct16(0)
             }
         }
+        impl core::fmt::Debug for Pct16 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pct16")
+                    .field("pct16i", &self.pct16i())
+                    .field("pct16q", &self.pct16q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pct16 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pct16 {
+                    pct16i: u16,
+                    pct16q: u16,
+                }
+                let proxy = Pct16 {
+                    pct16i: self.pct16i(),
+                    pct16q: self.pct16q(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29051,6 +39118,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Parameter used in TPM, provided by software"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29072,6 +39162,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Phaseshift {
                 Phaseshift(0)
+            }
+        }
+        impl core::fmt::Debug for Phaseshift {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Phaseshift")
+                    .field("phaseshift", &self.phaseshift())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Phaseshift {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Phaseshift {
+                    phaseshift: u16,
+                }
+                let proxy = Phaseshift {
+                    phaseshift: self.phaseshift(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -29130,6 +39240,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29186,6 +39325,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29209,6 +39377,24 @@ pub mod radio {
                 RadioMode(0)
             }
         }
+        impl core::fmt::Debug for RadioMode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RadioMode")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RadioMode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RadioMode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = RadioMode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29230,6 +39416,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -29332,6 +39538,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29354,6 +39601,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -29379,6 +39646,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29400,6 +39687,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -29601,6 +39904,74 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29622,6 +39993,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -29647,6 +40038,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29668,6 +40079,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Timing"]
@@ -29693,6 +40120,22 @@ pub mod radio {
                 Timing(0)
             }
         }
+        impl core::fmt::Debug for Timing {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Timing").field("ru", &self.ru()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Timing {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Timing {
+                    ru: super::vals::Ru,
+                }
+                let proxy = Timing { ru: self.ru() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29714,6 +40157,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -29740,10 +40203,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -29782,7 +40266,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -29814,7 +40299,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -29844,7 +40330,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -29874,7 +40361,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -29914,7 +40402,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -29954,7 +40443,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8us unit (default) Set to 20 if parsed CTETime is larger han 20"]
             _20 = 0x0,
@@ -29987,7 +40477,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -30017,7 +40508,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -30050,7 +40542,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -30080,7 +40573,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ffosource {
             #[doc = "Use FFOIN"]
             EXTERNAL = 0x0,
@@ -30110,7 +40604,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -30144,7 +40639,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -30195,7 +40691,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -30225,7 +40722,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -30259,7 +40757,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rate {
             #[doc = "Radio mode BLE1M is used"]
             BLE1M = 0x0,
@@ -30289,7 +40788,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Repeatpattern {
             #[doc = "Do not repeat (1 time in total)"]
             NO_REPEAT = 0x0,
@@ -30332,7 +40832,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Role {
             #[doc = "Initiator"]
             INITIATOR = 0x0,
@@ -30362,7 +40863,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Legacy ramp-up time"]
             LEGACY = 0x0,
@@ -30392,7 +40894,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -30424,7 +40927,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -30454,7 +40958,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -30484,7 +40989,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -30523,7 +41029,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the DISABLED state"]
             DISABLED = 0x0,
@@ -30574,7 +41081,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -30614,7 +41122,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -30654,7 +41163,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -30694,7 +41204,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -30799,6 +41310,77 @@ pub mod radio {
                 self.0
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("NEG28_DBM"),
+                    0x02 => f.write_str("NEG20_DBM"),
+                    0x02 => f.write_str("NEG22_DBM"),
+                    0x03 => f.write_str("NEG18_DBM"),
+                    0x04 => f.write_str("NEG16_DBM"),
+                    0x05 => f.write_str("NEG14_DBM"),
+                    0x06 => f.write_str("NEG12_DBM"),
+                    0x07 => f.write_str("NEG10_DBM"),
+                    0x08 => f.write_str("NEG9_DBM"),
+                    0x09 => f.write_str("NEG8_DBM"),
+                    0x0a => f.write_str("NEG7_DBM"),
+                    0x0b => f.write_str("NEG6_DBM"),
+                    0x0d => f.write_str("NEG5_DBM"),
+                    0x0f => f.write_str("NEG4_DBM"),
+                    0x11 => f.write_str("NEG3_DBM"),
+                    0x13 => f.write_str("NEG2_DBM"),
+                    0x15 => f.write_str("NEG1_DBM"),
+                    0x18 => f.write_str("_0_DBM"),
+                    0x1b => f.write_str("POS1_DBM"),
+                    0x1f => f.write_str("POS2_DBM"),
+                    0x23 => f.write_str("POS3_DBM"),
+                    0x28 => f.write_str("POS4_DBM"),
+                    0x2d => f.write_str("POS5_DBM"),
+                    0x33 => f.write_str("POS6_DBM"),
+                    0x39 => f.write_str("POS7_DBM"),
+                    0x3f => f.write_str("POS8_DBM"),
+                    0x0110 => f.write_str("NEG46_DBM"),
+                    0x0130 => f.write_str("NEG40_DBM"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "NEG28_DBM"),
+                    0x02 => defmt::write!(f, "NEG20_DBM"),
+                    0x02 => defmt::write!(f, "NEG22_DBM"),
+                    0x03 => defmt::write!(f, "NEG18_DBM"),
+                    0x04 => defmt::write!(f, "NEG16_DBM"),
+                    0x05 => defmt::write!(f, "NEG14_DBM"),
+                    0x06 => defmt::write!(f, "NEG12_DBM"),
+                    0x07 => defmt::write!(f, "NEG10_DBM"),
+                    0x08 => defmt::write!(f, "NEG9_DBM"),
+                    0x09 => defmt::write!(f, "NEG8_DBM"),
+                    0x0a => defmt::write!(f, "NEG7_DBM"),
+                    0x0b => defmt::write!(f, "NEG6_DBM"),
+                    0x0d => defmt::write!(f, "NEG5_DBM"),
+                    0x0f => defmt::write!(f, "NEG4_DBM"),
+                    0x11 => defmt::write!(f, "NEG3_DBM"),
+                    0x13 => defmt::write!(f, "NEG2_DBM"),
+                    0x15 => defmt::write!(f, "NEG1_DBM"),
+                    0x18 => defmt::write!(f, "_0_DBM"),
+                    0x1b => defmt::write!(f, "POS1_DBM"),
+                    0x1f => defmt::write!(f, "POS2_DBM"),
+                    0x23 => defmt::write!(f, "POS3_DBM"),
+                    0x28 => defmt::write!(f, "POS4_DBM"),
+                    0x2d => defmt::write!(f, "POS5_DBM"),
+                    0x33 => defmt::write!(f, "POS6_DBM"),
+                    0x39 => defmt::write!(f, "POS7_DBM"),
+                    0x3f => defmt::write!(f, "POS8_DBM"),
+                    0x0110 => defmt::write!(f, "NEG46_DBM"),
+                    0x0130 => defmt::write!(f, "NEG40_DBM"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Txpower {
             #[inline(always)]
             fn from(val: u16) -> Txpower {
@@ -30812,7 +41394,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Whiteoffset {
             #[doc = "S0 included in whitening"]
             INCLUDE = 0x0,
@@ -30959,6 +41542,22 @@ pub mod regulators {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen").field("val", &self.val()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    val: bool,
+                }
+                let proxy = Dcdcen { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable register for VREGM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30982,6 +41581,26 @@ pub mod regulators {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "VREGMAIN inductor detection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31001,6 +41620,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Inductordet {
                 Inductordet(0)
+            }
+        }
+        impl core::fmt::Debug for Inductordet {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Inductordet")
+                    .field("detected", &self.detected())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Inductordet {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Inductordet {
+                    detected: super::vals::Detected,
+                }
+                let proxy = Inductordet {
+                    detected: self.detected(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power-fail comparator configuration"]
@@ -31048,6 +41687,32 @@ pub mod regulators {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("eventdisable", &self.eventdisable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    eventdisable: super::vals::Eventdisable,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    eventdisable: self.eventdisable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power-fail comparator status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31069,6 +41734,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Pofstat {
                 Pofstat(0)
+            }
+        }
+        impl core::fmt::Debug for Pofstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofstat")
+                    .field("comparator", &self.comparator())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofstat {
+                    comparator: super::vals::Comparator,
+                }
+                let proxy = Pofstat {
+                    comparator: self.comparator(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System OFF register"]
@@ -31094,10 +41779,31 @@ pub mod regulators {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Comparator {
             #[doc = "Voltage detected above VPOF threshold"]
             ABOVE = 0x0,
@@ -31127,7 +41833,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detected {
             #[doc = "VREGMAIN inductor not detected"]
             INDUCTOR_NOT_DETECTED = 0x0,
@@ -31157,7 +41864,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Eventdisable {
             #[doc = "POFWARN event is generated"]
             ENABLED = 0x0,
@@ -31187,7 +41895,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             #[doc = "Set threshold to 1.7 V"]
             V17 = 0x0,
@@ -31430,6 +42139,65 @@ pub mod reset {
             #[inline(always)]
             fn default() -> Resetreas {
                 Resetreas(0)
+            }
+        }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog0", &self.dog0())
+                    .field("dog1", &self.dog1())
+                    .field("ctrlapsoft", &self.ctrlapsoft())
+                    .field("ctrlaphard", &self.ctrlaphard())
+                    .field("ctrlappin", &self.ctrlappin())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("grtc", &self.grtc())
+                    .field("nfc", &self.nfc())
+                    .field("sectamper", &self.sectamper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog0: bool,
+                    dog1: bool,
+                    ctrlapsoft: bool,
+                    ctrlaphard: bool,
+                    ctrlappin: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    grtc: bool,
+                    nfc: bool,
+                    sectamper: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog0: self.dog0(),
+                    dog1: self.dog1(),
+                    ctrlapsoft: self.ctrlapsoft(),
+                    ctrlaphard: self.ctrlaphard(),
+                    ctrlappin: self.ctrlappin(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    grtc: self.grtc(),
+                    nfc: self.nfc(),
+                    sectamper: self.sectamper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -31729,6 +42497,26 @@ pub mod rramc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("erase", &self.erase())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    erase: super::vals::Erase,
+                }
+                let proxy = Eraseall {
+                    erase: self.erase(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31796,6 +42584,38 @@ pub mod rramc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("wokenup", &self.wokenup())
+                    .field("ready", &self.ready())
+                    .field("readynext", &self.readynext())
+                    .field("accesserror", &self.accesserror())
+                    .field("eccerror", &self.eccerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    wokenup: bool,
+                    ready: bool,
+                    readynext: bool,
+                    accesserror: bool,
+                    eccerror: bool,
+                }
+                let proxy = Int {
+                    wokenup: self.wokenup(),
+                    ready: self.ready(),
+                    readynext: self.readynext(),
+                    accesserror: self.accesserror(),
+                    eccerror: self.eccerror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Low power mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31817,6 +42637,24 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Lowpowerconfig {
                 Lowpowerconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpowerconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpowerconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpowerconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpowerconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Lowpowerconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power configuration"]
@@ -31854,6 +42692,29 @@ pub mod rramc {
                 PowerConfig(0)
             }
         }
+        impl core::fmt::Debug for PowerConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PowerConfig")
+                    .field("accesstimeout", &self.accesstimeout())
+                    .field("pof", &self.pof())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PowerConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PowerConfig {
+                    accesstimeout: u16,
+                    pof: super::vals::Pof,
+                }
+                let proxy = PowerConfig {
+                    accesstimeout: self.accesstimeout(),
+                    pof: self.pof(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RRAMC ready status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31877,6 +42738,26 @@ pub mod rramc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready next flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31898,6 +42779,26 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Readynext {
                 Readynext(0)
+            }
+        }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for ready next timeout counter, in units of AXI clock frequency"]
@@ -31932,6 +42833,29 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Readynexttimeout {
                 Readynexttimeout(0)
+            }
+        }
+        impl core::fmt::Debug for Readynexttimeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynexttimeout")
+                    .field("value", &self.value())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynexttimeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynexttimeout {
+                    value: u16,
+                    en: bool,
+                }
+                let proxy = Readynexttimeout {
+                    value: self.value(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Region configuration"]
@@ -32034,6 +42958,47 @@ pub mod rramc {
                 RegionConfig(0)
             }
         }
+        impl core::fmt::Debug for RegionConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionConfig")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("owner", &self.owner())
+                    .field("writeonce", &self.writeonce())
+                    .field("lock", &self.lock())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionConfig {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    owner: super::vals::Owner,
+                    writeonce: bool,
+                    lock: bool,
+                    size: u8,
+                }
+                let proxy = RegionConfig {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    owner: self.owner(),
+                    writeonce: self.writeonce(),
+                    lock: self.lock(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32068,6 +43033,29 @@ pub mod rramc {
                 RramcConfig(0)
             }
         }
+        impl core::fmt::Debug for RramcConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RramcConfig")
+                    .field("wen", &self.wen())
+                    .field("writebufsize", &self.writebufsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RramcConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RramcConfig {
+                    wen: bool,
+                    writebufsize: super::vals::Writebufsize,
+                }
+                let proxy = RramcConfig {
+                    wen: self.wen(),
+                    writebufsize: self.writebufsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Internal write-buffer is empty"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32089,10 +43077,31 @@ pub mod rramc {
                 Writebufempty(0)
             }
         }
+        impl core::fmt::Debug for Writebufempty {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writebufempty")
+                    .field("empty", &self.empty())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writebufempty {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writebufempty {
+                    empty: bool,
+                }
+                let proxy = Writebufempty {
+                    empty: self.empty(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Erase {
             #[doc = "No operation"]
             NO_OPERATION = 0x0,
@@ -32122,7 +43131,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "The RRAM goes into power down mode"]
             POWER_DOWN = 0x0,
@@ -32156,7 +43166,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Owner {
             #[doc = "Owner ID protection is not enforced"]
             NOT_ENFORCED = 0x0,
@@ -32199,7 +43210,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pof {
             #[doc = "Wait until the current RRAM write finishes"]
             WAIT = 0x0,
@@ -32241,6 +43253,23 @@ pub mod rramc {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Writebufsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("UNBUFFERED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writebufsize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "UNBUFFERED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Writebufsize {
@@ -32448,6 +43477,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32470,6 +43519,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -32521,6 +43590,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32570,6 +43678,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768 / (PRESCALER + 1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32591,6 +43738,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -32618,6 +43785,39 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "comparen_clear",
+                        &[
+                            self.comparen_clear(0usize),
+                            self.comparen_clear(1usize),
+                            self.comparen_clear(2usize),
+                            self.comparen_clear(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    comparen_clear: [bool; 4usize],
+                }
+                let proxy = Shorts {
+                    comparen_clear: [
+                        self.comparen_clear(0usize),
+                        self.comparen_clear(1usize),
+                        self.comparen_clear(2usize),
+                        self.comparen_clear(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -33017,6 +44217,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33097,6 +44317,41 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("gain", &self.gain())
+                    .field("burst", &self.burst())
+                    .field("refsel", &self.refsel())
+                    .field("mode", &self.mode())
+                    .field("tacq", &self.tacq())
+                    .field("tconv", &self.tconv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    gain: super::vals::Gain,
+                    burst: bool,
+                    refsel: super::vals::Refsel,
+                    mode: super::vals::ConfigMode,
+                    tacq: u16,
+                    tconv: u8,
+                }
+                let proxy = Config {
+                    gain: self.gain(),
+                    burst: self.burst(),
+                    refsel: self.refsel(),
+                    mode: self.mode(),
+                    tacq: self.tacq(),
+                    tconv: self.tconv(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of buffer bytes transferred since last START, continuously updated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33120,6 +44375,26 @@ pub mod saadc {
                 Currentamount(0)
             }
         }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33141,6 +44416,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -33251,6 +44546,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33285,6 +44663,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Linearity calibration coefficient"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33306,6 +44707,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Lincalcoeff {
                 Lincalcoeff(0)
+            }
+        }
+        impl core::fmt::Debug for Lincalcoeff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lincalcoeff")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lincalcoeff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lincalcoeff {
+                    val: u16,
+                }
+                let proxy = Lincalcoeff { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of buffer bytes to transfer"]
@@ -33331,6 +44750,26 @@ pub mod saadc {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable noise shaping"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33354,6 +44793,26 @@ pub mod saadc {
                 Noiseshape(0)
             }
         }
+        impl core::fmt::Debug for Noiseshape {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Noiseshape")
+                    .field("noiseshape", &self.noiseshape())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Noiseshape {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Noiseshape {
+                    noiseshape: super::vals::Noiseshape,
+                }
+                let proxy = Noiseshape {
+                    noiseshape: self.noiseshape(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33375,6 +44834,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Oversample {
                 Oversample(0)
+            }
+        }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
@@ -33421,6 +44900,32 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pin: u8,
+                    port: u8,
+                    connect: super::vals::PselnConnect,
+                }
+                let proxy = Pseln {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -33481,6 +44986,35 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("internal", &self.internal())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pin: u8,
+                    port: u8,
+                    internal: super::vals::Internal,
+                    connect: super::vals::PselpConnect,
+                }
+                let proxy = Pselp {
+                    pin: self.pin(),
+                    port: self.port(),
+                    internal: self.internal(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33502,6 +45036,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -33539,6 +45091,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33562,10 +45137,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -33595,7 +45191,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "2"]
             GAIN2 = 0x0,
@@ -33637,7 +45234,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Internal {
             #[doc = "Connected to the internal 0.9V analog supply rail"]
             AVDD = 0x0,
@@ -33670,7 +45268,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Noiseshape {
             #[doc = "Disable noiseshaping. Oversampling based on accumulate and average."]
             DISABLE = 0x0,
@@ -33703,7 +45302,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -33754,7 +45354,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselnConnect {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -33786,7 +45387,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselpConnect {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -33819,7 +45421,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (1.024 V)"]
             INTERNAL = 0x0,
@@ -33849,7 +45452,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -33879,7 +45483,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -33909,7 +45514,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -33996,6 +45602,32 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event END"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34026,6 +45658,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task START"]
@@ -34060,10 +45715,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -34872,6 +46551,26 @@ pub mod spim {
                 Csndur(0)
             }
         }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Polarity of CSN output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34893,6 +46592,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csnpol {
                 Csnpol(0)
+            }
+        }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol_0", &self.csnpol_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol_0: super::vals::Csnpol0,
+                }
+                let proxy = Csnpol {
+                    csnpol_0: self.csnpol_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DCX configuration"]
@@ -34918,6 +46637,26 @@ pub mod spim {
                 Dcxcnt(0)
             }
         }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34939,6 +46678,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -35067,6 +46826,66 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field(
+                        "dmarxmatch",
+                        &[
+                            self.dmarxmatch(0usize),
+                            self.dmarxmatch(1usize),
+                            self.dmarxmatch(2usize),
+                            self.dmarxmatch(3usize),
+                        ],
+                    )
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch: [bool; 4usize],
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch: [
+                        self.dmarxmatch(0usize),
+                        self.dmarxmatch(1usize),
+                        self.dmarxmatch(2usize),
+                        self.dmarxmatch(3usize),
+                    ],
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35171,6 +46990,47 @@ pub mod spim {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35192,6 +47052,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The prescaler is used to set the SPI frequency."]
@@ -35217,6 +47093,26 @@ pub mod spim {
                 Prescaler(0)
             }
         }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("divisor", &self.divisor())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    divisor: u8,
+                }
+                let proxy = Prescaler {
+                    divisor: self.divisor(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35238,6 +47134,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -35263,6 +47179,26 @@ pub mod spim {
                 RxList(0)
             }
         }
+        impl core::fmt::Debug for RxList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxList")
+                    .field("type_", &self.type_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxList {
+                    type_: super::vals::RxListType,
+                }
+                let proxy = RxList {
+                    type_: self.type_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35286,6 +47222,26 @@ pub mod spim {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35305,6 +47261,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample delay for input serial data on MISO"]
@@ -35328,6 +47304,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Rxdelay {
                 Rxdelay(0)
+            }
+        }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -35441,6 +47437,74 @@ pub mod spim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35486,6 +47550,32 @@ pub mod spim {
                 SpimConfig(0)
             }
         }
+        impl core::fmt::Debug for SpimConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpimConfig")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpimConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpimConfig {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = SpimConfig {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35507,6 +47597,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -35532,6 +47642,26 @@ pub mod spim {
                 TxList(0)
             }
         }
+        impl core::fmt::Debug for TxList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxList")
+                    .field("type_", &self.type_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxList {
+                    type_: super::vals::TxListType,
+                }
+                let proxy = TxList {
+                    type_: self.type_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35555,6 +47685,26 @@ pub mod spim {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35576,10 +47726,31 @@ pub mod spim {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -35609,7 +47780,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -35639,7 +47811,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol0 {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -35669,7 +47842,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -35713,7 +47887,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -35743,7 +47918,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -35773,7 +47949,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -35803,7 +47980,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -35833,7 +48011,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -35863,7 +48042,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxListType {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -35899,7 +48079,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxListType {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -36607,6 +48788,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36628,6 +48825,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -36745,6 +48962,63 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("acquired", &self.acquired())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field(
+                        "dmarxmatch",
+                        &[
+                            self.dmarxmatch(0usize),
+                            self.dmarxmatch(1usize),
+                            self.dmarxmatch(2usize),
+                            self.dmarxmatch(3usize),
+                        ],
+                    )
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    acquired: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch: [bool; 4usize],
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    acquired: self.acquired(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch: [
+                        self.dmarxmatch(0usize),
+                        self.dmarxmatch(1usize),
+                        self.dmarxmatch(2usize),
+                        self.dmarxmatch(3usize),
+                    ],
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36849,6 +49123,47 @@ pub mod spis {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36870,6 +49185,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -36895,6 +49226,26 @@ pub mod spis {
                 RxAmount(0)
             }
         }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36918,6 +49269,26 @@ pub mod spis {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36937,6 +49308,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Semaphore status register"]
@@ -36960,6 +49351,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Semstat {
                 Semstat(0)
+            }
+        }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -37073,6 +49484,74 @@ pub mod spis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37118,6 +49597,32 @@ pub mod spis {
                 SpisConfig(0)
             }
         }
+        impl core::fmt::Debug for SpisConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpisConfig")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpisConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpisConfig {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = SpisConfig {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status from last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37152,6 +49657,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37173,6 +49701,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -37198,6 +49746,26 @@ pub mod spis {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37219,10 +49787,31 @@ pub mod spis {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -37252,7 +49841,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -37282,7 +49872,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -37326,7 +49917,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -37356,7 +49948,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -37386,7 +49979,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -37416,7 +50010,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -37446,7 +50041,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -37476,7 +50072,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -37835,6 +50432,26 @@ pub mod spu {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u16,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for CC n of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37867,6 +50484,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Cc {
                 Cc(0)
+            }
+        }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Cc {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for channel group n of DPPIC"]
@@ -37903,6 +50543,29 @@ pub mod spu {
                 Chg(0)
             }
         }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Chg {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of features for CLKOUT/CLKCFG of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37935,6 +50598,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Clk {
                 Clk(0)
+            }
+        }
+        impl core::fmt::Debug for Clk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clk")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clk {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Clk {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for channel n of DPPIC"]
@@ -37971,6 +50657,29 @@ pub mod spu {
                 DppicCh(0)
             }
         }
+        impl core::fmt::Debug for DppicCh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppicCh")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppicCh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppicCh {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = DppicCh {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for channel o of GPIOTE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38003,6 +50712,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> GpioteCh {
                 GpioteCh(0)
+            }
+        }
+        impl core::fmt::Debug for GpioteCh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioteCh")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioteCh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioteCh {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GpioteCh {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for interrupt o of GPIOTE\\[n\\]"]
@@ -38039,6 +50771,29 @@ pub mod spu {
                 GpioteInterrupt(0)
             }
         }
+        impl core::fmt::Debug for GpioteInterrupt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioteInterrupt")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioteInterrupt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioteInterrupt {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GpioteInterrupt {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for interrupt n of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38073,6 +50828,29 @@ pub mod spu {
                 GrtcInterrupt(0)
             }
         }
+        impl core::fmt::Debug for GrtcInterrupt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GrtcInterrupt")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GrtcInterrupt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GrtcInterrupt {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GrtcInterrupt {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38094,6 +50872,26 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("periphaccerr", &self.periphaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    periphaccerr: bool,
+                }
+                let proxy = Int {
+                    periphaccerr: self.periphaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Get and set the applicable access permissions for the peripheral slave index n"]
@@ -38175,6 +50973,41 @@ pub mod spu {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("securemapping", &self.securemapping())
+                    .field("dma", &self.dma())
+                    .field("secattr", &self.secattr())
+                    .field("dmasec", &self.dmasec())
+                    .field("lock", &self.lock())
+                    .field("present", &self.present())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    securemapping: super::vals::Securemapping,
+                    dma: super::vals::Dma,
+                    secattr: bool,
+                    dmasec: bool,
+                    lock: bool,
+                    present: super::vals::Present,
+                }
+                let proxy = Perm {
+                    securemapping: self.securemapping(),
+                    dma: self.dma(),
+                    secattr: self.secattr(),
+                    dmasec: self.dmasec(),
+                    lock: self.lock(),
+                    present: self.present(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for GPIO\\[n\\] PIN\\[o\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38207,6 +51040,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Pin {
                 Pin(0)
+            }
+        }
+        impl core::fmt::Debug for Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pin")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pin {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Pin {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of feature for PWMCONFIG of GRTC"]
@@ -38243,6 +51099,29 @@ pub mod spu {
                 Pwmconfig(0)
             }
         }
+        impl core::fmt::Debug for Pwmconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pwmconfig")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pwmconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pwmconfig {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Pwmconfig {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for CRACEN SEED"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38275,6 +51154,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Seed {
                 Seed(0)
+            }
+        }
+        impl core::fmt::Debug for Seed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seed")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seed {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Seed {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of features for SYSCOUNTERL/SYSCOUNTERH of GRTC"]
@@ -38311,10 +51213,34 @@ pub mod spu {
                 Syscounter(0)
             }
         }
+        impl core::fmt::Debug for Syscounter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syscounter")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syscounter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syscounter {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Syscounter {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dma {
             #[doc = "Peripheral has no DMA capability"]
             NO_DMA = 0x0,
@@ -38347,7 +51273,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "Peripheral is not present"]
             NOT_PRESENT = 0x0,
@@ -38377,7 +51304,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Securemapping {
             #[doc = "This peripheral is always accessible as a non-secure peripheral"]
             NON_SECURE = 0x0,
@@ -38505,6 +51433,26 @@ pub mod tad {
                 Dbgpwrupreq(0)
             }
         }
+        impl core::fmt::Debug for Dbgpwrupreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbgpwrupreq")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbgpwrupreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbgpwrupreq {
+                    active: bool,
+                }
+                let proxy = Dbgpwrupreq {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable debug domain and aquire selected GPIOs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38524,6 +51472,26 @@ pub mod tad {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System power-up request"]
@@ -38549,6 +51517,26 @@ pub mod tad {
                 Syspwrupreq(0)
             }
         }
+        impl core::fmt::Debug for Syspwrupreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syspwrupreq")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syspwrupreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syspwrupreq {
+                    active: bool,
+                }
+                let proxy = Syspwrupreq {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SW-DP Target instance"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38570,6 +51558,26 @@ pub mod tad {
             #[inline(always)]
             fn default() -> Tinstance {
                 Tinstance(0)
+            }
+        }
+        impl core::fmt::Debug for Tinstance {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tinstance")
+                    .field("tinstance", &self.tinstance())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tinstance {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tinstance {
+                    tinstance: u8,
+                }
+                let proxy = Tinstance {
+                    tinstance: self.tinstance(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Trace port speed"]
@@ -38595,10 +51603,31 @@ pub mod tad {
                 Traceportspeed(0)
             }
         }
+        impl core::fmt::Debug for Traceportspeed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceportspeed")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceportspeed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceportspeed {
+                    traceportspeed: super::vals::Traceportspeed,
+                }
+                let proxy = Traceportspeed {
+                    traceportspeed: self.traceportspeed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "Trace port speed equals CPU clock"]
             DIV1 = 0x0,
@@ -39240,6 +52269,35 @@ pub mod tampc {
                 ActiveshieldCtrl(0)
             }
         }
+        impl core::fmt::Debug for ActiveshieldCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ActiveshieldCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ActiveshieldCtrl {
+                    value: super::vals::ActiveshieldCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ActiveshieldCtrlWriteprotection,
+                    key: super::vals::ActiveshieldCtrlKey,
+                }
+                let proxy = ActiveshieldCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for active shield detector enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39261,6 +52319,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ActiveshieldStatus {
                 ActiveshieldStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ActiveshieldStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ActiveshieldStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ActiveshieldStatus {
+                    error: bool,
+                }
+                let proxy = ActiveshieldStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register to enable invasive (halting) debug in domain n's access port."]
@@ -39320,6 +52398,35 @@ pub mod tampc {
                 ApDbgenCtrl(0)
             }
         }
+        impl core::fmt::Debug for ApDbgenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApDbgenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApDbgenCtrl {
+                    value: super::vals::ApDbgenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ApDbgenCtrlWriteprotection,
+                    key: super::vals::ApDbgenCtrlKey,
+                }
+                let proxy = ApDbgenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for invasive (halting) debug enable for domain n's access port."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39341,6 +52448,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ApDbgenStatus {
                 ApDbgenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ApDbgenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApDbgenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApDbgenStatus {
+                    error: bool,
+                }
+                let proxy = ApDbgenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Active shield detector channel enable register."]
@@ -39368,6 +52495,39 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> Chen {
                 Chen(0)
+            }
+        }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 4usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for CRACEN tamper detector enable signal."]
@@ -39427,6 +52587,35 @@ pub mod tampc {
                 CracentampCtrl(0)
             }
         }
+        impl core::fmt::Debug for CracentampCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CracentampCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CracentampCtrl {
+                    value: super::vals::CracentampCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::CracentampCtrlWriteprotection,
+                    key: super::vals::CracentampCtrlKey,
+                }
+                let proxy = CracentampCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for CRACEN tamper detector enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39448,6 +52637,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> CracentampStatus {
                 CracentampStatus(0)
+            }
+        }
+        impl core::fmt::Debug for CracentampStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CracentampStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CracentampStatus {
+                    error: bool,
+                }
+                let proxy = CracentampStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for invasive (halting) debug enable for the local debug components within domain n."]
@@ -39510,6 +52719,35 @@ pub mod tampc {
                 DomainDbgenCtrl(0)
             }
         }
+        impl core::fmt::Debug for DomainDbgenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DomainDbgenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DomainDbgenCtrl {
+                    value: super::vals::DomainDbgenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::DomainDbgenCtrlWriteprotection,
+                    key: super::vals::DomainDbgenCtrlKey,
+                }
+                let proxy = DomainDbgenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for invasive (halting) debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39531,6 +52769,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> DomainDbgenStatus {
                 DomainDbgenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for DomainDbgenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DomainDbgenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DomainDbgenStatus {
+                    error: bool,
+                }
+                let proxy = DomainDbgenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for erase protection."]
@@ -39593,6 +52851,35 @@ pub mod tampc {
                 EraseprotectCtrl(0)
             }
         }
+        impl core::fmt::Debug for EraseprotectCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectCtrl {
+                    value: super::vals::EraseprotectCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::EraseprotectCtrlWriteprotection,
+                    key: super::vals::EraseprotectCtrlKey,
+                }
+                let proxy = EraseprotectCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for eraseprotect."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39614,6 +52901,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> EraseprotectStatus {
                 EraseprotectStatus(0)
+            }
+        }
+        impl core::fmt::Debug for EraseprotectStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectStatus {
+                    error: bool,
+                }
+                let proxy = EraseprotectStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for external tamper reset enable signal."]
@@ -39673,6 +52980,35 @@ pub mod tampc {
                 ExtresetenCtrl(0)
             }
         }
+        impl core::fmt::Debug for ExtresetenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtresetenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtresetenCtrl {
+                    value: super::vals::ExtresetenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ExtresetenCtrlWriteprotection,
+                    key: super::vals::ExtresetenCtrlKey,
+                }
+                let proxy = ExtresetenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for external tamper reset enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39694,6 +53030,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ExtresetenStatus {
                 ExtresetenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ExtresetenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtresetenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtresetenStatus {
+                    error: bool,
+                }
+                let proxy = ExtresetenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for fast domain glitch detectors enable signal."]
@@ -39758,6 +53114,35 @@ pub mod tampc {
                 GlitchfastdomainCtrl(0)
             }
         }
+        impl core::fmt::Debug for GlitchfastdomainCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchfastdomainCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchfastdomainCtrl {
+                    value: super::vals::GlitchfastdomainCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::GlitchfastdomainCtrlWriteprotection,
+                    key: super::vals::GlitchfastdomainCtrlKey,
+                }
+                let proxy = GlitchfastdomainCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for fast domain glitch detectors enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39779,6 +53164,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> GlitchfastdomainStatus {
                 GlitchfastdomainStatus(0)
+            }
+        }
+        impl core::fmt::Debug for GlitchfastdomainStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchfastdomainStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchfastdomainStatus {
+                    error: bool,
+                }
+                let proxy = GlitchfastdomainStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for slow domain glitch detectors enable signal."]
@@ -39843,6 +53248,35 @@ pub mod tampc {
                 GlitchslowdomainCtrl(0)
             }
         }
+        impl core::fmt::Debug for GlitchslowdomainCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchslowdomainCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchslowdomainCtrl {
+                    value: super::vals::GlitchslowdomainCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::GlitchslowdomainCtrlWriteprotection,
+                    key: super::vals::GlitchslowdomainCtrlKey,
+                }
+                let proxy = GlitchslowdomainCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for slow domain glitch detectors enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39864,6 +53298,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> GlitchslowdomainStatus {
                 GlitchslowdomainStatus(0)
+            }
+        }
+        impl core::fmt::Debug for GlitchslowdomainStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchslowdomainStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchslowdomainStatus {
+                    error: bool,
+                }
+                let proxy = GlitchslowdomainStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -39898,6 +53352,29 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tamper", &self.tamper())
+                    .field("writeerror", &self.writeerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tamper: bool,
+                    writeerror: bool,
+                }
+                let proxy = Int {
+                    tamper: self.tamper(),
+                    writeerror: self.writeerror(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for internal tamper reset enable signal."]
@@ -39957,6 +53434,35 @@ pub mod tampc {
                 IntresetenCtrl(0)
             }
         }
+        impl core::fmt::Debug for IntresetenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IntresetenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IntresetenCtrl {
+                    value: super::vals::IntresetenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::IntresetenCtrlWriteprotection,
+                    key: super::vals::IntresetenCtrlKey,
+                }
+                let proxy = IntresetenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for internal tamper reset enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39978,6 +53484,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> IntresetenStatus {
                 IntresetenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for IntresetenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IntresetenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IntresetenStatus {
+                    error: bool,
+                }
+                let proxy = IntresetenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for non-invasive debug enable for the local debug components within domain n."]
@@ -40037,6 +53563,35 @@ pub mod tampc {
                 NidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for NidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NidenCtrl {
+                    value: super::vals::NidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::NidenCtrlWriteprotection,
+                    key: super::vals::NidenCtrlKey,
+                }
+                let proxy = NidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for non-invasive debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40058,6 +53613,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> NidenStatus {
                 NidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for NidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NidenStatus {
+                    error: bool,
+                }
+                let proxy = NidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for secure priviliged invasive (halting) debug enable for the local debug components within domain n."]
@@ -40117,6 +53692,35 @@ pub mod tampc {
                 SpidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for SpidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpidenCtrl {
+                    value: super::vals::SpidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::SpidenCtrlWriteprotection,
+                    key: super::vals::SpidenCtrlKey,
+                }
+                let proxy = SpidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for secure priviliged invasive (halting) debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40138,6 +53742,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> SpidenStatus {
                 SpidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for SpidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpidenStatus {
+                    error: bool,
+                }
+                let proxy = SpidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for secure priviliged non-invasive debug enable for the local debug components within domain n."]
@@ -40197,6 +53821,35 @@ pub mod tampc {
                 SpnidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for SpnidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpnidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpnidenCtrl {
+                    value: super::vals::SpnidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::SpnidenCtrlWriteprotection,
+                    key: super::vals::SpnidenCtrlKey,
+                }
+                let proxy = SpnidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for secure priviliged non-invasive debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40218,6 +53871,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> SpnidenStatus {
                 SpnidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for SpnidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpnidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpnidenStatus {
+                    error: bool,
+                }
+                let proxy = SpnidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The tamper controller status."]
@@ -40295,6 +53968,51 @@ pub mod tampc {
                 TampcStatus(0)
             }
         }
+        impl core::fmt::Debug for TampcStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TampcStatus")
+                    .field("activeshield", &self.activeshield())
+                    .field("protect", &self.protect())
+                    .field("cracentamp", &self.cracentamp())
+                    .field("glitchslowdomain", &[self.glitchslowdomain(0usize)])
+                    .field(
+                        "glitchfastdomain",
+                        &[
+                            self.glitchfastdomain(0usize),
+                            self.glitchfastdomain(1usize),
+                            self.glitchfastdomain(2usize),
+                            self.glitchfastdomain(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TampcStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TampcStatus {
+                    activeshield: bool,
+                    protect: bool,
+                    cracentamp: bool,
+                    glitchslowdomain: [bool; 1usize],
+                    glitchfastdomain: [bool; 4usize],
+                }
+                let proxy = TampcStatus {
+                    activeshield: self.activeshield(),
+                    protect: self.protect(),
+                    cracentamp: self.cracentamp(),
+                    glitchslowdomain: [self.glitchslowdomain(0usize)],
+                    glitchfastdomain: [
+                        self.glitchfastdomain(0usize),
+                        self.glitchfastdomain(1usize),
+                        self.glitchfastdomain(2usize),
+                        self.glitchfastdomain(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -40312,6 +54030,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ActiveshieldCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ActiveshieldCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ActiveshieldCtrlKey {
@@ -40325,7 +54060,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ActiveshieldCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40355,7 +54091,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ActiveshieldCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40414,6 +54151,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ApDbgenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ApDbgenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ApDbgenCtrlKey {
@@ -40427,7 +54181,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ApDbgenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40457,7 +54212,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ApDbgenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40516,6 +54272,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for CracentampCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CracentampCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> CracentampCtrlKey {
@@ -40529,7 +54302,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CracentampCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40559,7 +54333,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CracentampCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40618,6 +54393,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for DomainDbgenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for DomainDbgenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> DomainDbgenCtrlKey {
@@ -40631,7 +54423,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DomainDbgenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40661,7 +54454,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DomainDbgenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40720,6 +54514,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for EraseprotectCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> EraseprotectCtrlKey {
@@ -40733,7 +54544,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EraseprotectCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40763,7 +54575,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EraseprotectCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40822,6 +54635,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ExtresetenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ExtresetenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ExtresetenCtrlKey {
@@ -40835,7 +54665,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtresetenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40865,7 +54696,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtresetenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -40924,6 +54756,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for GlitchfastdomainCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for GlitchfastdomainCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> GlitchfastdomainCtrlKey {
@@ -40937,7 +54786,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchfastdomainCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -40967,7 +54817,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchfastdomainCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41026,6 +54877,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for GlitchslowdomainCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for GlitchslowdomainCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> GlitchslowdomainCtrlKey {
@@ -41039,7 +54907,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchslowdomainCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -41069,7 +54938,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchslowdomainCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41128,6 +54998,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for IntresetenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for IntresetenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> IntresetenCtrlKey {
@@ -41141,7 +55028,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum IntresetenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -41171,7 +55059,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum IntresetenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41230,6 +55119,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for NidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for NidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> NidenCtrlKey {
@@ -41243,7 +55149,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -41273,7 +55180,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41332,6 +55240,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for SpidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for SpidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> SpidenCtrlKey {
@@ -41345,7 +55270,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -41375,7 +55301,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41434,6 +55361,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for SpnidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for SpnidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> SpnidenCtrlKey {
@@ -41447,7 +55391,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpnidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -41477,7 +55422,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpnidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -41632,6 +55578,26 @@ pub mod temp {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -41818,6 +55784,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41845,6 +55831,47 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                            self.compare(6usize),
+                            self.compare(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 8usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                        self.compare(6usize),
+                        self.compare(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41866,6 +55893,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -41891,6 +55934,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41912,6 +55975,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -41956,10 +56039,76 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                            self.compare_clear(6usize),
+                            self.compare_clear(7usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                            self.compare_stop(6usize),
+                            self.compare_stop(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 8usize],
+                    compare_stop: [bool; 8usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                        self.compare_clear(6usize),
+                        self.compare_clear(7usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                        self.compare_stop(6usize),
+                        self.compare_stop(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -41993,7 +56142,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -42300,6 +56450,35 @@ pub mod tpiu {
                 Authstatus(0)
             }
         }
+        impl core::fmt::Debug for Authstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Authstatus")
+                    .field("nsid", &self.nsid())
+                    .field("nsnid", &self.nsnid())
+                    .field("sid", &self.sid())
+                    .field("snid", &self.snid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Authstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Authstatus {
+                    nsid: super::vals::Nsid,
+                    nsnid: super::vals::Nsnid,
+                    sid: super::vals::Sid,
+                    snid: super::vals::Snid,
+                }
+                let proxy = Authstatus {
+                    nsid: self.nsid(),
+                    nsnid: self.nsnid(),
+                    sid: self.sid(),
+                    snid: self.snid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software can use the claim tag to coordinate application and debugger access to trace unit functionality. The claim tags have no effect on the operation of the component. The CLAIMCLR register sets the bits in the claim tag to 0 and determines the current value of the claim tag."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42356,6 +56535,35 @@ pub mod tpiu {
                 Claimclr(0)
             }
         }
+        impl core::fmt::Debug for Claimclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Claimclr")
+                    .field("bit_0", &self.bit_0())
+                    .field("bit_1", &self.bit_1())
+                    .field("bit_2", &self.bit_2())
+                    .field("bit_3", &self.bit_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Claimclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Claimclr {
+                    bit_0: super::vals::ClaimclrBit0,
+                    bit_1: super::vals::ClaimclrBit1,
+                    bit_2: super::vals::ClaimclrBit2,
+                    bit_3: super::vals::ClaimclrBit3,
+                }
+                let proxy = Claimclr {
+                    bit_0: self.bit_0(),
+                    bit_1: self.bit_1(),
+                    bit_2: self.bit_2(),
+                    bit_3: self.bit_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software can use the claim tag to coordinate application and debugger access to trace unit functionality. The claim tags have no effect on the operation of the component. The CLAIMSET register sets bits in the claim tag, and determines the number of claim bits implemented."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42410,6 +56618,35 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Claimset {
                 Claimset(0)
+            }
+        }
+        impl core::fmt::Debug for Claimset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Claimset")
+                    .field("bit_0", &self.bit_0())
+                    .field("bit_1", &self.bit_1())
+                    .field("bit_2", &self.bit_2())
+                    .field("bit_3", &self.bit_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Claimset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Claimset {
+                    bit_0: super::vals::ClaimsetBit0,
+                    bit_1: super::vals::ClaimsetBit1,
+                    bit_2: super::vals::ClaimsetBit2,
+                    bit_3: super::vals::ClaimsetBit3,
+                }
+                let proxy = Claimset {
+                    bit_0: self.bit_0(),
+                    bit_1: self.bit_1(),
+                    bit_2: self.bit_2(),
+                    bit_3: self.bit_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Each bit location is a single port size. One bit can be set, and indicates the current port size."]
@@ -42776,6 +57013,119 @@ pub mod tpiu {
                 Currentportsize(0)
             }
         }
+        impl core::fmt::Debug for Currentportsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentportsize")
+                    .field("port_size_1", &self.port_size_1())
+                    .field("port_size_2", &self.port_size_2())
+                    .field("port_size_3", &self.port_size_3())
+                    .field("port_size_4", &self.port_size_4())
+                    .field("port_size_5", &self.port_size_5())
+                    .field("port_size_6", &self.port_size_6())
+                    .field("port_size_7", &self.port_size_7())
+                    .field("port_size_8", &self.port_size_8())
+                    .field("port_size_9", &self.port_size_9())
+                    .field("port_size_10", &self.port_size_10())
+                    .field("port_size_11", &self.port_size_11())
+                    .field("port_size_12", &self.port_size_12())
+                    .field("port_size_13", &self.port_size_13())
+                    .field("port_size_14", &self.port_size_14())
+                    .field("port_size_15", &self.port_size_15())
+                    .field("port_size_16", &self.port_size_16())
+                    .field("port_size_17", &self.port_size_17())
+                    .field("port_size_18", &self.port_size_18())
+                    .field("port_size_19", &self.port_size_19())
+                    .field("port_size_20", &self.port_size_20())
+                    .field("port_size_21", &self.port_size_21())
+                    .field("port_size_22", &self.port_size_22())
+                    .field("port_size_23", &self.port_size_23())
+                    .field("port_size_24", &self.port_size_24())
+                    .field("port_size_25", &self.port_size_25())
+                    .field("port_size_26", &self.port_size_26())
+                    .field("port_size_27", &self.port_size_27())
+                    .field("port_size_28", &self.port_size_28())
+                    .field("port_size_29", &self.port_size_29())
+                    .field("port_size_30", &self.port_size_30())
+                    .field("port_size_31", &self.port_size_31())
+                    .field("port_size_32", &self.port_size_32())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentportsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentportsize {
+                    port_size_1: bool,
+                    port_size_2: bool,
+                    port_size_3: bool,
+                    port_size_4: bool,
+                    port_size_5: bool,
+                    port_size_6: bool,
+                    port_size_7: bool,
+                    port_size_8: bool,
+                    port_size_9: bool,
+                    port_size_10: bool,
+                    port_size_11: bool,
+                    port_size_12: bool,
+                    port_size_13: bool,
+                    port_size_14: bool,
+                    port_size_15: bool,
+                    port_size_16: bool,
+                    port_size_17: bool,
+                    port_size_18: bool,
+                    port_size_19: bool,
+                    port_size_20: bool,
+                    port_size_21: bool,
+                    port_size_22: bool,
+                    port_size_23: bool,
+                    port_size_24: bool,
+                    port_size_25: bool,
+                    port_size_26: bool,
+                    port_size_27: bool,
+                    port_size_28: bool,
+                    port_size_29: bool,
+                    port_size_30: bool,
+                    port_size_31: bool,
+                    port_size_32: bool,
+                }
+                let proxy = Currentportsize {
+                    port_size_1: self.port_size_1(),
+                    port_size_2: self.port_size_2(),
+                    port_size_3: self.port_size_3(),
+                    port_size_4: self.port_size_4(),
+                    port_size_5: self.port_size_5(),
+                    port_size_6: self.port_size_6(),
+                    port_size_7: self.port_size_7(),
+                    port_size_8: self.port_size_8(),
+                    port_size_9: self.port_size_9(),
+                    port_size_10: self.port_size_10(),
+                    port_size_11: self.port_size_11(),
+                    port_size_12: self.port_size_12(),
+                    port_size_13: self.port_size_13(),
+                    port_size_14: self.port_size_14(),
+                    port_size_15: self.port_size_15(),
+                    port_size_16: self.port_size_16(),
+                    port_size_17: self.port_size_17(),
+                    port_size_18: self.port_size_18(),
+                    port_size_19: self.port_size_19(),
+                    port_size_20: self.port_size_20(),
+                    port_size_21: self.port_size_21(),
+                    port_size_22: self.port_size_22(),
+                    port_size_23: self.port_size_23(),
+                    port_size_24: self.port_size_24(),
+                    port_size_25: self.port_size_25(),
+                    port_size_26: self.port_size_26(),
+                    port_size_27: self.port_size_27(),
+                    port_size_28: self.port_size_28(),
+                    port_size_29: self.port_size_29(),
+                    port_size_30: self.port_size_30(),
+                    port_size_31: self.port_size_31(),
+                    port_size_32: self.port_size_32(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current_test_pattern_mode indicates the current test pattern or mode selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42852,6 +57202,41 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Currenttestpatternmodes {
                 Currenttestpatternmodes(0)
+            }
+        }
+        impl core::fmt::Debug for Currenttestpatternmodes {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currenttestpatternmodes")
+                    .field("patw1", &self.patw1())
+                    .field("patw0", &self.patw0())
+                    .field("pata5", &self.pata5())
+                    .field("patf0", &self.patf0())
+                    .field("ptimeen", &self.ptimeen())
+                    .field("pconten", &self.pconten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currenttestpatternmodes {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currenttestpatternmodes {
+                    patw1: bool,
+                    patw0: bool,
+                    pata5: bool,
+                    patf0: bool,
+                    ptimeen: bool,
+                    pconten: bool,
+                }
+                let proxy = Currenttestpatternmodes {
+                    patw1: self.patw1(),
+                    patw0: self.patw0(),
+                    pata5: self.pata5(),
+                    patf0: self.patf0(),
+                    ptimeen: self.ptimeen(),
+                    pconten: self.pconten(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the capabilities of the component."]
@@ -42932,6 +57317,41 @@ pub mod tpiu {
                 Devid(0)
             }
         }
+        impl core::fmt::Debug for Devid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devid")
+                    .field("muxnum", &self.muxnum())
+                    .field("clkrelat", &self.clkrelat())
+                    .field("fifosize", &self.fifosize())
+                    .field("tclkdata", &self.tclkdata())
+                    .field("swoman", &self.swoman())
+                    .field("swouartnrz", &self.swouartnrz())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devid {
+                    muxnum: u8,
+                    clkrelat: super::vals::Clkrelat,
+                    fifosize: super::vals::Fifosize,
+                    tclkdata: super::vals::Tclkdata,
+                    swoman: bool,
+                    swouartnrz: bool,
+                }
+                let proxy = Devid {
+                    muxnum: self.muxnum(),
+                    clkrelat: self.clkrelat(),
+                    fifosize: self.fifosize(),
+                    tclkdata: self.tclkdata(),
+                    swoman: self.swoman(),
+                    swouartnrz: self.swouartnrz(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The DEVTYPE register provides a debugger with information about the component when the Part Number field is not recognized. The debugger can then report this information."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42964,6 +57384,29 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Devtype {
                 Devtype(0)
+            }
+        }
+        impl core::fmt::Debug for Devtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devtype")
+                    .field("major", &self.major())
+                    .field("sub", &self.sub())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devtype {
+                    major: super::vals::Major,
+                    sub: super::vals::Sub,
+                }
+                let proxy = Devtype {
+                    major: self.major(),
+                    sub: self.sub(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Two ports can be used as a control and feedback mechanism for any serializers, pin sharing multiplexers, or other solutions that might be added to the trace output pins either for pin control or a high-speed trace port solution."]
@@ -43066,6 +57509,47 @@ pub mod tpiu {
                 Extctlinport(0)
             }
         }
+        impl core::fmt::Debug for Extctlinport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extctlinport")
+                    .field("extctlin_0", &self.extctlin_0())
+                    .field("extctlin_1", &self.extctlin_1())
+                    .field("extctlin_2", &self.extctlin_2())
+                    .field("extctlin_3", &self.extctlin_3())
+                    .field("extctlin_4", &self.extctlin_4())
+                    .field("extctlin_5", &self.extctlin_5())
+                    .field("extctlin_6", &self.extctlin_6())
+                    .field("extctlin_7", &self.extctlin_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extctlinport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extctlinport {
+                    extctlin_0: super::vals::Extctlin0,
+                    extctlin_1: super::vals::Extctlin1,
+                    extctlin_2: super::vals::Extctlin2,
+                    extctlin_3: super::vals::Extctlin3,
+                    extctlin_4: super::vals::Extctlin4,
+                    extctlin_5: super::vals::Extctlin5,
+                    extctlin_6: super::vals::Extctlin6,
+                    extctlin_7: super::vals::Extctlin7,
+                }
+                let proxy = Extctlinport {
+                    extctlin_0: self.extctlin_0(),
+                    extctlin_1: self.extctlin_1(),
+                    extctlin_2: self.extctlin_2(),
+                    extctlin_3: self.extctlin_3(),
+                    extctlin_4: self.extctlin_4(),
+                    extctlin_5: self.extctlin_5(),
+                    extctlin_6: self.extctlin_6(),
+                    extctlin_7: self.extctlin_7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Two ports can be used as a control and feedback mechanism for any serializers, pin sharing multiplexers, or other solutions that might be added to the trace output pins either for pin control or a high speed trace port solution. These ports are raw register banks that sample or export the corresponding external pins."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43164,6 +57648,47 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Extctloutport {
                 Extctloutport(0)
+            }
+        }
+        impl core::fmt::Debug for Extctloutport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extctloutport")
+                    .field("extctlout_0", &self.extctlout_0())
+                    .field("extctlout_1", &self.extctlout_1())
+                    .field("extctlout_2", &self.extctlout_2())
+                    .field("extctlout_3", &self.extctlout_3())
+                    .field("extctlout_4", &self.extctlout_4())
+                    .field("extctlout_5", &self.extctlout_5())
+                    .field("extctlout_6", &self.extctlout_6())
+                    .field("extctlout_7", &self.extctlout_7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extctloutport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extctloutport {
+                    extctlout_0: super::vals::Extctlout0,
+                    extctlout_1: super::vals::Extctlout1,
+                    extctlout_2: super::vals::Extctlout2,
+                    extctlout_3: super::vals::Extctlout3,
+                    extctlout_4: super::vals::Extctlout4,
+                    extctlout_5: super::vals::Extctlout5,
+                    extctlout_6: super::vals::Extctlout6,
+                    extctlout_7: super::vals::Extctlout7,
+                }
+                let proxy = Extctloutport {
+                    extctlout_0: self.extctlout_0(),
+                    extctlout_1: self.extctlout_1(),
+                    extctlout_2: self.extctlout_2(),
+                    extctlout_3: self.extctlout_3(),
+                    extctlout_4: self.extctlout_4(),
+                    extctlout_5: self.extctlout_5(),
+                    extctlout_6: self.extctlout_6(),
+                    extctlout_7: self.extctlout_7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The FFCR register controls the generation of stop, trigger, and flush events."]
@@ -43299,6 +57824,56 @@ pub mod tpiu {
                 Ffcr(0)
             }
         }
+        impl core::fmt::Debug for Ffcr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffcr")
+                    .field("enftc", &self.enftc())
+                    .field("enfcont", &self.enfcont())
+                    .field("fonflin", &self.fonflin())
+                    .field("fontrig", &self.fontrig())
+                    .field("fonmanr", &self.fonmanr())
+                    .field("fonmanw", &self.fonmanw())
+                    .field("trigin", &self.trigin())
+                    .field("trigevt", &self.trigevt())
+                    .field("trigfl", &self.trigfl())
+                    .field("stopfl", &self.stopfl())
+                    .field("stoptrig", &self.stoptrig())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffcr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffcr {
+                    enftc: bool,
+                    enfcont: bool,
+                    fonflin: bool,
+                    fontrig: bool,
+                    fonmanr: bool,
+                    fonmanw: bool,
+                    trigin: bool,
+                    trigevt: bool,
+                    trigfl: bool,
+                    stopfl: bool,
+                    stoptrig: bool,
+                }
+                let proxy = Ffcr {
+                    enftc: self.enftc(),
+                    enfcont: self.enfcont(),
+                    fonflin: self.fonflin(),
+                    fontrig: self.fontrig(),
+                    fonmanr: self.fonmanr(),
+                    fonmanw: self.fonmanw(),
+                    trigin: self.trigin(),
+                    trigevt: self.trigevt(),
+                    trigfl: self.trigfl(),
+                    stopfl: self.stopfl(),
+                    stoptrig: self.stoptrig(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The FFSR register indicates the current status of the formatter and flush features available in the TPIU."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43344,6 +57919,32 @@ pub mod tpiu {
                 Ffsr(0)
             }
         }
+        impl core::fmt::Debug for Ffsr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffsr")
+                    .field("flinprog", &self.flinprog())
+                    .field("ftstopped", &self.ftstopped())
+                    .field("tcpresent", &self.tcpresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffsr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffsr {
+                    flinprog: bool,
+                    ftstopped: super::vals::Ftstopped,
+                    tcpresent: bool,
+                }
+                let proxy = Ffsr {
+                    flinprog: self.flinprog(),
+                    ftstopped: self.ftstopped(),
+                    tcpresent: self.tcpresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The FSCR register enables the frequency of synchronization information to be optimized to suit the Trace Port Analyzer (TPA) capture buffer size."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43365,6 +57966,26 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Fscr {
                 Fscr(0)
+            }
+        }
+        impl core::fmt::Debug for Fscr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fscr")
+                    .field("cyccount", &self.cyccount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fscr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fscr {
+                    cyccount: u16,
+                }
+                let proxy = Fscr {
+                    cyccount: self.cyccount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The ITATBCTR0 register captures the values of the atvalids, afreadys, and atbytess inputs to the TPIU. To ensure the integration registers work correctly in a system, the value of atbytess is only valid when atvalids, bit\\[0\\], is HIGH."]
@@ -43412,6 +58033,32 @@ pub mod tpiu {
                 Itatbctr0(0)
             }
         }
+        impl core::fmt::Debug for Itatbctr0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Itatbctr0")
+                    .field("atvalid", &self.atvalid())
+                    .field("afready", &self.afready())
+                    .field("atbytes", &self.atbytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Itatbctr0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Itatbctr0 {
+                    atvalid: super::vals::Atvalid,
+                    afready: super::vals::Afready,
+                    atbytes: super::vals::Atbytes,
+                }
+                let proxy = Itatbctr0 {
+                    atvalid: self.atvalid(),
+                    afready: self.afready(),
+                    atbytes: self.atbytes(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The ITATBCTR1 register contains the value of the atids input to the TPIU. This is only valid when atvalids is HIGH."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43433,6 +58080,24 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Itatbctr1 {
                 Itatbctr1(0)
+            }
+        }
+        impl core::fmt::Debug for Itatbctr1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Itatbctr1")
+                    .field("atid", &self.atid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Itatbctr1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Itatbctr1 {
+                    atid: super::vals::Atid,
+                }
+                let proxy = Itatbctr1 { atid: self.atid() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enables control of the atreadys and afvalids outputs of the TPIU."]
@@ -43467,6 +58132,29 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Itatbctr2 {
                 Itatbctr2(0)
+            }
+        }
+        impl core::fmt::Debug for Itatbctr2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Itatbctr2")
+                    .field("atready", &self.atready())
+                    .field("afvalid", &self.afvalid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Itatbctr2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Itatbctr2 {
+                    atready: super::vals::Atready,
+                    afvalid: super::vals::Afvalid,
+                }
+                let proxy = Itatbctr2 {
+                    atready: self.atready(),
+                    afvalid: self.afvalid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The ITATBDATA0 register contains the value of the atdatas inputs to the TPIU. The values are valid only when atvalids is HIGH."]
@@ -43536,6 +58224,38 @@ pub mod tpiu {
                 Itatbdata0(0)
             }
         }
+        impl core::fmt::Debug for Itatbdata0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Itatbdata0")
+                    .field("atdata_0", &self.atdata_0())
+                    .field("atdata_1", &self.atdata_1())
+                    .field("atdata_2", &self.atdata_2())
+                    .field("atdata_3", &self.atdata_3())
+                    .field("atdata_4", &self.atdata_4())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Itatbdata0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Itatbdata0 {
+                    atdata_0: super::vals::Atdata0,
+                    atdata_1: super::vals::Atdata1,
+                    atdata_2: super::vals::Atdata2,
+                    atdata_3: super::vals::Atdata3,
+                    atdata_4: super::vals::Atdata4,
+                }
+                let proxy = Itatbdata0 {
+                    atdata_0: self.atdata_0(),
+                    atdata_1: self.atdata_1(),
+                    atdata_2: self.atdata_2(),
+                    atdata_3: self.atdata_3(),
+                    atdata_4: self.atdata_4(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Used to enable topology detection. This register enables the component to switch from a functional mode, the default behavior, to integration mode where the inputs and outputs of the component can be directly controlled for integration testing and topology solving."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43557,6 +58277,26 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Itctrl {
                 Itctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Itctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Itctrl")
+                    .field("integrationmode", &self.integrationmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Itctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Itctrl {
+                    integrationmode: bool,
+                }
+                let proxy = Itctrl {
+                    integrationmode: self.integrationmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The ITTRFLIN register contains the values of the flushin and trigin inputs to the TPIU."]
@@ -43593,6 +58333,29 @@ pub mod tpiu {
                 Ittrflin(0)
             }
         }
+        impl core::fmt::Debug for Ittrflin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ittrflin")
+                    .field("trigin", &self.trigin())
+                    .field("flushin", &self.flushin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ittrflin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ittrflin {
+                    trigin: super::vals::IttrflinTrigin,
+                    flushin: super::vals::Flushin,
+                }
+                let proxy = Ittrflin {
+                    trigin: self.trigin(),
+                    flushin: self.flushin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The ITTRFLINACK register enables control of the triginack and flushinack outputs from the TPIU."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43627,6 +58390,29 @@ pub mod tpiu {
                 Ittrflinack(0)
             }
         }
+        impl core::fmt::Debug for Ittrflinack {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ittrflinack")
+                    .field("triginack", &self.triginack())
+                    .field("flushinack", &self.flushinack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ittrflinack {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ittrflinack {
+                    triginack: super::vals::Triginack,
+                    flushinack: super::vals::Flushinack,
+                }
+                let proxy = Ittrflinack {
+                    triginack: self.triginack(),
+                    flushinack: self.flushinack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This is used to enable write access to device registers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43649,6 +58435,26 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Lar {
                 Lar(0)
+            }
+        }
+        impl core::fmt::Debug for Lar {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lar")
+                    .field("access", &self.access())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lar {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lar {
+                    access: super::vals::Access,
+                }
+                let proxy = Lar {
+                    access: self.access(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "This indicates the status of the lock control mechanism. This lock prevents accidental writes by code under debug. Accesses to the extended stimulus port registers are not affected by the lock mechanism. This register must always be present although there might not be any lock access control mechanism. The lock mechanism, where present and locked, must block write accesses to any control register, except the Lock Access Register. For most components this covers all registers except for the Lock Access Register."]
@@ -43694,6 +58500,32 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Lsr {
                 Lsr(0)
+            }
+        }
+        impl core::fmt::Debug for Lsr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lsr")
+                    .field("present", &self.present())
+                    .field("locked", &self.locked())
+                    .field("type_", &self.type_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lsr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lsr {
+                    present: bool,
+                    locked: bool,
+                    type_: super::vals::Type,
+                }
+                let proxy = Lsr {
+                    present: self.present(),
+                    locked: self.locked(),
+                    type_: self.type_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Each bit location is a single port size that is supported on the device."]
@@ -44060,6 +58892,119 @@ pub mod tpiu {
                 Supportedportsizes(0)
             }
         }
+        impl core::fmt::Debug for Supportedportsizes {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Supportedportsizes")
+                    .field("port_size_1", &self.port_size_1())
+                    .field("port_size_2", &self.port_size_2())
+                    .field("port_size_3", &self.port_size_3())
+                    .field("port_size_4", &self.port_size_4())
+                    .field("port_size_5", &self.port_size_5())
+                    .field("port_size_6", &self.port_size_6())
+                    .field("port_size_7", &self.port_size_7())
+                    .field("port_size_8", &self.port_size_8())
+                    .field("port_size_9", &self.port_size_9())
+                    .field("port_size_10", &self.port_size_10())
+                    .field("port_size_11", &self.port_size_11())
+                    .field("port_size_12", &self.port_size_12())
+                    .field("port_size_13", &self.port_size_13())
+                    .field("port_size_14", &self.port_size_14())
+                    .field("port_size_15", &self.port_size_15())
+                    .field("port_size_16", &self.port_size_16())
+                    .field("port_size_17", &self.port_size_17())
+                    .field("port_size_18", &self.port_size_18())
+                    .field("port_size_19", &self.port_size_19())
+                    .field("port_size_20", &self.port_size_20())
+                    .field("port_size_21", &self.port_size_21())
+                    .field("port_size_22", &self.port_size_22())
+                    .field("port_size_23", &self.port_size_23())
+                    .field("port_size_24", &self.port_size_24())
+                    .field("port_size_25", &self.port_size_25())
+                    .field("port_size_26", &self.port_size_26())
+                    .field("port_size_27", &self.port_size_27())
+                    .field("port_size_28", &self.port_size_28())
+                    .field("port_size_29", &self.port_size_29())
+                    .field("port_size_30", &self.port_size_30())
+                    .field("port_size_31", &self.port_size_31())
+                    .field("port_size_32", &self.port_size_32())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Supportedportsizes {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Supportedportsizes {
+                    port_size_1: bool,
+                    port_size_2: bool,
+                    port_size_3: bool,
+                    port_size_4: bool,
+                    port_size_5: bool,
+                    port_size_6: bool,
+                    port_size_7: bool,
+                    port_size_8: bool,
+                    port_size_9: bool,
+                    port_size_10: bool,
+                    port_size_11: bool,
+                    port_size_12: bool,
+                    port_size_13: bool,
+                    port_size_14: bool,
+                    port_size_15: bool,
+                    port_size_16: bool,
+                    port_size_17: bool,
+                    port_size_18: bool,
+                    port_size_19: bool,
+                    port_size_20: bool,
+                    port_size_21: bool,
+                    port_size_22: bool,
+                    port_size_23: bool,
+                    port_size_24: bool,
+                    port_size_25: bool,
+                    port_size_26: bool,
+                    port_size_27: bool,
+                    port_size_28: bool,
+                    port_size_29: bool,
+                    port_size_30: bool,
+                    port_size_31: bool,
+                    port_size_32: bool,
+                }
+                let proxy = Supportedportsizes {
+                    port_size_1: self.port_size_1(),
+                    port_size_2: self.port_size_2(),
+                    port_size_3: self.port_size_3(),
+                    port_size_4: self.port_size_4(),
+                    port_size_5: self.port_size_5(),
+                    port_size_6: self.port_size_6(),
+                    port_size_7: self.port_size_7(),
+                    port_size_8: self.port_size_8(),
+                    port_size_9: self.port_size_9(),
+                    port_size_10: self.port_size_10(),
+                    port_size_11: self.port_size_11(),
+                    port_size_12: self.port_size_12(),
+                    port_size_13: self.port_size_13(),
+                    port_size_14: self.port_size_14(),
+                    port_size_15: self.port_size_15(),
+                    port_size_16: self.port_size_16(),
+                    port_size_17: self.port_size_17(),
+                    port_size_18: self.port_size_18(),
+                    port_size_19: self.port_size_19(),
+                    port_size_20: self.port_size_20(),
+                    port_size_21: self.port_size_21(),
+                    port_size_22: self.port_size_22(),
+                    port_size_23: self.port_size_23(),
+                    port_size_24: self.port_size_24(),
+                    port_size_25: self.port_size_25(),
+                    port_size_26: self.port_size_26(),
+                    port_size_27: self.port_size_27(),
+                    port_size_28: self.port_size_28(),
+                    port_size_29: self.port_size_29(),
+                    port_size_30: self.port_size_30(),
+                    port_size_31: self.port_size_31(),
+                    port_size_32: self.port_size_32(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The Supported_trigger_modes register indicates the implemented trigger counter multipliers and other supported features of the trigger system."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44160,6 +59105,47 @@ pub mod tpiu {
                 Supportedtriggermodes(0)
             }
         }
+        impl core::fmt::Debug for Supportedtriggermodes {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Supportedtriggermodes")
+                    .field("mult_0", &self.mult_0())
+                    .field("mult_1", &self.mult_1())
+                    .field("mult_2", &self.mult_2())
+                    .field("mult_3", &self.mult_3())
+                    .field("mult_4", &self.mult_4())
+                    .field("tcount8", &self.tcount8())
+                    .field("triggered", &self.triggered())
+                    .field("trgrun", &self.trgrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Supportedtriggermodes {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Supportedtriggermodes {
+                    mult_0: bool,
+                    mult_1: bool,
+                    mult_2: bool,
+                    mult_3: bool,
+                    mult_4: bool,
+                    tcount8: bool,
+                    triggered: bool,
+                    trgrun: bool,
+                }
+                let proxy = Supportedtriggermodes {
+                    mult_0: self.mult_0(),
+                    mult_1: self.mult_1(),
+                    mult_2: self.mult_2(),
+                    mult_3: self.mult_3(),
+                    mult_4: self.mult_4(),
+                    tcount8: self.tcount8(),
+                    triggered: self.triggered(),
+                    trgrun: self.trgrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The Supported_test_pattern_modes register provides a set of known bit sequences or patterns that can be output over the trace port and can be detected by the TPA or other associated trace capture device."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44238,6 +59224,41 @@ pub mod tpiu {
                 Suppportedtestpatternmodes(0)
             }
         }
+        impl core::fmt::Debug for Suppportedtestpatternmodes {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Suppportedtestpatternmodes")
+                    .field("patw1", &self.patw1())
+                    .field("patw0", &self.patw0())
+                    .field("pata5", &self.pata5())
+                    .field("patf0", &self.patf0())
+                    .field("ptimeen", &self.ptimeen())
+                    .field("pconten", &self.pconten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Suppportedtestpatternmodes {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Suppportedtestpatternmodes {
+                    patw1: bool,
+                    patw0: bool,
+                    pata5: bool,
+                    patf0: bool,
+                    ptimeen: bool,
+                    pconten: bool,
+                }
+                let proxy = Suppportedtestpatternmodes {
+                    patw1: self.patw1(),
+                    patw0: self.patw0(),
+                    pata5: self.pata5(),
+                    patf0: self.patf0(),
+                    ptimeen: self.ptimeen(),
+                    pconten: self.pconten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The TPRCR register is an 8-bit counter start value that is decremented. A write sets the initial counter value and a read returns the programmed value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44261,6 +59282,26 @@ pub mod tpiu {
                 Tprcr(0)
             }
         }
+        impl core::fmt::Debug for Tprcr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tprcr")
+                    .field("pattcount", &self.pattcount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tprcr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tprcr {
+                    pattcount: u8,
+                }
+                let proxy = Tprcr {
+                    pattcount: self.pattcount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The Trigger_counter_value register enables delaying the indication of triggers to any external connected trace capture or storage devices."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44282,6 +59323,26 @@ pub mod tpiu {
             #[inline(always)]
             fn default() -> Triggercountervalue {
                 Triggercountervalue(0)
+            }
+        }
+        impl core::fmt::Debug for Triggercountervalue {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Triggercountervalue")
+                    .field("trig_count", &self.trig_count())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Triggercountervalue {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Triggercountervalue {
+                    trig_count: u8,
+                }
+                let proxy = Triggercountervalue {
+                    trig_count: self.trig_count(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The Trigger_multiplier register contains the selectors for the trigger counter multiplier."]
@@ -44351,6 +59412,38 @@ pub mod tpiu {
                 Triggermultiplier(0)
             }
         }
+        impl core::fmt::Debug for Triggermultiplier {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Triggermultiplier")
+                    .field("mult_0", &self.mult_0())
+                    .field("mult_1", &self.mult_1())
+                    .field("mult_2", &self.mult_2())
+                    .field("mult_3", &self.mult_3())
+                    .field("mult_4", &self.mult_4())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Triggermultiplier {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Triggermultiplier {
+                    mult_0: bool,
+                    mult_1: bool,
+                    mult_2: bool,
+                    mult_3: bool,
+                    mult_4: bool,
+                }
+                let proxy = Triggermultiplier {
+                    mult_0: self.mult_0(),
+                    mult_1: self.mult_1(),
+                    mult_2: self.mult_2(),
+                    mult_3: self.mult_3(),
+                    mult_4: self.mult_4(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -44368,6 +59461,23 @@ pub mod tpiu {
                 self.0
             }
         }
+        impl core::fmt::Debug for Access {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xc5ac_ce55 => f.write_str("UN_LOCK"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Access {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xc5ac_ce55 => defmt::write!(f, "UN_LOCK"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Access {
             #[inline(always)]
             fn from(val: u32) -> Access {
@@ -44381,7 +59491,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Afready {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44411,7 +59522,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Afvalid {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44441,7 +59553,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atbytes {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44473,7 +59586,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atdata0 {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44503,7 +59617,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atdata1 {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44533,7 +59648,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atdata2 {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44563,7 +59679,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atdata3 {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44593,7 +59710,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atdata4 {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44639,6 +59757,25 @@ pub mod tpiu {
                 self.0
             }
         }
+        impl core::fmt::Debug for Atid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("LOW"),
+                    0x01 => f.write_str("HIGH"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Atid {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "LOW"),
+                    0x01 => defmt::write!(f, "HIGH"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Atid {
             #[inline(always)]
             fn from(val: u8) -> Atid {
@@ -44652,7 +59789,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atready {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44682,7 +59820,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Atvalid {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -44712,7 +59851,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimclrBit0 {
             #[doc = "Claim bit 0 is not set."]
             CLEARED = 0x0,
@@ -44742,7 +59882,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimclrBit1 {
             #[doc = "Claim bit 1 is not set."]
             CLEARED = 0x0,
@@ -44772,7 +59913,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimclrBit2 {
             #[doc = "Claim bit 2 is not set."]
             CLEARED = 0x0,
@@ -44802,7 +59944,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimclrBit3 {
             #[doc = "Claim bit 3 is not set."]
             CLEARED = 0x0,
@@ -44832,7 +59975,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimsetBit0 {
             #[doc = "Claim bit 0 is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -44862,7 +60006,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimsetBit1 {
             #[doc = "Claim bit 1 is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -44892,7 +60037,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimsetBit2 {
             #[doc = "Claim bit 2 is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -44922,7 +60068,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ClaimsetBit3 {
             #[doc = "Claim bit 3 is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -44952,7 +60099,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clkrelat {
             #[doc = "atclk and traceclkin are synchronous."]
             SYNCHRONOUS = 0x0,
@@ -44982,7 +60130,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin0 {
             #[doc = "Input EXTCTL0 is low."]
             LOW = 0x0,
@@ -45012,7 +60161,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin1 {
             #[doc = "Input EXTCTL1 is low."]
             LOW = 0x0,
@@ -45042,7 +60192,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin2 {
             #[doc = "Input EXTCTL2 is low."]
             LOW = 0x0,
@@ -45072,7 +60223,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin3 {
             #[doc = "Input EXTCTL3 is low."]
             LOW = 0x0,
@@ -45102,7 +60254,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin4 {
             #[doc = "Input EXTCTL4 is low."]
             LOW = 0x0,
@@ -45132,7 +60285,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin5 {
             #[doc = "Input EXTCTL5 is low."]
             LOW = 0x0,
@@ -45162,7 +60316,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin6 {
             #[doc = "Input EXTCTL6 is low."]
             LOW = 0x0,
@@ -45192,7 +60347,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlin7 {
             #[doc = "Input EXTCTL7 is low."]
             LOW = 0x0,
@@ -45222,7 +60378,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout0 {
             #[doc = "Output EXTCTL0 is low."]
             LOW = 0x0,
@@ -45252,7 +60409,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout1 {
             #[doc = "Output EXTCTL1 is low."]
             LOW = 0x0,
@@ -45282,7 +60440,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout2 {
             #[doc = "Output EXTCTL2 is low."]
             LOW = 0x0,
@@ -45312,7 +60471,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout3 {
             #[doc = "Output EXTCTL3 is low."]
             LOW = 0x0,
@@ -45342,7 +60502,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout4 {
             #[doc = "Output EXTCTL4 is low."]
             LOW = 0x0,
@@ -45372,7 +60533,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout5 {
             #[doc = "Output EXTCTL5 is low."]
             LOW = 0x0,
@@ -45402,7 +60564,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout6 {
             #[doc = "Output EXTCTL6 is low."]
             LOW = 0x0,
@@ -45432,7 +60595,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Extctlout7 {
             #[doc = "Output EXTCTL7 is low."]
             LOW = 0x0,
@@ -45462,7 +60626,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Fifosize {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -45497,7 +60662,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Flushin {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -45527,7 +60693,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Flushinack {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -45557,7 +60724,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ftstopped {
             #[doc = "Formatter has not stopped."]
             RUNNING = 0x0,
@@ -45587,7 +60755,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum IttrflinTrigin {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -45617,7 +60786,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Major {
             _RESERVED_0 = 0x0,
             #[doc = "Peripheral is a trace sink."]
@@ -45660,7 +60830,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nsid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -45692,7 +60863,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nsnid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -45724,7 +60896,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -45756,7 +60929,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Snid {
             #[doc = "The feature is not implemented."]
             NOT_IMPLEMENTED = 0x0,
@@ -45788,7 +60962,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sub {
             _RESERVED_0 = 0x0,
             #[doc = "Indicates that this component is a trace port component."]
@@ -45831,7 +61006,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tclkdata {
             #[doc = "Trace clock and data is supported."]
             SUPPORTED = 0x0,
@@ -45861,7 +61037,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Triginack {
             #[doc = "Pin is logic 0."]
             LOW = 0x0,
@@ -45891,7 +61068,8 @@ pub mod tpiu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Type {
             #[doc = "This component implements a 32-bit Lock Access Register."]
             BITS32 = 0x0,
@@ -46714,6 +61892,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -46818,6 +62016,47 @@ pub mod twim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = Config {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -46839,6 +62078,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -46886,6 +62145,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -46908,6 +62193,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -47087,6 +62392,68 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -47108,6 +62475,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -47133,6 +62520,26 @@ pub mod twim {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -47152,6 +62559,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -47309,6 +62736,86 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_dma_rx_start", &self.lasttx_dma_rx_start())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_dma_tx_start", &self.lastrx_dma_tx_start())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_dma_rx_start: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_dma_tx_start: bool,
+                    lastrx_stop: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_dma_rx_start: self.lasttx_dma_rx_start(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_dma_tx_start: self.lastrx_dma_tx_start(),
+                    lastrx_stop: self.lastrx_stop(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -47330,6 +62837,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -47355,6 +62882,26 @@ pub mod twim {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -47376,10 +62923,31 @@ pub mod twim {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -47441,6 +63009,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -47454,7 +63043,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -47484,7 +63074,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -47514,7 +63105,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -47544,7 +63136,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -48301,6 +63894,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48322,6 +63935,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -48367,6 +64000,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -48535,6 +64194,65 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    write: bool,
+                    read: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    write: self.write(),
+                    read: self.read(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48639,6 +64357,47 @@ pub mod twis {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48660,6 +64419,22 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -48685,6 +64460,26 @@ pub mod twis {
                 RxAmount(0)
             }
         }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48708,6 +64503,26 @@ pub mod twis {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48727,6 +64542,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -48851,6 +64686,77 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48885,6 +64791,29 @@ pub mod twis {
                 TwisConfig(0)
             }
         }
+        impl core::fmt::Debug for TwisConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TwisConfig")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TwisConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TwisConfig {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = TwisConfig {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48906,6 +64835,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TwisMatch {
                 TwisMatch(0)
+            }
+        }
+        impl core::fmt::Debug for TwisMatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TwisMatch")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TwisMatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TwisMatch {
+                    match_: bool,
+                }
+                let proxy = TwisMatch {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -48931,6 +64880,26 @@ pub mod twis {
                 TxAmount(0)
             }
         }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48954,6 +64923,26 @@ pub mod twis {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -48975,10 +64964,31 @@ pub mod twis {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -49022,7 +65032,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -49052,7 +65063,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -49082,7 +65094,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -49112,7 +65125,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -49969,6 +65983,26 @@ pub mod uarte {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Baud rate. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -49993,6 +66027,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50014,6 +66068,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -50072,6 +66146,35 @@ pub mod uarte {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set the number of UARTE bits to count before triggering packet timeout."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50093,6 +66196,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Frametimeout {
                 Frametimeout(0)
+            }
+        }
+        impl core::fmt::Debug for Frametimeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frametimeout")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frametimeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frametimeout {
+                    countertop: u16,
+                }
+                let proxy = Frametimeout {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -50305,6 +66428,77 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("txstopped", &self.txstopped())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .field("frametimeout", &self.frametimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    txdrdy: bool,
+                    rxdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                    txstopped: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                    frametimeout: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    txdrdy: self.txdrdy(),
+                    rxdrdy: self.rxdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    txstopped: self.txstopped(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                    frametimeout: self.frametimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50409,6 +66603,47 @@ pub mod uarte {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50430,6 +66665,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -50455,6 +66710,26 @@ pub mod uarte {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50474,6 +66749,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -50620,6 +66915,83 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("dma_rx_end_dma_rx_start", &self.dma_rx_end_dma_rx_start())
+                    .field("dma_rx_end_dma_rx_stop", &self.dma_rx_end_dma_rx_stop())
+                    .field("dma_tx_end_dma_tx_stop", &self.dma_tx_end_dma_tx_stop())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .field("frametimeout_dma_rx_stop", &self.frametimeout_dma_rx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    dma_rx_end_dma_rx_start: bool,
+                    dma_rx_end_dma_rx_stop: bool,
+                    dma_tx_end_dma_tx_stop: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                    frametimeout_dma_rx_stop: bool,
+                }
+                let proxy = Shorts {
+                    dma_rx_end_dma_rx_start: self.dma_rx_end_dma_rx_start(),
+                    dma_rx_end_dma_rx_stop: self.dma_rx_end_dma_rx_stop(),
+                    dma_tx_end_dma_tx_stop: self.dma_tx_end_dma_tx_stop(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                    frametimeout_dma_rx_stop: self.frametimeout_dma_rx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50641,6 +67013,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -50666,6 +67058,26 @@ pub mod uarte {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -50685,6 +67097,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxTerminateonbuserror {
                 TxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of parity, hardware flow control, framesize, and packet timeout."]
@@ -50777,6 +67209,44 @@ pub mod uarte {
                 UarteConfig(0)
             }
         }
+        impl core::fmt::Debug for UarteConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("UarteConfig")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .field("framesize", &self.framesize())
+                    .field("endian", &self.endian())
+                    .field("frametimeout", &self.frametimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for UarteConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct UarteConfig {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::ConfigStop,
+                    paritytype: super::vals::Paritytype,
+                    framesize: super::vals::Framesize,
+                    endian: super::vals::Endian,
+                    frametimeout: bool,
+                }
+                let proxy = UarteConfig {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                    framesize: self.framesize(),
+                    endian: self.endian(),
+                    frametimeout: self.frametimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -50828,6 +67298,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -50841,7 +67362,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -50877,7 +67399,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigStop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -50907,7 +67430,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -50951,7 +67475,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Data is trimmed from MSB end."]
             MSB = 0x0,
@@ -50981,7 +67506,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framesize {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -51029,7 +67555,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -51059,7 +67586,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -51089,7 +67617,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -51119,7 +67648,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -51149,7 +67679,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -51500,6 +68031,24 @@ pub mod uicr {
                 ApprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for ApprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectProtect0 {
+                    pall: super::vals::ApprotectProtect0Pall,
+                }
+                let proxy = ApprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51520,6 +68069,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> ApprotectProtect1 {
                 ApprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for ApprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectProtect1 {
+                    pall: super::vals::ApprotectProtect1Pall,
+                }
+                let proxy = ApprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Revocation status for RoT authenticated operation public key generation \\[n\\]."]
@@ -51546,6 +68113,26 @@ pub mod uicr {
                 AuthopkeyRevoke(0)
             }
         }
+        impl core::fmt::Debug for AuthopkeyRevoke {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuthopkeyRevoke")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuthopkeyRevoke {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuthopkeyRevoke {
+                    status: super::vals::AuthopkeyRevokeStatus,
+                }
+                let proxy = AuthopkeyRevoke {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51568,6 +68155,24 @@ pub mod uicr {
                 AuxapprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for AuxapprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuxapprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuxapprotectProtect0 {
+                    pall: super::vals::AuxapprotectProtect0Pall,
+                }
+                let proxy = AuxapprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51588,6 +68193,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> AuxapprotectProtect1 {
                 AuxapprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for AuxapprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuxapprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuxapprotectProtect1 {
+                    pall: super::vals::AuxapprotectProtect1Pall,
+                }
+                let proxy = AuxapprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Immutable boot region configuration."]
@@ -51679,6 +68302,44 @@ pub mod uicr {
                 Bootconf(0)
             }
         }
+        impl core::fmt::Debug for Bootconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bootconf")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("writeonce", &self.writeonce())
+                    .field("lock", &self.lock())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bootconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bootconf {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    writeonce: bool,
+                    lock: bool,
+                    size: u8,
+                }
+                let proxy = Bootconf {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    writeonce: self.writeonce(),
+                    lock: self.lock(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51701,6 +68362,24 @@ pub mod uicr {
                 EraseprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for EraseprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectProtect0 {
+                    pall: super::vals::EraseprotectProtect0Pall,
+                }
+                let proxy = EraseprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51721,6 +68400,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> EraseprotectProtect1 {
                 EraseprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for EraseprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectProtect1 {
+                    pall: super::vals::EraseprotectProtect1Pall,
+                }
+                let proxy = EraseprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Revocation status for RoT public key generation \\[n\\]."]
@@ -51747,6 +68444,26 @@ pub mod uicr {
                 PubkeyRevoke(0)
             }
         }
+        impl core::fmt::Debug for PubkeyRevoke {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PubkeyRevoke")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PubkeyRevoke {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PubkeyRevoke {
+                    status: super::vals::PubkeyRevokeStatus,
+                }
+                let proxy = PubkeyRevoke {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -51767,6 +68484,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> SecureapprotectProtect0 {
                 SecureapprotectProtect0(0)
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectProtect0 {
+                    pall: super::vals::SecureapprotectProtect0Pall,
+                }
+                let proxy = SecureapprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access port protection register"]
@@ -51791,6 +68526,24 @@ pub mod uicr {
                 SecureapprotectProtect1(0)
             }
         }
+        impl core::fmt::Debug for SecureapprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectProtect1 {
+                    pall: super::vals::SecureapprotectProtect1Pall,
+                }
+                let proxy = SecureapprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -51806,6 +68559,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectProtect0Pall {
@@ -51835,6 +68605,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for ApprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for ApprotectProtect1Pall {
             #[inline(always)]
             fn from(val: u32) -> ApprotectProtect1Pall {
@@ -51860,6 +68647,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for AuthopkeyRevokeStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("NOT_REVOKED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuthopkeyRevokeStatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "NOT_REVOKED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for AuthopkeyRevokeStatus {
@@ -51889,6 +68693,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for AuxapprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for AuxapprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> AuxapprotectProtect0Pall {
@@ -51914,6 +68735,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for AuxapprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for AuxapprotectProtect1Pall {
@@ -51943,6 +68781,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for EraseprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> EraseprotectProtect0Pall {
@@ -51968,6 +68823,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for EraseprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for EraseprotectProtect1Pall {
@@ -51997,6 +68869,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for PubkeyRevokeStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("NOT_REVOKED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PubkeyRevokeStatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "NOT_REVOKED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for PubkeyRevokeStatus {
             #[inline(always)]
             fn from(val: u32) -> PubkeyRevokeStatus {
@@ -52024,6 +68913,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for SecureapprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for SecureapprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> SecureapprotectProtect0Pall {
@@ -52049,6 +68955,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for SecureapprotectProtect1Pall {
@@ -52342,6 +69265,29 @@ pub mod vpr {
                 Abstractauto(0)
             }
         }
+        impl core::fmt::Debug for Abstractauto {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractauto")
+                    .field("autoexecdata", &self.autoexecdata())
+                    .field("autoexecprogbuf", &self.autoexecprogbuf())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractauto {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractauto {
+                    autoexecdata: u16,
+                    autoexecprogbuf: u16,
+                }
+                let proxy = Abstractauto {
+                    autoexecdata: self.autoexecdata(),
+                    autoexecprogbuf: self.autoexecprogbuf(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Abstract command"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -52376,6 +69322,29 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Abstractcmd {
                 Abstractcmd(0)
+            }
+        }
+        impl core::fmt::Debug for Abstractcmd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractcmd")
+                    .field("control", &self.control())
+                    .field("cmdtype", &self.cmdtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractcmd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractcmd {
+                    control: u32,
+                    cmdtype: super::vals::Cmdtype,
+                }
+                let proxy = Abstractcmd {
+                    control: self.control(),
+                    cmdtype: self.cmdtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Abstract Control and Status"]
@@ -52434,6 +69403,35 @@ pub mod vpr {
                 Abstractcs(0)
             }
         }
+        impl core::fmt::Debug for Abstractcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractcs")
+                    .field("datacount", &self.datacount())
+                    .field("cmderr", &self.cmderr())
+                    .field("busy", &self.busy())
+                    .field("progbufsize", &self.progbufsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractcs {
+                    datacount: u8,
+                    cmderr: super::vals::Cmderr,
+                    busy: bool,
+                    progbufsize: u8,
+                }
+                let proxy = Abstractcs {
+                    datacount: self.datacount(),
+                    cmderr: self.cmderr(),
+                    busy: self.busy(),
+                    progbufsize: self.progbufsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State of the CPU after a core reset"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -52455,6 +69453,22 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Cpurun {
                 Cpurun(0)
+            }
+        }
+        impl core::fmt::Debug for Cpurun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cpurun").field("en", &self.en()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpurun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cpurun {
+                    en: super::vals::CpurunEn,
+                }
+                let proxy = Cpurun { en: self.en() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Debug Module Control"]
@@ -52592,6 +69606,56 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Dmcontrol {
                 Dmcontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Dmcontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dmcontrol")
+                    .field("dmactive", &self.dmactive())
+                    .field("ndmreset", &self.ndmreset())
+                    .field("clrresethaltreq", &self.clrresethaltreq())
+                    .field("setresethaltreq", &self.setresethaltreq())
+                    .field("hartselhi", &self.hartselhi())
+                    .field("hartsello", &self.hartsello())
+                    .field("hasel", &self.hasel())
+                    .field("ackhavereset", &self.ackhavereset())
+                    .field("hartreset", &self.hartreset())
+                    .field("resumereq", &self.resumereq())
+                    .field("haltreq", &self.haltreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dmcontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dmcontrol {
+                    dmactive: bool,
+                    ndmreset: bool,
+                    clrresethaltreq: super::vals::Clrresethaltreq,
+                    setresethaltreq: super::vals::Setresethaltreq,
+                    hartselhi: u16,
+                    hartsello: u16,
+                    hasel: super::vals::Hasel,
+                    ackhavereset: super::vals::Ackhavereset,
+                    hartreset: bool,
+                    resumereq: super::vals::Resumereq,
+                    haltreq: super::vals::Haltreq,
+                }
+                let proxy = Dmcontrol {
+                    dmactive: self.dmactive(),
+                    ndmreset: self.ndmreset(),
+                    clrresethaltreq: self.clrresethaltreq(),
+                    setresethaltreq: self.setresethaltreq(),
+                    hartselhi: self.hartselhi(),
+                    hartsello: self.hartsello(),
+                    hasel: self.hasel(),
+                    ackhavereset: self.ackhavereset(),
+                    hartreset: self.hartreset(),
+                    resumereq: self.resumereq(),
+                    haltreq: self.haltreq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Debug Module Status"]
@@ -52804,6 +69868,77 @@ pub mod vpr {
                 Dmstatus(0)
             }
         }
+        impl core::fmt::Debug for Dmstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dmstatus")
+                    .field("version", &self.version())
+                    .field("confstrptrvalid", &self.confstrptrvalid())
+                    .field("hasresethaltreq", &self.hasresethaltreq())
+                    .field("authbusy", &self.authbusy())
+                    .field("authenticated", &self.authenticated())
+                    .field("anyhalted", &self.anyhalted())
+                    .field("allhalted", &self.allhalted())
+                    .field("anyrunning", &self.anyrunning())
+                    .field("allrunning", &self.allrunning())
+                    .field("anyunavail", &self.anyunavail())
+                    .field("allunavail", &self.allunavail())
+                    .field("anynonexistent", &self.anynonexistent())
+                    .field("allnonexistent", &self.allnonexistent())
+                    .field("anyresumeack", &self.anyresumeack())
+                    .field("allresumeack", &self.allresumeack())
+                    .field("anyhavereset", &self.anyhavereset())
+                    .field("allhavereset", &self.allhavereset())
+                    .field("impebreak", &self.impebreak())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dmstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dmstatus {
+                    version: super::vals::Version,
+                    confstrptrvalid: super::vals::Confstrptrvalid,
+                    hasresethaltreq: bool,
+                    authbusy: bool,
+                    authenticated: bool,
+                    anyhalted: bool,
+                    allhalted: bool,
+                    anyrunning: bool,
+                    allrunning: bool,
+                    anyunavail: bool,
+                    allunavail: bool,
+                    anynonexistent: bool,
+                    allnonexistent: bool,
+                    anyresumeack: bool,
+                    allresumeack: bool,
+                    anyhavereset: bool,
+                    allhavereset: bool,
+                    impebreak: bool,
+                }
+                let proxy = Dmstatus {
+                    version: self.version(),
+                    confstrptrvalid: self.confstrptrvalid(),
+                    hasresethaltreq: self.hasresethaltreq(),
+                    authbusy: self.authbusy(),
+                    authenticated: self.authenticated(),
+                    anyhalted: self.anyhalted(),
+                    allhalted: self.allhalted(),
+                    anyrunning: self.anyrunning(),
+                    allrunning: self.allrunning(),
+                    anyunavail: self.anyunavail(),
+                    allunavail: self.allunavail(),
+                    anynonexistent: self.anynonexistent(),
+                    allnonexistent: self.allnonexistent(),
+                    anyresumeack: self.anyresumeack(),
+                    allresumeack: self.allresumeack(),
+                    anyhavereset: self.anyhavereset(),
+                    allhavereset: self.allhavereset(),
+                    impebreak: self.impebreak(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hart Information"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -52860,6 +69995,35 @@ pub mod vpr {
                 Hartinfo(0)
             }
         }
+        impl core::fmt::Debug for Hartinfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hartinfo")
+                    .field("dataaddr", &self.dataaddr())
+                    .field("datasize", &self.datasize())
+                    .field("dataaccess", &self.dataaccess())
+                    .field("nscratch", &self.nscratch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hartinfo {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hartinfo {
+                    dataaddr: u16,
+                    datasize: u8,
+                    dataaccess: bool,
+                    nscratch: u8,
+                }
+                let proxy = Hartinfo {
+                    dataaddr: self.dataaddr(),
+                    datasize: self.datasize(),
+                    dataaccess: self.dataaccess(),
+                    nscratch: self.nscratch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hart Array Window Select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -52881,6 +70045,26 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Hawindowsel {
                 Hawindowsel(0)
+            }
+        }
+        impl core::fmt::Debug for Hawindowsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hawindowsel")
+                    .field("hawindowsel", &self.hawindowsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hawindowsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hawindowsel {
+                    hawindowsel: u16,
+                }
+                let proxy = Hawindowsel {
+                    hawindowsel: self.hawindowsel(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -52970,6 +70154,44 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("triggered16", &self.triggered16())
+                    .field("triggered17", &self.triggered17())
+                    .field("triggered18", &self.triggered18())
+                    .field("triggered19", &self.triggered19())
+                    .field("triggered20", &self.triggered20())
+                    .field("triggered21", &self.triggered21())
+                    .field("triggered22", &self.triggered22())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered16: bool,
+                    triggered17: bool,
+                    triggered18: bool,
+                    triggered19: bool,
+                    triggered20: bool,
+                    triggered21: bool,
+                    triggered22: bool,
+                }
+                let proxy = Int {
+                    triggered16: self.triggered16(),
+                    triggered17: self.triggered17(),
+                    triggered18: self.triggered18(),
+                    triggered19: self.triggered19(),
+                    triggered20: self.triggered20(),
+                    triggered21: self.triggered21(),
+                    triggered22: self.triggered22(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System Bus Access Control and Status"]
@@ -53115,10 +70337,70 @@ pub mod vpr {
                 Sbcs(0)
             }
         }
+        impl core::fmt::Debug for Sbcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sbcs")
+                    .field("sbaccess8", &self.sbaccess8())
+                    .field("sbaccess16", &self.sbaccess16())
+                    .field("sbaccess32", &self.sbaccess32())
+                    .field("sbaccess64", &self.sbaccess64())
+                    .field("sbaccess128", &self.sbaccess128())
+                    .field("sbasize", &self.sbasize())
+                    .field("sberror", &self.sberror())
+                    .field("sbreadondata", &self.sbreadondata())
+                    .field("sbautoincrement", &self.sbautoincrement())
+                    .field("sbaccess", &self.sbaccess())
+                    .field("sbreadonaddr", &self.sbreadonaddr())
+                    .field("sbbusy", &self.sbbusy())
+                    .field("sbbusyerror", &self.sbbusyerror())
+                    .field("sbversion", &self.sbversion())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sbcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sbcs {
+                    sbaccess8: bool,
+                    sbaccess16: bool,
+                    sbaccess32: bool,
+                    sbaccess64: bool,
+                    sbaccess128: bool,
+                    sbasize: u8,
+                    sberror: super::vals::Sberror,
+                    sbreadondata: bool,
+                    sbautoincrement: bool,
+                    sbaccess: super::vals::Sbaccess,
+                    sbreadonaddr: bool,
+                    sbbusy: bool,
+                    sbbusyerror: bool,
+                    sbversion: super::vals::Sbversion,
+                }
+                let proxy = Sbcs {
+                    sbaccess8: self.sbaccess8(),
+                    sbaccess16: self.sbaccess16(),
+                    sbaccess32: self.sbaccess32(),
+                    sbaccess64: self.sbaccess64(),
+                    sbaccess128: self.sbaccess128(),
+                    sbasize: self.sbasize(),
+                    sberror: self.sberror(),
+                    sbreadondata: self.sbreadondata(),
+                    sbautoincrement: self.sbautoincrement(),
+                    sbaccess: self.sbaccess(),
+                    sbreadonaddr: self.sbreadonaddr(),
+                    sbbusy: self.sbbusy(),
+                    sbbusyerror: self.sbbusyerror(),
+                    sbversion: self.sbversion(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ackhavereset {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -53148,7 +70430,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clrresethaltreq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -53178,7 +70461,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cmderr {
             #[doc = "No error."]
             NO_ERROR = 0x0,
@@ -53237,6 +70521,27 @@ pub mod vpr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Cmdtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("REGACCESS"),
+                    0x01 => f.write_str("QUICKACCESS"),
+                    0x02 => f.write_str("MEMACCESS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cmdtype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "REGACCESS"),
+                    0x01 => defmt::write!(f, "QUICKACCESS"),
+                    0x02 => defmt::write!(f, "MEMACCESS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Cmdtype {
             #[inline(always)]
             fn from(val: u8) -> Cmdtype {
@@ -53250,7 +70555,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Confstrptrvalid {
             #[doc = "The confstrptr0..confstrptr3 holds information which is not relevant to the configuration string."]
             NOT_RELEVANT = 0x0,
@@ -53280,7 +70586,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CpurunEn {
             #[doc = "CPU stopped. If this is the CPU state after a core reset, setting this bit will change the CPU state to CPU running."]
             STOPPED = 0x0,
@@ -53310,7 +70617,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Haltreq {
             #[doc = "Clears halt request bit for all currently selected harts."]
             CLEAR = 0x0,
@@ -53340,7 +70648,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hasel {
             #[doc = "Single hart selected."]
             SINGLE = 0x0,
@@ -53370,7 +70679,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resumereq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -53400,7 +70710,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sbaccess {
             #[doc = "8-bit."]
             SIZE8 = 0x0,
@@ -53439,7 +70750,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sberror {
             #[doc = "There was no bus error."]
             NORMAL = 0x0,
@@ -53479,7 +70791,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sbversion {
             #[doc = "The System Bus interface conforms to mainline drafts of thia RISC-V External Debug Support spec older than 1 January, 2018."]
             VERSION0 = 0x0,
@@ -53515,7 +70828,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Setresethaltreq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -53545,7 +70859,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Version {
             #[doc = "Debug module not present."]
             NOT_PRESENT = 0x0,
@@ -53760,6 +71075,32 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .field("stopen", &self.stopen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                    stopen: bool,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                    stopen: self.stopen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53792,6 +71133,29 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -53828,6 +71192,29 @@ pub mod wdt {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Nmi {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Request status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53855,6 +71242,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53877,6 +71305,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -53906,6 +71350,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -53927,6 +71412,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Runstatus {
                 Runstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Task stop enable"]
@@ -53953,10 +71458,27 @@ pub mod wdt {
                 Tsen(0)
             }
         }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tsen").field("tsen", &self.tsen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tsen {
+                    tsen: super::vals::Tsen,
+                }
+                let proxy = Tsen { tsen: self.tsen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause WDT while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -54000,6 +71522,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -54013,7 +71552,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause WDT while the CPU is sleeping"]
             PAUSE = 0x0,
@@ -54055,6 +71595,23 @@ pub mod wdt {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("ENABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "ENABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Tsen {

--- a/src/chips/nrf54l15-flpr/pac.rs
+++ b/src/chips/nrf54l15-flpr/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "0 - VPRCLIC_0"]
     VPRCLIC_0 = 0,
@@ -632,7 +633,8 @@ pub const UICR_S: uicr::Uicr = unsafe { uicr::Uicr::from_ptr(0x00ff_d000usize as
 #[doc = "Factory Information Configuration Registers"]
 pub const SICR_S: sicr::Sicr = unsafe { sicr::Sicr::from_ptr(0x00ff_e000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 0"]
-pub const DPPIC00_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4004_2000usize as _) };
+pub const DPPIC00_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4004_2000usize as _) };
 #[doc = "PPIB APB registers 0"]
 pub const PPIB00_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4004_3000usize as _) };
 #[doc = "PPIB APB registers 2"]
@@ -648,7 +650,8 @@ pub const SPIM00_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x4004_a000usize
 #[doc = "SPI Slave 0"]
 pub const SPIS00_NS: spis::Spis = unsafe { spis::Spis::from_ptr(0x4004_a000usize as _) };
 #[doc = "UART with EasyDMA 0"]
-pub const UARTE00_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x4004_a000usize as _) };
+pub const UARTE00_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x4004_a000usize as _) };
 #[doc = "VPR peripheral registers 0"]
 pub const VPR00_NS: vpr::Vpr = unsafe { vpr::Vpr::from_ptr(0x4004_c000usize as _) };
 #[doc = "GPIO Port 0"]
@@ -659,15 +662,18 @@ pub const CTRLAP_NS: ctrlapperi::Ctrlapperi =
 #[doc = "Trace and debug control 0"]
 pub const TAD_NS: tad::Tad = unsafe { tad::Tad::from_ptr(0x4005_3000usize as _) };
 #[doc = "Timer/Counter 0"]
-pub const TIMER00_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x4005_5000usize as _) };
+pub const TIMER00_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x4005_5000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 2"]
-pub const DPPIC10_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4008_2000usize as _) };
+pub const DPPIC10_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4008_2000usize as _) };
 #[doc = "PPIB APB registers 4"]
 pub const PPIB10_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4008_3000usize as _) };
 #[doc = "PPIB APB registers 6"]
 pub const PPIB11_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4008_4000usize as _) };
 #[doc = "Timer/Counter 2"]
-pub const TIMER10_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x4008_5000usize as _) };
+pub const TIMER10_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x4008_5000usize as _) };
 #[doc = "Real-time counter 0"]
 pub const RTC10_NS: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x4008_6000usize as _) };
 #[doc = "Event generator unit 0"]
@@ -675,7 +681,8 @@ pub const EGU10_NS: egu::Egu = unsafe { egu::Egu::from_ptr(0x4008_7000usize as _
 #[doc = "2.4 GHz radio 0"]
 pub const RADIO_NS: radio::Radio = unsafe { radio::Radio::from_ptr(0x4008_a000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 4"]
-pub const DPPIC20_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x400c_2000usize as _) };
+pub const DPPIC20_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x400c_2000usize as _) };
 #[doc = "PPIB APB registers 8"]
 pub const PPIB20_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x400c_3000usize as _) };
 #[doc = "PPIB APB registers 10"]
@@ -691,7 +698,8 @@ pub const TWIM20_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_6000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 0"]
 pub const TWIS20_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_6000usize as _) };
 #[doc = "UART with EasyDMA 2"]
-pub const UARTE20_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_6000usize as _) };
+pub const UARTE20_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_6000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 4"]
 pub const SPIM21_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x400c_7000usize as _) };
 #[doc = "SPI Slave 4"]
@@ -701,7 +709,8 @@ pub const TWIM21_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_7000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 2"]
 pub const TWIS21_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_7000usize as _) };
 #[doc = "UART with EasyDMA 4"]
-pub const UARTE21_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_7000usize as _) };
+pub const UARTE21_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_7000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 6"]
 pub const SPIM22_NS: spim::Spim = unsafe { spim::Spim::from_ptr(0x400c_8000usize as _) };
 #[doc = "SPI Slave 6"]
@@ -711,19 +720,25 @@ pub const TWIM22_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x400c_8000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 4"]
 pub const TWIS22_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x400c_8000usize as _) };
 #[doc = "UART with EasyDMA 6"]
-pub const UARTE22_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x400c_8000usize as _) };
+pub const UARTE22_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x400c_8000usize as _) };
 #[doc = "Event generator unit 2"]
 pub const EGU20_NS: egu::Egu = unsafe { egu::Egu::from_ptr(0x400c_9000usize as _) };
 #[doc = "Timer/Counter 4"]
-pub const TIMER20_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_a000usize as _) };
+pub const TIMER20_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_a000usize as _) };
 #[doc = "Timer/Counter 6"]
-pub const TIMER21_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_b000usize as _) };
+pub const TIMER21_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_b000usize as _) };
 #[doc = "Timer/Counter 8"]
-pub const TIMER22_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_c000usize as _) };
+pub const TIMER22_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_c000usize as _) };
 #[doc = "Timer/Counter 10"]
-pub const TIMER23_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_d000usize as _) };
+pub const TIMER23_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_d000usize as _) };
 #[doc = "Timer/Counter 12"]
-pub const TIMER24_NS: timer::Timer = unsafe { timer::Timer::from_ptr(0x400c_e000usize as _) };
+pub const TIMER24_NS: timer::Timer =
+    unsafe { timer::Timer::from_ptr(0x400c_e000usize as _) };
 #[doc = "Memory configuration 0"]
 pub const MEMCONF_NS: memconf::Memconf =
     unsafe { memconf::Memconf::from_ptr(0x400c_f000usize as _) };
@@ -746,7 +761,8 @@ pub const TEMP_NS: temp::Temp = unsafe { temp::Temp::from_ptr(0x400d_7000usize a
 #[doc = "GPIO Port 2"]
 pub const P1_NS: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x400d_8200usize as _) };
 #[doc = "GPIO Tasks and Events 0"]
-pub const GPIOTE20_NS: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x400d_a000usize as _) };
+pub const GPIOTE20_NS: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x400d_a000usize as _) };
 #[doc = "Inter-IC Sound 0"]
 pub const I2S20_NS: i2s::I2s = unsafe { i2s::I2s::from_ptr(0x400d_d000usize as _) };
 #[doc = "Quadrature Decoder 0"]
@@ -756,7 +772,8 @@ pub const QDEC21_NS: qdec::Qdec = unsafe { qdec::Qdec::from_ptr(0x400e_1000usize
 #[doc = "Global Real-time counter 0"]
 pub const GRTC_NS: grtc::Grtc = unsafe { grtc::Grtc::from_ptr(0x400e_2000usize as _) };
 #[doc = "Distributed programmable peripheral interconnect controller 6"]
-pub const DPPIC30_NS: dppic::Dppic = unsafe { dppic::Dppic::from_ptr(0x4010_2000usize as _) };
+pub const DPPIC30_NS: dppic::Dppic =
+    unsafe { dppic::Dppic::from_ptr(0x4010_2000usize as _) };
 #[doc = "PPIB APB registers 14"]
 pub const PPIB30_NS: ppib::Ppib = unsafe { ppib::Ppib::from_ptr(0x4010_3000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 8"]
@@ -768,19 +785,22 @@ pub const TWIM30_NS: twim::Twim = unsafe { twim::Twim::from_ptr(0x4010_4000usize
 #[doc = "I2C compatible Two-Wire Slave Interface with EasyDMA 6"]
 pub const TWIS30_NS: twis::Twis = unsafe { twis::Twis::from_ptr(0x4010_4000usize as _) };
 #[doc = "UART with EasyDMA 8"]
-pub const UARTE30_NS: uarte::Uarte = unsafe { uarte::Uarte::from_ptr(0x4010_4000usize as _) };
+pub const UARTE30_NS: uarte::Uarte =
+    unsafe { uarte::Uarte::from_ptr(0x4010_4000usize as _) };
 #[doc = "Real-time counter 2"]
 pub const RTC30_NS: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x4010_5000usize as _) };
 #[doc = "Comparator 0"]
 pub const COMP_NS: comp::Comp = unsafe { comp::Comp::from_ptr(0x4010_6000usize as _) };
 #[doc = "Low-power comparator 0"]
-pub const LPCOMP_NS: lpcomp::Lpcomp = unsafe { lpcomp::Lpcomp::from_ptr(0x4010_6000usize as _) };
+pub const LPCOMP_NS: lpcomp::Lpcomp =
+    unsafe { lpcomp::Lpcomp::from_ptr(0x4010_6000usize as _) };
 #[doc = "Watchdog Timer 1"]
 pub const WDT31_NS: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x4010_9000usize as _) };
 #[doc = "GPIO Port 4"]
 pub const P0_NS: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x4010_a000usize as _) };
 #[doc = "GPIO Tasks and Events 2"]
-pub const GPIOTE30_NS: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x4010_c000usize as _) };
+pub const GPIOTE30_NS: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x4010_c000usize as _) };
 #[doc = "Clock management 0"]
 pub const CLOCK_NS: clock::Clock = unsafe { clock::Clock::from_ptr(0x4010_e000usize as _) };
 #[doc = "Power control 0"]
@@ -812,7 +832,8 @@ pub const CCM00_S: ccm::Ccm = unsafe { ccm::Ccm::from_ptr(0x5004_6000usize as _)
 #[doc = "AES ECB Mode Encryption 1"]
 pub const ECB00_S: ecb::Ecb = unsafe { ecb::Ecb::from_ptr(0x5004_7000usize as _) };
 #[doc = "CRACEN"]
-pub const CRACEN_S: cracen::Cracen = unsafe { cracen::Cracen::from_ptr(0x5004_8000usize as _) };
+pub const CRACEN_S: cracen::Cracen =
+    unsafe { cracen::Cracen::from_ptr(0x5004_8000usize as _) };
 #[doc = "Serial Peripheral Interface Master with EasyDMA 1"]
 pub const SPIM00_S: spim::Spim = unsafe { spim::Spim::from_ptr(0x5004_a000usize as _) };
 #[doc = "SPI Slave 1"]
@@ -925,7 +946,8 @@ pub const TEMP_S: temp::Temp = unsafe { temp::Temp::from_ptr(0x500d_7000usize as
 #[doc = "GPIO Port 3"]
 pub const P1_S: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x500d_8200usize as _) };
 #[doc = "GPIO Tasks and Events 1"]
-pub const GPIOTE20_S: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x500d_a000usize as _) };
+pub const GPIOTE20_S: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x500d_a000usize as _) };
 #[doc = "Tamper controller"]
 pub const TAMPC_S: tampc::Tampc = unsafe { tampc::Tampc::from_ptr(0x500d_c000usize as _) };
 #[doc = "Inter-IC Sound 1"]
@@ -957,7 +979,8 @@ pub const RTC30_S: rtc::Rtc = unsafe { rtc::Rtc::from_ptr(0x5010_5000usize as _)
 #[doc = "Comparator 1"]
 pub const COMP_S: comp::Comp = unsafe { comp::Comp::from_ptr(0x5010_6000usize as _) };
 #[doc = "Low-power comparator 1"]
-pub const LPCOMP_S: lpcomp::Lpcomp = unsafe { lpcomp::Lpcomp::from_ptr(0x5010_6000usize as _) };
+pub const LPCOMP_S: lpcomp::Lpcomp =
+    unsafe { lpcomp::Lpcomp::from_ptr(0x5010_6000usize as _) };
 #[doc = "Watchdog Timer 0"]
 pub const WDT30_S: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x5010_8000usize as _) };
 #[doc = "Watchdog Timer 2"]
@@ -965,7 +988,8 @@ pub const WDT31_S: wdt::Wdt = unsafe { wdt::Wdt::from_ptr(0x5010_9000usize as _)
 #[doc = "GPIO Port 5"]
 pub const P0_S: gpio::Gpio = unsafe { gpio::Gpio::from_ptr(0x5010_a000usize as _) };
 #[doc = "GPIO Tasks and Events 3"]
-pub const GPIOTE30_S: gpiote::Gpiote = unsafe { gpiote::Gpiote::from_ptr(0x5010_c000usize as _) };
+pub const GPIOTE30_S: gpiote::Gpiote =
+    unsafe { gpiote::Gpiote::from_ptr(0x5010_c000usize as _) };
 #[doc = "Clock management 1"]
 pub const CLOCK_S: clock::Clock = unsafe { clock::Clock::from_ptr(0x5010_e000usize as _) };
 #[doc = "Power control 1"]
@@ -1185,6 +1209,26 @@ pub mod aar {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u8,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable AAR"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1208,6 +1252,26 @@ pub mod aar {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Error status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1229,6 +1293,26 @@ pub mod aar {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1287,6 +1371,35 @@ pub mod aar {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("resolved", &self.resolved())
+                    .field("notresolved", &self.notresolved())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    resolved: bool,
+                    notresolved: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    resolved: self.resolved(),
+                    notresolved: self.notresolved(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of IRKs to resolve"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1310,10 +1423,31 @@ pub mod aar {
                 Maxresolved(0)
             }
         }
+        impl core::fmt::Debug for Maxresolved {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxresolved")
+                    .field("maxresolved", &self.maxresolved())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxresolved {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxresolved {
+                    maxresolved: u16,
+                }
+                let proxy = Maxresolved {
+                    maxresolved: self.maxresolved(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1345,7 +1479,8 @@ pub mod aar {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -1638,6 +1773,26 @@ pub mod ccm {
                 Adatamask(0)
             }
         }
+        impl core::fmt::Debug for Adatamask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Adatamask")
+                    .field("adatamask", &self.adatamask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Adatamask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Adatamask {
+                    adatamask: u8,
+                }
+                let proxy = Adatamask {
+                    adatamask: self.adatamask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1661,6 +1816,26 @@ pub mod ccm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Error status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1682,6 +1857,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -1718,6 +1913,29 @@ pub mod ccm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "MAC check result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1739,6 +1957,26 @@ pub mod ccm {
             #[inline(always)]
             fn default() -> Macstatus {
                 Macstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Macstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Macstatus")
+                    .field("macstatus", &self.macstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Macstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Macstatus {
+                    macstatus: super::vals::Macstatus,
+                }
+                let proxy = Macstatus {
+                    macstatus: self.macstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operation mode"]
@@ -1799,6 +2037,35 @@ pub mod ccm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("mode", &self.mode())
+                    .field("protocol", &self.protocol())
+                    .field("datarate", &self.datarate())
+                    .field("maclen", &self.maclen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                    protocol: super::vals::Protocol,
+                    datarate: super::vals::Datarate,
+                    maclen: super::vals::Maclen,
+                }
+                let proxy = Mode {
+                    mode: self.mode(),
+                    protocol: self.protocol(),
+                    datarate: self.datarate(),
+                    maclen: self.maclen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate override setting."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1822,10 +2089,31 @@ pub mod ccm {
                 Rateoverride(0)
             }
         }
+        impl core::fmt::Debug for Rateoverride {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rateoverride")
+                    .field("rateoverride", &self.rateoverride())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rateoverride {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rateoverride {
+                    rateoverride: super::vals::Rateoverride,
+                }
+                let proxy = Rateoverride {
+                    rateoverride: self.rateoverride(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Datarate {
             #[doc = "125 Kbps"]
             _125KBIT = 0x0,
@@ -1865,7 +2153,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -1897,7 +2186,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -1936,7 +2226,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Maclen {
             #[doc = "M = 0 This is a special case for CCM* where encryption is required but not authentication"]
             M0 = 0x0,
@@ -1978,7 +2269,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Macstatus {
             #[doc = "MAC check failed"]
             CHECK_FAILED = 0x0,
@@ -2008,7 +2300,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "AES CCM packet encryption mode"]
             ENCRYPTION = 0x0,
@@ -2041,7 +2334,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Protocol {
             #[doc = "Bluetooth Low Energy packet format"]
             BLE = 0x0,
@@ -2073,7 +2367,8 @@ pub mod ccm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rateoverride {
             #[doc = "125 Kbps"]
             _125KBIT = 0x0,
@@ -2218,6 +2513,32 @@ pub mod clic {
                 Cliccfg(0)
             }
         }
+        impl core::fmt::Debug for Cliccfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cliccfg")
+                    .field("nvbits", &self.nvbits())
+                    .field("nlbits", &self.nlbits())
+                    .field("nmbits", &self.nmbits())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cliccfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cliccfg {
+                    nvbits: bool,
+                    nlbits: super::vals::Nlbits,
+                    nmbits: super::vals::Nmbits,
+                }
+                let proxy = Cliccfg {
+                    nvbits: self.nvbits(),
+                    nlbits: self.nlbits(),
+                    nmbits: self.nmbits(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CLIC information."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2261,6 +2582,32 @@ pub mod clic {
             #[inline(always)]
             fn default() -> Clicinfo {
                 Clicinfo(0)
+            }
+        }
+        impl core::fmt::Debug for Clicinfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clicinfo")
+                    .field("numinterrupts", &self.numinterrupts())
+                    .field("version", &self.version())
+                    .field("numtrigger", &self.numtrigger())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clicinfo {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clicinfo {
+                    numinterrupts: u16,
+                    version: u8,
+                    numtrigger: u8,
+                }
+                let proxy = Clicinfo {
+                    numinterrupts: self.numinterrupts(),
+                    version: self.version(),
+                    numtrigger: self.numtrigger(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Interrupt control register for IRQ number \\[n\\]."]
@@ -2366,10 +2713,52 @@ pub mod clic {
                 Clicint(0)
             }
         }
+        impl core::fmt::Debug for Clicint {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clicint")
+                    .field("ip", &self.ip())
+                    .field("read1", &self.read1())
+                    .field("ie", &self.ie())
+                    .field("read2", &self.read2())
+                    .field("shv", &self.shv())
+                    .field("trig", &self.trig())
+                    .field("mode", &self.mode())
+                    .field("priority", &self.priority())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clicint {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clicint {
+                    ip: bool,
+                    read1: u8,
+                    ie: bool,
+                    read2: u8,
+                    shv: bool,
+                    trig: super::vals::Trig,
+                    mode: super::vals::Mode,
+                    priority: super::vals::Priority,
+                }
+                let proxy = Clicint {
+                    ip: self.ip(),
+                    read1: self.read1(),
+                    ie: self.ie(),
+                    read2: self.read2(),
+                    shv: self.shv(),
+                    trig: self.trig(),
+                    mode: self.mode(),
+                    priority: self.priority(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -2400,7 +2789,8 @@ pub mod clic {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nlbits {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -2443,7 +2833,8 @@ pub mod clic {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nmbits {
             #[doc = "All interrupts are M-mode only"]
             MODE_M = 0x0,
@@ -2494,6 +2885,29 @@ pub mod clic {
                 self.0
             }
         }
+        impl core::fmt::Debug for Priority {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x3f => f.write_str("PRIOLEVEL0"),
+                    0x7f => f.write_str("PRIOLEVEL1"),
+                    0xbf => f.write_str("PRIOLEVEL2"),
+                    0xff => f.write_str("PRIOLEVEL3"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Priority {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x3f => defmt::write!(f, "PRIOLEVEL0"),
+                    0x7f => defmt::write!(f, "PRIOLEVEL1"),
+                    0xbf => defmt::write!(f, "PRIOLEVEL2"),
+                    0xff => defmt::write!(f, "PRIOLEVEL3"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Priority {
             #[inline(always)]
             fn from(val: u8) -> Priority {
@@ -2507,7 +2921,8 @@ pub mod clic {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Trig {
             _RESERVED_0 = 0x0,
             #[doc = "Interrupts are edge-triggered"]
@@ -2970,6 +3385,44 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("xostarted", &self.xostarted())
+                    .field("pllstarted", &self.pllstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .field("done", &self.done())
+                    .field("xotuned", &self.xotuned())
+                    .field("xotuneerror", &self.xotuneerror())
+                    .field("xotunefailed", &self.xotunefailed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    xostarted: bool,
+                    pllstarted: bool,
+                    lfclkstarted: bool,
+                    done: bool,
+                    xotuned: bool,
+                    xotuneerror: bool,
+                    xotunefailed: bool,
+                }
+                let proxy = Int {
+                    xostarted: self.xostarted(),
+                    pllstarted: self.pllstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                    done: self.done(),
+                    xotuned: self.xotuned(),
+                    xotuneerror: self.xotuneerror(),
+                    xotunefailed: self.xotunefailed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that LFCLKSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2991,6 +3444,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> LfclkRun {
                 LfclkRun(0)
+            }
+        }
+        impl core::fmt::Debug for LfclkRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("LfclkRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LfclkRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct LfclkRun {
+                    status: bool,
+                }
+                let proxy = LfclkRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Copy of LFCLK.SRCCOPY register, set when LFCLKSTARTED event is triggered."]
@@ -3038,6 +3511,32 @@ pub mod clock {
                 LfclkStat(0)
             }
         }
+        impl core::fmt::Debug for LfclkStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("LfclkStat")
+                    .field("src", &self.src())
+                    .field("alwaysrunning", &self.alwaysrunning())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LfclkStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct LfclkStat {
+                    src: super::vals::Lfclksrc,
+                    alwaysrunning: bool,
+                    state: bool,
+                }
+                let proxy = LfclkStat {
+                    src: self.src(),
+                    alwaysrunning: self.alwaysrunning(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that PLLSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3059,6 +3558,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> PllRun {
                 PllRun(0)
+            }
+        }
+        impl core::fmt::Debug for PllRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PllRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PllRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PllRun {
+                    status: bool,
+                }
+                let proxy = PllRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Which PLL settings were selected when triggering START task"]
@@ -3084,6 +3603,26 @@ pub mod clock {
                 PllStat(0)
             }
         }
+        impl core::fmt::Debug for PllStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PllStat")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PllStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PllStat {
+                    state: bool,
+                }
+                let proxy = PllStat {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clock source for LFCLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3105,6 +3644,22 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Src {
                 Src(0)
+            }
+        }
+        impl core::fmt::Debug for Src {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Src").field("src", &self.src()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Src {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Src {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Src { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Copy of LFCLK.SRC register, set when LFCLKSTART task is triggered"]
@@ -3130,6 +3685,22 @@ pub mod clock {
                 Srccopy(0)
             }
         }
+        impl core::fmt::Debug for Srccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Srccopy").field("src", &self.src()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Srccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Srccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Srccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Indicates that XOSTART task was triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3151,6 +3722,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> XoRun {
                 XoRun(0)
+            }
+        }
+        impl core::fmt::Debug for XoRun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("XoRun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for XoRun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct XoRun {
+                    status: bool,
+                }
+                let proxy = XoRun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "XO status"]
@@ -3176,10 +3767,31 @@ pub mod clock {
                 XoStat(0)
             }
         }
+        impl core::fmt::Debug for XoStat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("XoStat")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for XoStat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct XoStat {
+                    state: bool,
+                }
+                let proxy = XoStat {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "32.768 kHz RC oscillator"]
             LFRC = 0x0,
@@ -3486,6 +4098,26 @@ pub mod comp {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3520,6 +4152,29 @@ pub mod comp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Extrefsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3541,6 +4196,22 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: super::vals::Hyst,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -3599,6 +4270,35 @@ pub mod comp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current source select on analog input"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3620,6 +4320,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Isource {
                 Isource(0)
+            }
+        }
+        impl core::fmt::Debug for Isource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Isource")
+                    .field("isource", &self.isource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Isource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Isource {
+                    isource: super::vals::Isource,
+                }
+                let proxy = Isource {
+                    isource: self.isource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mode configuration"]
@@ -3656,6 +4376,29 @@ pub mod comp {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("sp", &self.sp())
+                    .field("main", &self.main())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    sp: super::vals::Sp,
+                    main: super::vals::Main,
+                }
+                let proxy = Mode {
+                    sp: self.sp(),
+                    main: self.main(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3690,6 +4433,29 @@ pub mod comp {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reference source select for single-ended mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3713,6 +4479,26 @@ pub mod comp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3734,6 +4520,26 @@ pub mod comp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -3803,6 +4609,38 @@ pub mod comp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Threshold configuration for hysteresis unit"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3837,10 +4675,34 @@ pub mod comp {
                 Th(0)
             }
         }
+        impl core::fmt::Debug for Th {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Th")
+                    .field("thdown", &self.thdown())
+                    .field("thup", &self.thup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Th {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Th {
+                    thdown: u8,
+                    thup: u8,
+                }
+                let proxy = Th {
+                    thdown: self.thdown(),
+                    thup: self.thup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -3872,7 +4734,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hyst {
             #[doc = "Comparator hysteresis disabled"]
             NO_HYST = 0x0,
@@ -3902,7 +4765,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Isource {
             #[doc = "Current source disabled"]
             OFF = 0x0,
@@ -3936,7 +4800,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Main {
             #[doc = "Single-ended mode"]
             SE = 0x0,
@@ -3966,7 +4831,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VREF = internal 1.2 V reference"]
             INT1V2 = 0x0,
@@ -4003,7 +4869,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -4033,7 +4900,8 @@ pub mod comp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sp {
             #[doc = "Low-power mode"]
             LOW = 0x0,
@@ -4194,6 +5062,32 @@ pub mod cracen {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("cryptomaster", &self.cryptomaster())
+                    .field("rng", &self.rng())
+                    .field("pkeikg", &self.pkeikg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    cryptomaster: bool,
+                    rng: bool,
+                    pkeikg: bool,
+                }
+                let proxy = Enable {
+                    cryptomaster: self.cryptomaster(),
+                    rng: self.rng(),
+                    pkeikg: self.pkeikg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4239,6 +5133,32 @@ pub mod cracen {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cryptomaster", &self.cryptomaster())
+                    .field("rng", &self.rng())
+                    .field("pkeikg", &self.pkeikg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cryptomaster: bool,
+                    rng: bool,
+                    pkeikg: bool,
+                }
+                let proxy = Int {
+                    cryptomaster: self.cryptomaster(),
+                    rng: self.rng(),
+                    pkeikg: self.pkeikg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock the access to the protected RAM."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4260,6 +5180,26 @@ pub mod cracen {
             #[inline(always)]
             fn default() -> Protectedramlock {
                 Protectedramlock(0)
+            }
+        }
+        impl core::fmt::Debug for Protectedramlock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Protectedramlock")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Protectedramlock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Protectedramlock {
+                    enable: bool,
+                }
+                let proxy = Protectedramlock {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Lock the access to the SEED register."]
@@ -4285,6 +5225,26 @@ pub mod cracen {
                 Seedlock(0)
             }
         }
+        impl core::fmt::Debug for Seedlock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seedlock")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seedlock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seedlock {
+                    enable: bool,
+                }
+                let proxy = Seedlock {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Marks the SEED register as valid"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4306,6 +5266,26 @@ pub mod cracen {
             #[inline(always)]
             fn default() -> Seedvalid {
                 Seedvalid(0)
+            }
+        }
+        impl core::fmt::Debug for Seedvalid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seedvalid")
+                    .field("valid", &self.valid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seedvalid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seedvalid {
+                    valid: bool,
+                }
+                let proxy = Seedvalid {
+                    valid: self.valid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4823,6 +5803,29 @@ pub mod cracencore {
                 Ais31conf0(0)
             }
         }
+        impl core::fmt::Debug for Ais31conf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf0")
+                    .field("startupthreshold", &self.startupthreshold())
+                    .field("onlinethreshold", &self.onlinethreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf0 {
+                    startupthreshold: u16,
+                    onlinethreshold: u16,
+                }
+                let proxy = Ais31conf0 {
+                    startupthreshold: self.startupthreshold(),
+                    onlinethreshold: self.onlinethreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "AIS31 configuration register 1."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4857,6 +5860,29 @@ pub mod cracencore {
                 Ais31conf1(0)
             }
         }
+        impl core::fmt::Debug for Ais31conf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf1")
+                    .field("onlinerepthreshold", &self.onlinerepthreshold())
+                    .field("hexpectedvalue", &self.hexpectedvalue())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf1 {
+                    onlinerepthreshold: u16,
+                    hexpectedvalue: u16,
+                }
+                let proxy = Ais31conf1 {
+                    onlinerepthreshold: self.onlinerepthreshold(),
+                    hexpectedvalue: self.hexpectedvalue(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "AIS31 configuration register 2."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4889,6 +5915,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ais31conf2 {
                 Ais31conf2(0)
+            }
+        }
+        impl core::fmt::Debug for Ais31conf2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31conf2")
+                    .field("hmin", &self.hmin())
+                    .field("hmax", &self.hmax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31conf2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31conf2 {
+                    hmin: u16,
+                    hmax: u16,
+                }
+                let proxy = Ais31conf2 {
+                    hmin: self.hmin(),
+                    hmax: self.hmax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "AIS31 status register."]
@@ -4934,6 +5983,32 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ais31status {
                 Ais31status(0)
+            }
+        }
+        impl core::fmt::Debug for Ais31status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ais31status")
+                    .field("numprelimalarms", &self.numprelimalarms())
+                    .field("prelimnoisealarmrng", &self.prelimnoisealarmrng())
+                    .field("prelimnoisealarmrep", &self.prelimnoisealarmrep())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ais31status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ais31status {
+                    numprelimalarms: u16,
+                    prelimnoisealarmrng: bool,
+                    prelimnoisealarmrep: bool,
+                }
+                let proxy = Ais31status {
+                    numprelimalarms: self.numprelimalarms(),
+                    prelimnoisealarmrng: self.prelimnoisealarmrng(),
+                    prelimnoisealarmrep: self.prelimnoisealarmrep(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_AesModesPoss value."]
@@ -4992,6 +6067,35 @@ pub mod cracencore {
                 Ba411eaeshwcfg1(0)
             }
         }
+        impl core::fmt::Debug for Ba411eaeshwcfg1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba411eaeshwcfg1")
+                    .field("ba411eaeshwcfgmode", &self.ba411eaeshwcfgmode())
+                    .field("ba411eaeshwcfgcs", &self.ba411eaeshwcfgcs())
+                    .field("ba411eaeshwcfgmasking", &self.ba411eaeshwcfgmasking())
+                    .field("ba411eaeshwcfgkeysize", &self.ba411eaeshwcfgkeysize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba411eaeshwcfg1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba411eaeshwcfg1 {
+                    ba411eaeshwcfgmode: u16,
+                    ba411eaeshwcfgcs: bool,
+                    ba411eaeshwcfgmasking: bool,
+                    ba411eaeshwcfgkeysize: u8,
+                }
+                let proxy = Ba411eaeshwcfg1 {
+                    ba411eaeshwcfgmode: self.ba411eaeshwcfgmode(),
+                    ba411eaeshwcfgcs: self.ba411eaeshwcfgcs(),
+                    ba411eaeshwcfgmasking: self.ba411eaeshwcfgmasking(),
+                    ba411eaeshwcfgkeysize: self.ba411eaeshwcfgkeysize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_CtrSize value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5013,6 +6117,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ba411eaeshwcfg2 {
                 Ba411eaeshwcfg2(0)
+            }
+        }
+        impl core::fmt::Debug for Ba411eaeshwcfg2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba411eaeshwcfg2")
+                    .field("ba411eaeshwcfg2", &self.ba411eaeshwcfg2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba411eaeshwcfg2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba411eaeshwcfg2 {
+                    ba411eaeshwcfg2: u16,
+                }
+                let proxy = Ba411eaeshwcfg2 {
+                    ba411eaeshwcfg2: self.ba411eaeshwcfg2(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_Hash value"]
@@ -5071,6 +6195,38 @@ pub mod cracencore {
                 Ba413hashhwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba413hashhwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba413hashhwcfg")
+                    .field("ba413hashhwcfgmask", &self.ba413hashhwcfgmask())
+                    .field("ba413hashhwcfgpadding", &self.ba413hashhwcfgpadding())
+                    .field("ba413hashhwcfghmac", &self.ba413hashhwcfghmac())
+                    .field(
+                        "ba413hashhwcfgverifydigest",
+                        &self.ba413hashhwcfgverifydigest(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba413hashhwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba413hashhwcfg {
+                    ba413hashhwcfgmask: u8,
+                    ba413hashhwcfgpadding: bool,
+                    ba413hashhwcfghmac: bool,
+                    ba413hashhwcfgverifydigest: bool,
+                }
+                let proxy = Ba413hashhwcfg {
+                    ba413hashhwcfgmask: self.ba413hashhwcfgmask(),
+                    ba413hashhwcfgpadding: self.ba413hashhwcfgpadding(),
+                    ba413hashhwcfghmac: self.ba413hashhwcfghmac(),
+                    ba413hashhwcfgverifydigest: self.ba413hashhwcfgverifydigest(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_Sha3CtxtEn value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5092,6 +6248,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ba418sha3hwcfg {
                 Ba418sha3hwcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Ba418sha3hwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba418sha3hwcfg")
+                    .field("ba418sha3hwcfg", &self.ba418sha3hwcfg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba418sha3hwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba418sha3hwcfg {
+                    ba418sha3hwcfg: bool,
+                }
+                let proxy = Ba418sha3hwcfg {
+                    ba418sha3hwcfg: self.ba418sha3hwcfg(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Generic g_SM4ModesPoss value."]
@@ -5128,6 +6304,29 @@ pub mod cracencore {
                 Ba419sm4hwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba419sm4hwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba419sm4hwcfg")
+                    .field("ba419sm4hwcfg", &self.ba419sm4hwcfg())
+                    .field("usemasking", &self.usemasking())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba419sm4hwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba419sm4hwcfg {
+                    ba419sm4hwcfg: u16,
+                    usemasking: bool,
+                }
+                let proxy = Ba419sm4hwcfg {
+                    ba419sm4hwcfg: self.ba419sm4hwcfg(),
+                    usemasking: self.usemasking(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Generic g_aria_modePoss value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5151,6 +6350,26 @@ pub mod cracencore {
                 Ba424ariahwcfg(0)
             }
         }
+        impl core::fmt::Debug for Ba424ariahwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ba424ariahwcfg")
+                    .field("ba424ariahwcfg", &self.ba424ariahwcfg())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ba424ariahwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ba424ariahwcfg {
+                    ba424ariahwcfg: u16,
+                }
+                let proxy = Ba424ariahwcfg {
+                    ba424ariahwcfg: self.ba424ariahwcfg(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample clock divider."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5172,6 +6391,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Clkdiv {
                 Clkdiv(0)
+            }
+        }
+        impl core::fmt::Debug for Clkdiv {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkdiv")
+                    .field("clkdiv", &self.clkdiv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkdiv {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkdiv {
+                    clkdiv: u8,
+                }
+                let proxy = Clkdiv {
+                    clkdiv: self.clkdiv(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Command register."]
@@ -5321,6 +6560,59 @@ pub mod cracencore {
                 Command(0)
             }
         }
+        impl core::fmt::Debug for Command {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Command")
+                    .field("opeaddr", &self.opeaddr())
+                    .field("fieldf", &self.fieldf())
+                    .field("opbytesm1", &self.opbytesm1())
+                    .field("randmod", &self.randmod())
+                    .field("selcurve", &self.selcurve())
+                    .field("randke", &self.randke())
+                    .field("randproj", &self.randproj())
+                    .field("edwards", &self.edwards())
+                    .field("swapbytes", &self.swapbytes())
+                    .field("flaga", &self.flaga())
+                    .field("flagb", &self.flagb())
+                    .field("calcr2", &self.calcr2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Command {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Command {
+                    opeaddr: u8,
+                    fieldf: bool,
+                    opbytesm1: u16,
+                    randmod: bool,
+                    selcurve: super::vals::Selcurve,
+                    randke: bool,
+                    randproj: bool,
+                    edwards: bool,
+                    swapbytes: super::vals::Swapbytes,
+                    flaga: bool,
+                    flagb: bool,
+                    calcr2: super::vals::Calcr2,
+                }
+                let proxy = Command {
+                    opeaddr: self.opeaddr(),
+                    fieldf: self.fieldf(),
+                    opbytesm1: self.opbytesm1(),
+                    randmod: self.randmod(),
+                    selcurve: self.selcurve(),
+                    randke: self.randke(),
+                    randproj: self.randproj(),
+                    edwards: self.edwards(),
+                    swapbytes: self.swapbytes(),
+                    flaga: self.flaga(),
+                    flagb: self.flagb(),
+                    calcr2: self.calcr2(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5378,6 +6670,38 @@ pub mod cracencore {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("fetchctrlindirect", &self.fetchctrlindirect())
+                    .field("pushctrlindirect", &self.pushctrlindirect())
+                    .field("fetchstop", &self.fetchstop())
+                    .field("pushstop", &self.pushstop())
+                    .field("softrst", &self.softrst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    fetchctrlindirect: bool,
+                    pushctrlindirect: bool,
+                    fetchstop: bool,
+                    pushstop: bool,
+                    softrst: bool,
+                }
+                let proxy = Config {
+                    fetchctrlindirect: self.fetchctrlindirect(),
+                    pushctrlindirect: self.pushctrlindirect(),
+                    fetchstop: self.fetchstop(),
+                    pushstop: self.pushstop(),
+                    softrst: self.softrst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5406,6 +6730,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> CryptmstrdmaStart {
                 CryptmstrdmaStart(0)
+            }
+        }
+        impl core::fmt::Debug for CryptmstrdmaStart {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptmstrdmaStart")
+                    .field("startfetch", &self.startfetch())
+                    .field("startpush", &self.startpush())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptmstrdmaStart {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptmstrdmaStart {
+                    startfetch: bool,
+                    startpush: bool,
+                }
+                let proxy = CryptmstrdmaStart {
+                    startfetch: self.startfetch(),
+                    startpush: self.startpush(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status"]
@@ -5474,6 +6821,41 @@ pub mod cracencore {
                 CryptmstrdmaStatus(0)
             }
         }
+        impl core::fmt::Debug for CryptmstrdmaStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CryptmstrdmaStatus")
+                    .field("fetchbusy", &self.fetchbusy())
+                    .field("pushbusy", &self.pushbusy())
+                    .field("fetchnotempty", &self.fetchnotempty())
+                    .field("pushwaitingfifo", &self.pushwaitingfifo())
+                    .field("softrstbusy", &self.softrstbusy())
+                    .field("pushnbdata", &self.pushnbdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CryptmstrdmaStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CryptmstrdmaStatus {
+                    fetchbusy: bool,
+                    pushbusy: bool,
+                    fetchnotempty: bool,
+                    pushwaitingfifo: bool,
+                    softrstbusy: bool,
+                    pushnbdata: u16,
+                }
+                let proxy = CryptmstrdmaStatus {
+                    fetchbusy: self.fetchbusy(),
+                    pushbusy: self.pushbusy(),
+                    fetchnotempty: self.fetchnotempty(),
+                    pushwaitingfifo: self.pushwaitingfifo(),
+                    softrstbusy: self.softrstbusy(),
+                    pushnbdata: self.pushnbdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Fetch Length"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5523,6 +6905,35 @@ pub mod cracencore {
                 Fetchlen(0)
             }
         }
+        impl core::fmt::Debug for Fetchlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fetchlen")
+                    .field("fetchlen", &self.fetchlen())
+                    .field("fetchcstaddr", &self.fetchcstaddr())
+                    .field("fetchrealign", &self.fetchrealign())
+                    .field("fetchzpadding", &self.fetchzpadding())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fetchlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fetchlen {
+                    fetchlen: u32,
+                    fetchcstaddr: bool,
+                    fetchrealign: bool,
+                    fetchzpadding: bool,
+                }
+                let proxy = Fetchlen {
+                    fetchlen: self.fetchlen(),
+                    fetchcstaddr: self.fetchcstaddr(),
+                    fetchrealign: self.fetchrealign(),
+                    fetchzpadding: self.fetchzpadding(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FIFO threshold register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5544,6 +6955,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Fifothreshold {
                 Fifothreshold(0)
+            }
+        }
+        impl core::fmt::Debug for Fifothreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fifothreshold")
+                    .field("fifothreshold", &self.fifothreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fifothreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fifothreshold {
+                    fifothreshold: u8,
+                }
+                let proxy = Fifothreshold {
+                    fifothreshold: self.fifothreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "HwConfig register."]
@@ -5681,6 +7112,59 @@ pub mod cracencore {
                 IkgHwconfig(0)
             }
         }
+        impl core::fmt::Debug for IkgHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgHwconfig")
+                    .field("nbsymkeys", &self.nbsymkeys())
+                    .field("nbprivkeys", &self.nbprivkeys())
+                    .field("ikgcm", &self.ikgcm())
+                    .field("hwhealthtest", &self.hwhealthtest())
+                    .field("curve", &self.curve())
+                    .field("df", &self.df())
+                    .field("keysize", &self.keysize())
+                    .field("entropyinputlength", &self.entropyinputlength())
+                    .field("noncelength", &self.noncelength())
+                    .field(
+                        "personalizationstringlength",
+                        &self.personalizationstringlength(),
+                    )
+                    .field("additionalinputlength", &self.additionalinputlength())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgHwconfig {
+                    nbsymkeys: u8,
+                    nbprivkeys: u8,
+                    ikgcm: bool,
+                    hwhealthtest: bool,
+                    curve: super::vals::Curve,
+                    df: bool,
+                    keysize: super::vals::Keysize,
+                    entropyinputlength: u8,
+                    noncelength: u8,
+                    personalizationstringlength: u8,
+                    additionalinputlength: u8,
+                }
+                let proxy = IkgHwconfig {
+                    nbsymkeys: self.nbsymkeys(),
+                    nbprivkeys: self.nbprivkeys(),
+                    ikgcm: self.ikgcm(),
+                    hwhealthtest: self.hwhealthtest(),
+                    curve: self.curve(),
+                    df: self.df(),
+                    keysize: self.keysize(),
+                    entropyinputlength: self.entropyinputlength(),
+                    noncelength: self.noncelength(),
+                    personalizationstringlength: self.personalizationstringlength(),
+                    additionalinputlength: self.additionalinputlength(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5702,6 +7186,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> IkgStart {
                 IkgStart(0)
+            }
+        }
+        impl core::fmt::Debug for IkgStart {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgStart")
+                    .field("start", &self.start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgStart {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgStart {
+                    start: bool,
+                }
+                let proxy = IkgStart {
+                    start: self.start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -5791,6 +7295,44 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> IkgStatus {
                 IkgStatus(0)
+            }
+        }
+        impl core::fmt::Debug for IkgStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IkgStatus")
+                    .field("seederror", &self.seederror())
+                    .field("entropyerror", &self.entropyerror())
+                    .field("okay", &self.okay())
+                    .field("ctrdrbgbusy", &self.ctrdrbgbusy())
+                    .field("catastrophicerror", &self.catastrophicerror())
+                    .field("symkeystored", &self.symkeystored())
+                    .field("privkeystored", &self.privkeystored())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IkgStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IkgStatus {
+                    seederror: bool,
+                    entropyerror: bool,
+                    okay: bool,
+                    ctrdrbgbusy: bool,
+                    catastrophicerror: bool,
+                    symkeystored: bool,
+                    privkeystored: bool,
+                }
+                let proxy = IkgStatus {
+                    seederror: self.seederror(),
+                    entropyerror: self.entropyerror(),
+                    okay: self.okay(),
+                    ctrdrbgbusy: self.ctrdrbgbusy(),
+                    catastrophicerror: self.catastrophicerror(),
+                    symkeystored: self.symkeystored(),
+                    privkeystored: self.privkeystored(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Incuded IPs Hardware configuration"]
@@ -5959,6 +7501,68 @@ pub mod cracencore {
                 Inclipshwcfg(0)
             }
         }
+        impl core::fmt::Debug for Inclipshwcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Inclipshwcfg")
+                    .field("ba411aesincluded", &self.ba411aesincluded())
+                    .field("ba415hpaesgcmincluded", &self.ba415hpaesgcmincluded())
+                    .field("ba416hpaesxtsincluded", &self.ba416hpaesxtsincluded())
+                    .field("ba412desincluded", &self.ba412desincluded())
+                    .field("ba413hashincluded", &self.ba413hashincluded())
+                    .field("ba417chachapolyincluded", &self.ba417chachapolyincluded())
+                    .field("ba418sha3included", &self.ba418sha3included())
+                    .field("ba421zucincluded", &self.ba421zucincluded())
+                    .field("ba419sm4included", &self.ba419sm4included())
+                    .field("ba414eppkeincluded", &self.ba414eppkeincluded())
+                    .field("ba431ndrngincluded", &self.ba431ndrngincluded())
+                    .field(
+                        "ba420hpchachapolyincluded",
+                        &self.ba420hpchachapolyincluded(),
+                    )
+                    .field("ba423snow3gincluded", &self.ba423snow3gincluded())
+                    .field("ba422kasumiincluded", &self.ba422kasumiincluded())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Inclipshwcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Inclipshwcfg {
+                    ba411aesincluded: bool,
+                    ba415hpaesgcmincluded: bool,
+                    ba416hpaesxtsincluded: bool,
+                    ba412desincluded: bool,
+                    ba413hashincluded: bool,
+                    ba417chachapolyincluded: bool,
+                    ba418sha3included: bool,
+                    ba421zucincluded: bool,
+                    ba419sm4included: bool,
+                    ba414eppkeincluded: bool,
+                    ba431ndrngincluded: bool,
+                    ba420hpchachapolyincluded: bool,
+                    ba423snow3gincluded: bool,
+                    ba422kasumiincluded: bool,
+                }
+                let proxy = Inclipshwcfg {
+                    ba411aesincluded: self.ba411aesincluded(),
+                    ba415hpaesgcmincluded: self.ba415hpaesgcmincluded(),
+                    ba416hpaesxtsincluded: self.ba416hpaesxtsincluded(),
+                    ba412desincluded: self.ba412desincluded(),
+                    ba413hashincluded: self.ba413hashincluded(),
+                    ba417chachapolyincluded: self.ba417chachapolyincluded(),
+                    ba418sha3included: self.ba418sha3included(),
+                    ba421zucincluded: self.ba421zucincluded(),
+                    ba419sm4included: self.ba419sm4included(),
+                    ba414eppkeincluded: self.ba414eppkeincluded(),
+                    ba431ndrngincluded: self.ba431ndrngincluded(),
+                    ba420hpchachapolyincluded: self.ba420hpchachapolyincluded(),
+                    ba423snow3gincluded: self.ba423snow3gincluded(),
+                    ba422kasumiincluded: self.ba422kasumiincluded(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "InitData register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5980,6 +7584,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Initdata {
                 Initdata(0)
+            }
+        }
+        impl core::fmt::Debug for Initdata {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Initdata")
+                    .field("initdata", &self.initdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Initdata {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Initdata {
+                    initdata: bool,
+                }
+                let proxy = Initdata {
+                    initdata: self.initdata(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Initial wait counter value."]
@@ -6005,6 +7629,26 @@ pub mod cracencore {
                 Initwaitval(0)
             }
         }
+        impl core::fmt::Debug for Initwaitval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Initwaitval")
+                    .field("initwaitval", &self.initwaitval())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Initwaitval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Initwaitval {
+                    initwaitval: u16,
+                }
+                let proxy = Initwaitval {
+                    initwaitval: self.initwaitval(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interrupt Enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6024,6 +7668,22 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int").field("int", &self.int()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    int: u8,
+                }
+                let proxy = Int { int: self.int() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Operand size register."]
@@ -6048,6 +7708,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Opsize {
                 Opsize(0)
+            }
+        }
+        impl core::fmt::Debug for Opsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Opsize")
+                    .field("opsize", &self.opsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Opsize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Opsize {
+                    opsize: super::vals::Opsize,
+                }
+                let proxy = Opsize {
+                    opsize: self.opsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Command register."]
@@ -6082,6 +7762,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> PkControl {
                 PkControl(0)
+            }
+        }
+        impl core::fmt::Debug for PkControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkControl")
+                    .field("start", &self.start())
+                    .field("clearirq", &self.clearirq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkControl {
+                    start: bool,
+                    clearirq: bool,
+                }
+                let proxy = PkControl {
+                    start: self.start(),
+                    clearirq: self.clearirq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Hardware configuration register."]
@@ -6252,6 +7955,65 @@ pub mod cracencore {
                 PkHwconfig(0)
             }
         }
+        impl core::fmt::Debug for PkHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkHwconfig")
+                    .field("maxopsize", &self.maxopsize())
+                    .field("nbmult", &self.nbmult())
+                    .field("primefield", &self.primefield())
+                    .field("binaryfield", &self.binaryfield())
+                    .field("ecc", &self.ecc())
+                    .field("p256", &self.p256())
+                    .field("p384", &self.p384())
+                    .field("p521", &self.p521())
+                    .field("p192", &self.p192())
+                    .field("x25519", &self.x25519())
+                    .field("ahbmaster", &self.ahbmaster())
+                    .field("disablesmx", &self.disablesmx())
+                    .field("disableclrmem", &self.disableclrmem())
+                    .field("disablecm", &self.disablecm())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkHwconfig {
+                    maxopsize: u16,
+                    nbmult: super::vals::Nbmult,
+                    primefield: bool,
+                    binaryfield: bool,
+                    ecc: bool,
+                    p256: bool,
+                    p384: bool,
+                    p521: bool,
+                    p192: bool,
+                    x25519: bool,
+                    ahbmaster: super::vals::Ahbmaster,
+                    disablesmx: bool,
+                    disableclrmem: bool,
+                    disablecm: bool,
+                }
+                let proxy = PkHwconfig {
+                    maxopsize: self.maxopsize(),
+                    nbmult: self.nbmult(),
+                    primefield: self.primefield(),
+                    binaryfield: self.binaryfield(),
+                    ecc: self.ecc(),
+                    p256: self.p256(),
+                    p384: self.p384(),
+                    p521: self.p521(),
+                    p192: self.p192(),
+                    x25519: self.x25519(),
+                    ahbmaster: self.ahbmaster(),
+                    disablesmx: self.disablesmx(),
+                    disableclrmem: self.disableclrmem(),
+                    disablecm: self.disablecm(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6308,6 +8070,35 @@ pub mod cracencore {
                 PkStatus(0)
             }
         }
+        impl core::fmt::Debug for PkStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PkStatus")
+                    .field("errorflags", &self.errorflags())
+                    .field("pkbusy", &self.pkbusy())
+                    .field("intrptstatus", &self.intrptstatus())
+                    .field("failptr", &self.failptr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PkStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PkStatus {
+                    errorflags: u16,
+                    pkbusy: bool,
+                    intrptstatus: bool,
+                    failptr: u8,
+                }
+                let proxy = PkStatus {
+                    errorflags: self.errorflags(),
+                    pkbusy: self.pkbusy(),
+                    intrptstatus: self.intrptstatus(),
+                    failptr: self.failptr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PKE Command register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6353,6 +8144,32 @@ pub mod cracencore {
                 Pkecommand(0)
             }
         }
+        impl core::fmt::Debug for Pkecommand {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkecommand")
+                    .field("securemode", &self.securemode())
+                    .field("selectedkey", &self.selectedkey())
+                    .field("opsel", &self.opsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkecommand {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkecommand {
+                    securemode: bool,
+                    selectedkey: u8,
+                    opsel: super::vals::Opsel,
+                }
+                let proxy = Pkecommand {
+                    securemode: self.securemode(),
+                    selectedkey: self.selectedkey(),
+                    opsel: self.opsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PKE Control register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6385,6 +8202,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Pkecontrol {
                 Pkecontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Pkecontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkecontrol")
+                    .field("pkestart", &self.pkestart())
+                    .field("clearirq", &self.clearirq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkecontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkecontrol {
+                    pkestart: bool,
+                    clearirq: bool,
+                }
+                let proxy = Pkecontrol {
+                    pkestart: self.pkestart(),
+                    clearirq: self.clearirq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "PKE Status register."]
@@ -6454,6 +8294,38 @@ pub mod cracencore {
                 Pkestatus(0)
             }
         }
+        impl core::fmt::Debug for Pkestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pkestatus")
+                    .field("error", &self.error())
+                    .field("starterror", &self.starterror())
+                    .field("ikgpkbusy", &self.ikgpkbusy())
+                    .field("irqstatus", &self.irqstatus())
+                    .field("erasebusy", &self.erasebusy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pkestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pkestatus {
+                    error: bool,
+                    starterror: bool,
+                    ikgpkbusy: bool,
+                    irqstatus: bool,
+                    erasebusy: bool,
+                }
+                let proxy = Pkestatus {
+                    error: self.error(),
+                    starterror: self.starterror(),
+                    ikgpkbusy: self.ikgpkbusy(),
+                    irqstatus: self.irqstatus(),
+                    erasebusy: self.erasebusy(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Pointers register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6510,6 +8382,35 @@ pub mod cracencore {
                 Pointers(0)
             }
         }
+        impl core::fmt::Debug for Pointers {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pointers")
+                    .field("opptra", &self.opptra())
+                    .field("opptrb", &self.opptrb())
+                    .field("opptrc", &self.opptrc())
+                    .field("opptrn", &self.opptrn())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pointers {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pointers {
+                    opptra: u8,
+                    opptrb: u8,
+                    opptrc: u8,
+                    opptrn: u8,
+                }
+                let proxy = Pointers {
+                    opptra: self.opptra(),
+                    opptrb: self.opptrb(),
+                    opptrc: self.opptrc(),
+                    opptrn: self.opptrn(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Adaptive Proportion Test (1024-sample window) Cut-Off value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6531,6 +8432,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Propthreshold {
                 Propthreshold(0)
+            }
+        }
+        impl core::fmt::Debug for Propthreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Propthreshold")
+                    .field("propthreshold", &self.propthreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Propthreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Propthreshold {
+                    propthreshold: u16,
+                }
+                let proxy = Propthreshold {
+                    propthreshold: self.propthreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Push Length"]
@@ -6582,6 +8503,35 @@ pub mod cracencore {
                 Pushlen(0)
             }
         }
+        impl core::fmt::Debug for Pushlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pushlen")
+                    .field("pushlen", &self.pushlen())
+                    .field("pushcstaddr", &self.pushcstaddr())
+                    .field("pushrealign", &self.pushrealign())
+                    .field("pushdiscard", &self.pushdiscard())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pushlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pushlen {
+                    pushlen: u32,
+                    pushcstaddr: bool,
+                    pushrealign: bool,
+                    pushdiscard: bool,
+                }
+                let proxy = Pushlen {
+                    pushlen: self.pushlen(),
+                    pushcstaddr: self.pushcstaddr(),
+                    pushrealign: self.pushrealign(),
+                    pushdiscard: self.pushdiscard(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RAM error injection register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6614,6 +8564,29 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Ramerrorinject {
                 Ramerrorinject(0)
+            }
+        }
+        impl core::fmt::Debug for Ramerrorinject {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramerrorinject")
+                    .field("biterror1", &self.biterror1())
+                    .field("biterror2", &self.biterror2())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramerrorinject {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramerrorinject {
+                    biterror1: u16,
+                    biterror2: u16,
+                }
+                let proxy = Ramerrorinject {
+                    biterror1: self.biterror1(),
+                    biterror2: self.biterror2(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM error status register."]
@@ -6650,6 +8623,29 @@ pub mod cracencore {
                 Ramerrorstatus(0)
             }
         }
+        impl core::fmt::Debug for Ramerrorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ramerrorstatus")
+                    .field("ramcorrection", &self.ramcorrection())
+                    .field("ramfailure", &self.ramfailure())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ramerrorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ramerrorstatus {
+                    ramcorrection: bool,
+                    ramfailure: bool,
+                }
+                let proxy = Ramerrorstatus {
+                    ramcorrection: self.ramcorrection(),
+                    ramfailure: self.ramfailure(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Repetition Test Count Cut-Off value."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6673,6 +8669,26 @@ pub mod cracencore {
                 Repeatthreshold(0)
             }
         }
+        impl core::fmt::Debug for Repeatthreshold {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Repeatthreshold")
+                    .field("repeatthreshold", &self.repeatthreshold())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Repeatthreshold {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Repeatthreshold {
+                    repeatthreshold: u8,
+                }
+                let proxy = Repeatthreshold {
+                    repeatthreshold: self.repeatthreshold(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reseed Interval MSB register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6694,6 +8710,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Reseedintervalmsb {
                 Reseedintervalmsb(0)
+            }
+        }
+        impl core::fmt::Debug for Reseedintervalmsb {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reseedintervalmsb")
+                    .field("reseedintervalmsb", &self.reseedintervalmsb())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reseedintervalmsb {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reseedintervalmsb {
+                    reseedintervalmsb: u16,
+                }
+                let proxy = Reseedintervalmsb {
+                    reseedintervalmsb: self.reseedintervalmsb(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register"]
@@ -6897,6 +8933,74 @@ pub mod cracencore {
                 RngcontrolControl(0)
             }
         }
+        impl core::fmt::Debug for RngcontrolControl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolControl")
+                    .field("enable", &self.enable())
+                    .field("lfsren", &self.lfsren())
+                    .field("testen", &self.testen())
+                    .field("condbypass", &self.condbypass())
+                    .field("intenrep", &self.intenrep())
+                    .field("intenprop", &self.intenprop())
+                    .field("intenfull", &self.intenfull())
+                    .field("softrst", &self.softrst())
+                    .field("intenpre", &self.intenpre())
+                    .field("intenalm", &self.intenalm())
+                    .field("forceactiveros", &self.forceactiveros())
+                    .field("healthtestbypass", &self.healthtestbypass())
+                    .field("ais31bypass", &self.ais31bypass())
+                    .field("healthtestsel", &self.healthtestsel())
+                    .field("ais31testsel", &self.ais31testsel())
+                    .field("nb128bitblocks", &self.nb128bitblocks())
+                    .field("fifowritestartup", &self.fifowritestartup())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolControl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolControl {
+                    enable: bool,
+                    lfsren: bool,
+                    testen: super::vals::Testen,
+                    condbypass: super::vals::Condbypass,
+                    intenrep: bool,
+                    intenprop: bool,
+                    intenfull: bool,
+                    softrst: super::vals::ControlSoftrst,
+                    intenpre: bool,
+                    intenalm: bool,
+                    forceactiveros: bool,
+                    healthtestbypass: bool,
+                    ais31bypass: bool,
+                    healthtestsel: super::vals::Healthtestsel,
+                    ais31testsel: super::vals::Ais31testsel,
+                    nb128bitblocks: u8,
+                    fifowritestartup: bool,
+                }
+                let proxy = RngcontrolControl {
+                    enable: self.enable(),
+                    lfsren: self.lfsren(),
+                    testen: self.testen(),
+                    condbypass: self.condbypass(),
+                    intenrep: self.intenrep(),
+                    intenprop: self.intenprop(),
+                    intenfull: self.intenfull(),
+                    softrst: self.softrst(),
+                    intenpre: self.intenpre(),
+                    intenalm: self.intenalm(),
+                    forceactiveros: self.forceactiveros(),
+                    healthtestbypass: self.healthtestbypass(),
+                    ais31bypass: self.ais31bypass(),
+                    healthtestsel: self.healthtestsel(),
+                    ais31testsel: self.ais31testsel(),
+                    nb128bitblocks: self.nb128bitblocks(),
+                    fifowritestartup: self.fifowritestartup(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hardware configuration register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6940,6 +9044,32 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> RngcontrolHwconfig {
                 RngcontrolHwconfig(0)
+            }
+        }
+        impl core::fmt::Debug for RngcontrolHwconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolHwconfig")
+                    .field("numbofrings", &self.numbofrings())
+                    .field("ais31", &self.ais31())
+                    .field("ais31full", &self.ais31full())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolHwconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolHwconfig {
+                    numbofrings: u8,
+                    ais31: bool,
+                    ais31full: bool,
+                }
+                let proxy = RngcontrolHwconfig {
+                    numbofrings: self.numbofrings(),
+                    ais31: self.ais31(),
+                    ais31full: self.ais31full(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status register."]
@@ -7053,6 +9183,50 @@ pub mod cracencore {
                 RngcontrolStatus(0)
             }
         }
+        impl core::fmt::Debug for RngcontrolStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RngcontrolStatus")
+                    .field("testdatabusy", &self.testdatabusy())
+                    .field("state", &self.state())
+                    .field("repfail", &self.repfail())
+                    .field("propfail", &self.propfail())
+                    .field("fullint", &self.fullint())
+                    .field("preint", &self.preint())
+                    .field("almint", &self.almint())
+                    .field("startupfail", &self.startupfail())
+                    .field("fifoaccfail", &self.fifoaccfail())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RngcontrolStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RngcontrolStatus {
+                    testdatabusy: bool,
+                    state: super::vals::State,
+                    repfail: bool,
+                    propfail: bool,
+                    fullint: bool,
+                    preint: bool,
+                    almint: bool,
+                    startupfail: bool,
+                    fifoaccfail: bool,
+                }
+                let proxy = RngcontrolStatus {
+                    testdatabusy: self.testdatabusy(),
+                    state: self.state(),
+                    repfail: self.repfail(),
+                    propfail: self.propfail(),
+                    fullint: self.fullint(),
+                    preint: self.preint(),
+                    almint: self.almint(),
+                    startupfail: self.startupfail(),
+                    fifoaccfail: self.fifoaccfail(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SoftRst register."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7074,6 +9248,26 @@ pub mod cracencore {
             #[inline(always)]
             fn default() -> Softrst {
                 Softrst(0)
+            }
+        }
+        impl core::fmt::Debug for Softrst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Softrst")
+                    .field("softrst", &self.softrst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Softrst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Softrst {
+                    softrst: super::vals::SoftrstSoftrst,
+                }
+                let proxy = Softrst {
+                    softrst: self.softrst(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Switch off timer value."]
@@ -7099,10 +9293,31 @@ pub mod cracencore {
                 Swofftmrval(0)
             }
         }
+        impl core::fmt::Debug for Swofftmrval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swofftmrval")
+                    .field("swofftmrval", &self.swofftmrval())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swofftmrval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swofftmrval {
+                    swofftmrval: u16,
+                }
+                let proxy = Swofftmrval {
+                    swofftmrval: self.swofftmrval(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ahbmaster {
             #[doc = "Memory access through AHB Slave and internally in the PKE."]
             SLAVE = 0x0,
@@ -7132,7 +9347,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ais31testsel {
             #[doc = "Before conditioning."]
             BEFORE = 0x0,
@@ -7162,7 +9378,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Calcr2 {
             #[doc = "don't recalculate R² mod N"]
             NRECALCULATE = 0x0,
@@ -7192,7 +9409,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Condbypass {
             #[doc = "the conditioning function is used (normal mode)."]
             NORMAL = 0x0,
@@ -7222,7 +9440,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ControlSoftrst {
             #[doc = "Normal mode."]
             NORMAL = 0x0,
@@ -7252,7 +9471,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Curve {
             #[doc = "P256."]
             P256 = 0x0,
@@ -7285,7 +9505,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Healthtestsel {
             #[doc = "Before conditioning."]
             BEFORE = 0x0,
@@ -7315,7 +9536,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Keysize {
             _RESERVED_0 = 0x0,
             #[doc = "supports AES128"]
@@ -7352,7 +9574,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nbmult {
             #[doc = "1 multiplier"]
             MULT1 = 0x0,
@@ -7399,7 +9622,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Opsel {
             #[doc = "Public Key Generation"]
             PUBKEY = 0x0,
@@ -7454,6 +9678,31 @@ pub mod cracencore {
                 self.0
             }
         }
+        impl core::fmt::Debug for Opsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("OPSIZE256"),
+                    0x0209 => f.write_str("OPSIZE521"),
+                    0x0800 => f.write_str("OPSIZE2048"),
+                    0x0c00 => f.write_str("OPSIZE3072"),
+                    0x1000 => f.write_str("OPSIZE4096"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Opsize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "OPSIZE256"),
+                    0x0209 => defmt::write!(f, "OPSIZE521"),
+                    0x0800 => defmt::write!(f, "OPSIZE2048"),
+                    0x0c00 => defmt::write!(f, "OPSIZE3072"),
+                    0x1000 => defmt::write!(f, "OPSIZE4096"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Opsize {
             #[inline(always)]
             fn from(val: u16) -> Opsize {
@@ -7467,7 +9716,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Selcurve {
             #[doc = "Unspecified"]
             NOACCEL = 0x0,
@@ -7508,7 +9758,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SoftrstSoftrst {
             #[doc = "Normal mode."]
             NORMAL = 0x0,
@@ -7538,7 +9789,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Reset"]
             RESET = 0x0,
@@ -7578,7 +9830,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swapbytes {
             #[doc = "Native format (little endian)."]
             NATIVE = 0x0,
@@ -7608,7 +9861,8 @@ pub mod cracencore {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Testen {
             #[doc = "Noise source (normal mode)."]
             NORMAL = 0x0,
@@ -7801,6 +10055,29 @@ pub mod ctrlapperi {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxready", &self.rxready())
+                    .field("txdone", &self.txdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxready: bool,
+                    txdone: bool,
+                }
+                let proxy = Int {
+                    rxready: self.rxready(),
+                    txdone: self.txdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register locks the ERASEPROTECT.DISABLE register from being written until next reset."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7822,6 +10099,22 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Lock {
                 Lock(0)
+            }
+        }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System reset request."]
@@ -7847,6 +10140,26 @@ pub mod ctrlapperi {
                 Reset(0)
             }
         }
+        impl core::fmt::Debug for Reset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reset")
+                    .field("reset", &self.reset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reset {
+                    reset: super::vals::Reset,
+                }
+                let proxy = Reset {
+                    reset: self.reset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status to indicate if data sent from the debugger to the CPU has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7868,6 +10181,26 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Rxstatus {
                 Rxstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status to indicate if data sent from the CPU to the debugger has been read."]
@@ -7893,10 +10226,31 @@ pub mod ctrlapperi {
                 Txstatus(0)
             }
         }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reset {
             #[doc = "No reset is generated"]
             NO_RESET = 0x0,
@@ -8072,6 +10426,79 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 24usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8097,6 +10524,79 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                            self.ch(16usize),
+                            self.ch(17usize),
+                            self.ch(18usize),
+                            self.ch(19usize),
+                            self.ch(20usize),
+                            self.ch(21usize),
+                            self.ch(22usize),
+                            self.ch(23usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 24usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                        self.ch(16usize),
+                        self.ch(17usize),
+                        self.ch(18usize),
+                        self.ch(19usize),
+                        self.ch(20usize),
+                        self.ch(21usize),
+                        self.ch(22usize),
+                        self.ch(23usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8288,6 +10788,26 @@ pub mod ecb {
                 Errorstatus(0)
             }
         }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("errorstatus", &self.errorstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    errorstatus: super::vals::Errorstatus,
+                }
+                let proxy = Errorstatus {
+                    errorstatus: self.errorstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8322,10 +10842,34 @@ pub mod ecb {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    error: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorstatus {
             #[doc = "No errors have occurred"]
             NO_ERROR = 0x0,
@@ -8457,6 +11001,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -8677,6 +11278,24 @@ pub mod ficr {
                 Configid(0)
             }
         }
+        impl core::fmt::Debug for Configid {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configid")
+                    .field("hwid", &self.hwid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configid {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configid {
+                    hwid: u16,
+                }
+                let proxy = Configid { hwid: self.hwid() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8698,6 +11317,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Deviceaddrtype {
                 Deviceaddrtype(0)
+            }
+        }
+        impl core::fmt::Debug for Deviceaddrtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Deviceaddrtype")
+                    .field("deviceaddrtype", &self.deviceaddrtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Deviceaddrtype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Deviceaddrtype {
+                    deviceaddrtype: super::vals::Deviceaddrtype,
+                }
+                let proxy = Deviceaddrtype {
+                    deviceaddrtype: self.deviceaddrtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Package option"]
@@ -8724,6 +11363,26 @@ pub mod ficr {
                 Package(0)
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part code"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8746,6 +11405,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Part {
                 Part(0)
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM size (KB)"]
@@ -8772,6 +11447,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RRAM size (KB)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8794,6 +11485,22 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Rram {
                 Rram(0)
+            }
+        }
+        impl core::fmt::Debug for Rram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rram").field("rram", &self.rram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rram {
+                    rram: super::vals::Rram,
+                }
+                let proxy = Rram { rram: self.rram() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -8852,6 +11559,35 @@ pub mod ficr {
                 Tagheader0(0)
             }
         }
+        impl core::fmt::Debug for Tagheader0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader0")
+                    .field("mfgid", &self.mfgid())
+                    .field("ud1", &self.ud1())
+                    .field("ud2", &self.ud2())
+                    .field("ud3", &self.ud3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader0 {
+                    mfgid: u8,
+                    ud1: u8,
+                    ud2: u8,
+                    ud3: u8,
+                }
+                let proxy = Tagheader0 {
+                    mfgid: self.mfgid(),
+                    ud1: self.ud1(),
+                    ud2: self.ud2(),
+                    ud3: self.ud3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8906,6 +11642,35 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Tagheader1 {
                 Tagheader1(0)
+            }
+        }
+        impl core::fmt::Debug for Tagheader1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader1")
+                    .field("ud4", &self.ud4())
+                    .field("ud5", &self.ud5())
+                    .field("ud6", &self.ud6())
+                    .field("ud7", &self.ud7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader1 {
+                    ud4: u8,
+                    ud5: u8,
+                    ud6: u8,
+                    ud7: u8,
+                }
+                let proxy = Tagheader1 {
+                    ud4: self.ud4(),
+                    ud5: self.ud5(),
+                    ud6: self.ud6(),
+                    ud7: self.ud7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
@@ -8964,6 +11729,35 @@ pub mod ficr {
                 Tagheader2(0)
             }
         }
+        impl core::fmt::Debug for Tagheader2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader2")
+                    .field("ud8", &self.ud8())
+                    .field("ud9", &self.ud9())
+                    .field("ud10", &self.ud10())
+                    .field("ud11", &self.ud11())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader2 {
+                    ud8: u8,
+                    ud9: u8,
+                    ud10: u8,
+                    ud11: u8,
+                }
+                let proxy = Tagheader2 {
+                    ud8: self.ud8(),
+                    ud9: self.ud9(),
+                    ud10: self.ud10(),
+                    ud11: self.ud11(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default header for NFC Tag. Software can read these values to populate NFCID1_3RD_LAST, NFCID1_2ND_LAST and NFCID1_LAST."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9020,6 +11814,35 @@ pub mod ficr {
                 Tagheader3(0)
             }
         }
+        impl core::fmt::Debug for Tagheader3 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tagheader3")
+                    .field("ud12", &self.ud12())
+                    .field("ud13", &self.ud13())
+                    .field("ud14", &self.ud14())
+                    .field("ud15", &self.ud15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tagheader3 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tagheader3 {
+                    ud12: u8,
+                    ud13: u8,
+                    ud14: u8,
+                    ud15: u8,
+                }
+                let proxy = Tagheader3 {
+                    ud12: self.ud12(),
+                    ud13: self.ud13(),
+                    ud14: self.ud14(),
+                    ud15: self.ud15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Part Variant, Hardware version and Production configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9042,6 +11865,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Variant {
                 Variant(0)
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Variant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Variant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = Variant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "XOSC32K capacitor selection trim values"]
@@ -9078,6 +11921,29 @@ pub mod ficr {
                 Xosc32ktrim(0)
             }
         }
+        impl core::fmt::Debug for Xosc32ktrim {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32ktrim")
+                    .field("slope", &self.slope())
+                    .field("offset", &self.offset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32ktrim {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32ktrim {
+                    slope: u16,
+                    offset: u16,
+                }
+                let proxy = Xosc32ktrim {
+                    slope: self.slope(),
+                    offset: self.offset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "XOSC32M capacitor selection trim values"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9112,10 +11978,34 @@ pub mod ficr {
                 Xosc32mtrim(0)
             }
         }
+        impl core::fmt::Debug for Xosc32mtrim {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32mtrim")
+                    .field("slope", &self.slope())
+                    .field("offset", &self.offset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32mtrim {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32mtrim {
+                    slope: u16,
+                    offset: u16,
+                }
+                let proxy = Xosc32mtrim {
+                    slope: self.slope(),
+                    offset: self.offset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Deviceaddrtype {
             #[doc = "Public address"]
             PUBLIC = 0x0,
@@ -9159,6 +12049,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Package {
             #[inline(always)]
             fn from(val: u32) -> Package {
@@ -9186,6 +12093,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0005_4b15 => f.write_str("N54L15"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0005_4b15 => defmt::write!(f, "N54L15"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Part {
@@ -9217,6 +12143,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Ram {
             #[inline(always)]
             fn from(val: u32) -> Ram {
@@ -9246,6 +12191,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x05f4 => f.write_str("K1524"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x05f4 => defmt::write!(f, "K1524"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rram {
             #[inline(always)]
             fn from(val: u32) -> Rram {
@@ -9271,6 +12235,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -9345,10 +12326,34 @@ pub mod glitchdet {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("enable", &self.enable())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    enable: bool,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Config {
+                    enable: self.enable(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "High pass filter mode"]
             HIGH_PASS_FILTER = 0x0,
@@ -9475,6 +12480,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Direction of GPIO pins"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9500,6 +12525,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dir {
                 Dir(0)
+            }
+        }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR clear register"]
@@ -9529,6 +12643,95 @@ pub mod gpio {
                 Dirclr(0)
             }
         }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR set register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9554,6 +12757,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirset {
                 Dirset(0)
+            }
+        }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Read GPIO port"]
@@ -9583,6 +12875,95 @@ pub mod gpio {
                 In(0)
             }
         }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9608,6 +12989,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Latch {
                 Latch(0)
+            }
+        }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Write GPIO port"]
@@ -9637,6 +13107,95 @@ pub mod gpio {
                 Out(0)
             }
         }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clear individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9664,6 +13223,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9689,6 +13337,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Pin n configuration of GPIO pin"]
@@ -9783,10 +13520,49 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive0", &self.drive0())
+                    .field("drive1", &self.drive1())
+                    .field("sense", &self.sense())
+                    .field("ctrlsel", &self.ctrlsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive0: super::vals::Drive,
+                    drive1: super::vals::Drive,
+                    sense: super::vals::Sense,
+                    ctrlsel: super::vals::Ctrlsel,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive0: self.drive0(),
+                    drive1: self.drive1(),
+                    sense: self.sense(),
+                    ctrlsel: self.ctrlsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctrlsel {
             #[doc = "GPIO or peripherals with PSEL registers"]
             GPIO = 0x0,
@@ -9823,7 +13599,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -9853,7 +13630,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -9883,7 +13661,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0'"]
             S = 0x0,
@@ -9917,7 +13696,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -9947,7 +13727,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -9980,7 +13761,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -10250,6 +14032,38 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("port", &self.port())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    port: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    port: self.port(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10299,10 +14113,58 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port0nonsecure", &self.port0nonsecure())
+                    .field("port0secure", &self.port0secure())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port0nonsecure: bool,
+                    port0secure: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port0nonsecure: self.port0nonsecure(),
+                    port0secure: self.port0secure(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -10335,7 +14197,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -10365,7 +14228,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -10667,6 +14531,26 @@ pub mod grtc {
                 Active(0)
             }
         }
+        impl core::fmt::Debug for Active {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Active")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Active {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Active {
+                    active: bool,
+                }
+                let proxy = Active {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Count to add to CC\\[n\\] when this register is written."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10703,6 +14587,29 @@ pub mod grtc {
                 Ccadd(0)
             }
         }
+        impl core::fmt::Debug for Ccadd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccadd")
+                    .field("value", &self.value())
+                    .field("reference", &self.reference())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccadd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccadd {
+                    value: u32,
+                    reference: super::vals::Reference,
+                }
+                let proxy = Ccadd {
+                    value: self.value(),
+                    reference: self.reference(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Configure Capture/Compare register CC\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10724,6 +14631,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Ccen {
                 Ccen(0)
+            }
+        }
+        impl core::fmt::Debug for Ccen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccen")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccen {
+                    active: bool,
+                }
+                let proxy = Ccen {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: The higher 32-bits of Capture/Compare register CC\\[n\\]"]
@@ -10748,6 +14675,22 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Cch {
                 Cch(0)
+            }
+        }
+        impl core::fmt::Debug for Cch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cch").field("cch", &self.cch()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cch {
+                    cch: u32,
+                }
+                let proxy = Cch { cch: self.cch() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock Configuration"]
@@ -10785,6 +14728,29 @@ pub mod grtc {
                 Clkcfg(0)
             }
         }
+        impl core::fmt::Debug for Clkcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkcfg")
+                    .field("clkfastdiv", &self.clkfastdiv())
+                    .field("clksel", &self.clksel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkcfg {
+                    clkfastdiv: u8,
+                    clksel: super::vals::Clksel,
+                }
+                let proxy = Clkcfg {
+                    clkfastdiv: self.clkfastdiv(),
+                    clksel: self.clksel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of clock output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10819,6 +14785,29 @@ pub mod grtc {
                 Clkout(0)
             }
         }
+        impl core::fmt::Debug for Clkout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clkout")
+                    .field("clkout32k", &self.clkout32k())
+                    .field("clkoutfast", &self.clkoutfast())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clkout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clkout {
+                    clkout32k: bool,
+                    clkoutfast: bool,
+                }
+                let proxy = Clkout {
+                    clkout32k: self.clkout32k(),
+                    clkoutfast: self.clkoutfast(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable event routing"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10840,6 +14829,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Evt {
                 Evt(0)
+            }
+        }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    pwmperiodend: bool,
+                }
+                let proxy = Evt {
+                    pwmperiodend: self.pwmperiodend(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -11008,6 +15017,65 @@ pub mod grtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("compare0", &self.compare0())
+                    .field("compare1", &self.compare1())
+                    .field("compare2", &self.compare2())
+                    .field("compare3", &self.compare3())
+                    .field("compare4", &self.compare4())
+                    .field("compare5", &self.compare5())
+                    .field("compare6", &self.compare6())
+                    .field("compare7", &self.compare7())
+                    .field("compare8", &self.compare8())
+                    .field("compare9", &self.compare9())
+                    .field("compare10", &self.compare10())
+                    .field("compare11", &self.compare11())
+                    .field("rtcomparesync", &self.rtcomparesync())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare0: bool,
+                    compare1: bool,
+                    compare2: bool,
+                    compare3: bool,
+                    compare4: bool,
+                    compare5: bool,
+                    compare6: bool,
+                    compare7: bool,
+                    compare8: bool,
+                    compare9: bool,
+                    compare10: bool,
+                    compare11: bool,
+                    rtcomparesync: bool,
+                    pwmperiodend: bool,
+                }
+                let proxy = Int {
+                    compare0: self.compare0(),
+                    compare1: self.compare1(),
+                    compare2: self.compare2(),
+                    compare3: self.compare3(),
+                    compare4: self.compare4(),
+                    compare5: self.compare5(),
+                    compare6: self.compare6(),
+                    compare7: self.compare7(),
+                    compare8: self.compare8(),
+                    compare9: self.compare9(),
+                    compare10: self.compare10(),
+                    compare11: self.compare11(),
+                    rtcomparesync: self.rtcomparesync(),
+                    pwmperiodend: self.pwmperiodend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Count to add to CC\\[0\\] when the event EVENTS_COMPARE\\[0\\] triggers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11029,6 +15097,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Interval {
                 Interval(0)
+            }
+        }
+        impl core::fmt::Debug for Interval {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Interval")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Interval {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Interval {
+                    value: u16,
+                }
+                let proxy = Interval {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Counter mode selection"]
@@ -11065,6 +15153,29 @@ pub mod grtc {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("autoen", &self.autoen())
+                    .field("syscounteren", &self.syscounteren())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    autoen: super::vals::Autoen,
+                    syscounteren: bool,
+                }
+                let proxy = Mode {
+                    autoen: self.autoen(),
+                    syscounteren: self.syscounteren(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM configuration."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11088,6 +15199,26 @@ pub mod grtc {
                 Pwmconfig(0)
             }
         }
+        impl core::fmt::Debug for Pwmconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pwmconfig")
+                    .field("comparevalue", &self.comparevalue())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pwmconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pwmconfig {
+                    comparevalue: u8,
+                }
+                let proxy = Pwmconfig {
+                    comparevalue: self.comparevalue(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11109,6 +15240,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("rtcompare_clear", &self.rtcompare_clear())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    rtcompare_clear: bool,
+                }
+                let proxy = Shorts {
+                    rtcompare_clear: self.rtcompare_clear(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: The higher 20-bits of the SYSCOUNTER for index \\[n\\]"]
@@ -11158,6 +15309,32 @@ pub mod grtc {
                 Syscounterh(0)
             }
         }
+        impl core::fmt::Debug for Syscounterh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syscounterh")
+                    .field("value", &self.value())
+                    .field("busy", &self.busy())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syscounterh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syscounterh {
+                    value: u32,
+                    busy: super::vals::Busy,
+                    overflow: bool,
+                }
+                let proxy = Syscounterh {
+                    value: self.value(),
+                    busy: self.busy(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timeout after all CPUs gone into sleep state to stop the SYSCOUNTER"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11179,6 +15356,26 @@ pub mod grtc {
             #[inline(always)]
             fn default() -> Timeout {
                 Timeout(0)
+            }
+        }
+        impl core::fmt::Debug for Timeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Timeout")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Timeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Timeout {
+                    value: u16,
+                }
+                let proxy = Timeout {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GRTC wake up time."]
@@ -11204,10 +15401,31 @@ pub mod grtc {
                 Waketime(0)
             }
         }
+        impl core::fmt::Debug for Waketime {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Waketime")
+                    .field("value", &self.value())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Waketime {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Waketime {
+                    value: u8,
+                }
+                let proxy = Waketime {
+                    value: self.value(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Autoen {
             #[doc = "Default configuration to keep the SYSCOUNTER active."]
             DEFAULT = 0x0,
@@ -11237,7 +15455,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Busy {
             #[doc = "SYSCOUNTER is ready for read"]
             READY = 0x0,
@@ -11267,7 +15486,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clksel {
             #[doc = "GRTC LFCLK clock source is LFXO"]
             LFXO = 0x0,
@@ -11300,7 +15520,8 @@ pub mod grtc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reference {
             #[doc = "Adds SYSCOUNTER value."]
             SYSCOUNTER = 0x0,
@@ -11706,6 +15927,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11727,6 +15968,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module"]
@@ -11752,6 +16013,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11773,6 +16054,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -11831,6 +16132,35 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .field("framestart", &self.framestart())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                    framestart: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                    framestart: self.framestart(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11854,6 +16184,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11875,6 +16225,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I2S clock generator control"]
@@ -11901,6 +16271,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11922,6 +16312,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio"]
@@ -11947,6 +16353,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11968,6 +16394,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width"]
@@ -11993,6 +16435,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12012,6 +16474,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Terminateonbuserror {
                 Terminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Transmission (TX) enable"]
@@ -12037,10 +16519,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -12070,7 +16569,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -12103,7 +16603,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -12181,6 +16682,57 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    0x2800_0000 => f.write_str("_32MDIV6"),
+                    0x3000_0000 => f.write_str("_32MDIV5"),
+                    0x4000_0000 => f.write_str("_32MDIV4"),
+                    0x5000_0000 => f.write_str("_32MDIV3"),
+                    0x8000_0000 => f.write_str("_32MDIV2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    0x2800_0000 => defmt::write!(f, "_32MDIV6"),
+                    0x3000_0000 => defmt::write!(f, "_32MDIV5"),
+                    0x4000_0000 => defmt::write!(f, "_32MDIV4"),
+                    0x5000_0000 => defmt::write!(f, "_32MDIV3"),
+                    0x8000_0000 => defmt::write!(f, "_32MDIV2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -12194,7 +16746,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -12224,7 +16777,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -12275,7 +16829,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit sample."]
             _8BIT = 0x0,
@@ -12435,6 +16990,22 @@ pub mod kmu {
                 Keyslot(0)
             }
         }
+        impl core::fmt::Debug for Keyslot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Keyslot").field("id", &self.id()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Keyslot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Keyslot {
+                    id: u8,
+                }
+                let proxy = Keyslot { id: self.id() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "KMU status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12458,10 +17029,31 @@ pub mod kmu {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "KMU is ready for new operation"]
             READY = 0x0,
@@ -12678,6 +17270,26 @@ pub mod lpcomp {
                 Anadetect(0)
             }
         }
+        impl core::fmt::Debug for Anadetect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Anadetect")
+                    .field("anadetect", &self.anadetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Anadetect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Anadetect {
+                    anadetect: super::vals::Anadetect,
+                }
+                let proxy = Anadetect {
+                    anadetect: self.anadetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable LPCOMP"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12699,6 +17311,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "External reference select"]
@@ -12735,6 +17367,29 @@ pub mod lpcomp {
                 Extrefsel(0)
             }
         }
+        impl core::fmt::Debug for Extrefsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extrefsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extrefsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extrefsel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Extrefsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Comparator hysteresis enable"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12756,6 +17411,22 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Hyst {
                 Hyst(0)
+            }
+        }
+        impl core::fmt::Debug for Hyst {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hyst").field("hyst", &self.hyst()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hyst {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hyst {
+                    hyst: bool,
+                }
+                let proxy = Hyst { hyst: self.hyst() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -12814,6 +17485,35 @@ pub mod lpcomp {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("down", &self.down())
+                    .field("up", &self.up())
+                    .field("cross", &self.cross())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    down: bool,
+                    up: bool,
+                    cross: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    down: self.down(),
+                    up: self.up(),
+                    cross: self.cross(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Input pin select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12848,6 +17548,29 @@ pub mod lpcomp {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reference select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12871,6 +17594,26 @@ pub mod lpcomp {
                 Refsel(0)
             }
         }
+        impl core::fmt::Debug for Refsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refsel")
+                    .field("refsel", &self.refsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refsel {
+                    refsel: super::vals::Refsel,
+                }
+                let proxy = Refsel {
+                    refsel: self.refsel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Compare result"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12892,6 +17635,26 @@ pub mod lpcomp {
             #[inline(always)]
             fn default() -> Result {
                 Result(0)
+            }
+        }
+        impl core::fmt::Debug for Result {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Result")
+                    .field("result", &self.result())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Result {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Result {
+                    result: super::vals::Result,
+                }
+                let proxy = Result {
+                    result: self.result(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12961,10 +17724,43 @@ pub mod lpcomp {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_sample", &self.ready_sample())
+                    .field("ready_stop", &self.ready_stop())
+                    .field("down_stop", &self.down_stop())
+                    .field("up_stop", &self.up_stop())
+                    .field("cross_stop", &self.cross_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_sample: bool,
+                    ready_stop: bool,
+                    down_stop: bool,
+                    up_stop: bool,
+                    cross_stop: bool,
+                }
+                let proxy = Shorts {
+                    ready_sample: self.ready_sample(),
+                    ready_stop: self.ready_stop(),
+                    down_stop: self.down_stop(),
+                    up_stop: self.up_stop(),
+                    cross_stop: self.cross_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Anadetect {
             #[doc = "Generate ANADETECT on crossing, both upward crossing and downward crossing"]
             CROSS = 0x0,
@@ -12997,7 +17793,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable"]
             DISABLED = 0x0,
@@ -13029,7 +17826,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "VDD * 1/8 selected as reference"]
             REF1_8VDD = 0x0,
@@ -13087,7 +17885,8 @@ pub mod lpcomp {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Result {
             #[doc = "Input voltage is below the reference threshold (VIN+ &lt; VIN-)"]
             BELOW = 0x0,
@@ -13539,6 +18338,119 @@ pub mod memconf {
                 Control(0)
             }
         }
+        impl core::fmt::Debug for Control {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Control")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Control {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Control {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Control {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAM retention for RAM \\[n\\]."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13903,6 +18815,119 @@ pub mod memconf {
                 Ret(0)
             }
         }
+        impl core::fmt::Debug for Ret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ret")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ret {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Ret {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: RAM retention for the second bank in the RAM block"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14265,6 +19290,119 @@ pub mod memconf {
             #[inline(always)]
             fn default() -> Ret2 {
                 Ret2(0)
+            }
+        }
+        impl core::fmt::Debug for Ret2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ret2")
+                    .field("mem0", &self.mem0())
+                    .field("mem1", &self.mem1())
+                    .field("mem2", &self.mem2())
+                    .field("mem3", &self.mem3())
+                    .field("mem4", &self.mem4())
+                    .field("mem5", &self.mem5())
+                    .field("mem6", &self.mem6())
+                    .field("mem7", &self.mem7())
+                    .field("mem8", &self.mem8())
+                    .field("mem9", &self.mem9())
+                    .field("mem10", &self.mem10())
+                    .field("mem11", &self.mem11())
+                    .field("mem12", &self.mem12())
+                    .field("mem13", &self.mem13())
+                    .field("mem14", &self.mem14())
+                    .field("mem15", &self.mem15())
+                    .field("mem16", &self.mem16())
+                    .field("mem17", &self.mem17())
+                    .field("mem18", &self.mem18())
+                    .field("mem19", &self.mem19())
+                    .field("mem20", &self.mem20())
+                    .field("mem21", &self.mem21())
+                    .field("mem22", &self.mem22())
+                    .field("mem23", &self.mem23())
+                    .field("mem24", &self.mem24())
+                    .field("mem25", &self.mem25())
+                    .field("mem26", &self.mem26())
+                    .field("mem27", &self.mem27())
+                    .field("mem28", &self.mem28())
+                    .field("mem29", &self.mem29())
+                    .field("mem30", &self.mem30())
+                    .field("mem31", &self.mem31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ret2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ret2 {
+                    mem0: bool,
+                    mem1: bool,
+                    mem2: bool,
+                    mem3: bool,
+                    mem4: bool,
+                    mem5: bool,
+                    mem6: bool,
+                    mem7: bool,
+                    mem8: bool,
+                    mem9: bool,
+                    mem10: bool,
+                    mem11: bool,
+                    mem12: bool,
+                    mem13: bool,
+                    mem14: bool,
+                    mem15: bool,
+                    mem16: bool,
+                    mem17: bool,
+                    mem18: bool,
+                    mem19: bool,
+                    mem20: bool,
+                    mem21: bool,
+                    mem22: bool,
+                    mem23: bool,
+                    mem24: bool,
+                    mem25: bool,
+                    mem26: bool,
+                    mem27: bool,
+                    mem28: bool,
+                    mem29: bool,
+                    mem30: bool,
+                    mem31: bool,
+                }
+                let proxy = Ret2 {
+                    mem0: self.mem0(),
+                    mem1: self.mem1(),
+                    mem2: self.mem2(),
+                    mem3: self.mem3(),
+                    mem4: self.mem4(),
+                    mem5: self.mem5(),
+                    mem6: self.mem6(),
+                    mem7: self.mem7(),
+                    mem8: self.mem8(),
+                    mem9: self.mem9(),
+                    mem10: self.mem10(),
+                    mem11: self.mem11(),
+                    mem12: self.mem12(),
+                    mem13: self.mem13(),
+                    mem14: self.mem14(),
+                    mem15: self.mem15(),
+                    mem16: self.mem16(),
+                    mem17: self.mem17(),
+                    mem18: self.mem18(),
+                    mem19: self.mem19(),
+                    mem20: self.mem20(),
+                    mem21: self.mem21(),
+                    mem22: self.mem22(),
+                    mem23: self.mem23(),
+                    mem24: self.mem24(),
+                    mem25: self.mem25(),
+                    mem26: self.mem26(),
+                    mem27: self.mem27(),
+                    mem28: self.mem28(),
+                    mem29: self.mem29(),
+                    mem30: self.mem30(),
+                    mem31: self.mem31(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -14656,6 +19794,68 @@ pub mod mpc {
                 GlobalslaveMasterport(0)
             }
         }
+        impl core::fmt::Debug for GlobalslaveMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlobalslaveMasterport")
+                    .field("connection_0", &self.connection_0())
+                    .field("connection_1", &self.connection_1())
+                    .field("connection_2", &self.connection_2())
+                    .field("connection_3", &self.connection_3())
+                    .field("connection_4", &self.connection_4())
+                    .field("connection_5", &self.connection_5())
+                    .field("connection_6", &self.connection_6())
+                    .field("connection_7", &self.connection_7())
+                    .field("connection_8", &self.connection_8())
+                    .field("connection_9", &self.connection_9())
+                    .field("connection_10", &self.connection_10())
+                    .field("connection_11", &self.connection_11())
+                    .field("connection_12", &self.connection_12())
+                    .field("connection_13", &self.connection_13())
+                    .field("connection_14", &self.connection_14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlobalslaveMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlobalslaveMasterport {
+                    connection_0: bool,
+                    connection_1: bool,
+                    connection_2: bool,
+                    connection_3: bool,
+                    connection_4: bool,
+                    connection_5: bool,
+                    connection_6: bool,
+                    connection_7: bool,
+                    connection_8: bool,
+                    connection_9: bool,
+                    connection_10: bool,
+                    connection_11: bool,
+                    connection_12: bool,
+                    connection_13: bool,
+                    connection_14: bool,
+                }
+                let proxy = GlobalslaveMasterport {
+                    connection_0: self.connection_0(),
+                    connection_1: self.connection_1(),
+                    connection_2: self.connection_2(),
+                    connection_3: self.connection_3(),
+                    connection_4: self.connection_4(),
+                    connection_5: self.connection_5(),
+                    connection_6: self.connection_6(),
+                    connection_7: self.connection_7(),
+                    connection_8: self.connection_8(),
+                    connection_9: self.connection_9(),
+                    connection_10: self.connection_10(),
+                    connection_11: self.connection_11(),
+                    connection_12: self.connection_12(),
+                    connection_13: self.connection_13(),
+                    connection_14: self.connection_14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Access information for the transaction that triggered a memory access error. Register content won't be changed as long as MEMACCERR event is active."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14746,6 +19946,44 @@ pub mod mpc {
                 Info(0)
             }
         }
+        impl core::fmt::Debug for Info {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Info")
+                    .field("ownerid", &self.ownerid())
+                    .field("masterport", &self.masterport())
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("errorsource", &self.errorsource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Info {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Info {
+                    ownerid: u8,
+                    masterport: u8,
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    errorsource: super::vals::Errorsource,
+                }
+                let proxy = Info {
+                    ownerid: self.ownerid(),
+                    masterport: self.masterport(),
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    errorsource: self.errorsource(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14769,6 +20007,26 @@ pub mod mpc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("memaccerr", &self.memaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    memaccerr: bool,
+                }
+                let proxy = Int {
+                    memaccerr: self.memaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Lock global slave registers"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14790,6 +20048,22 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Lock {
                 Lock(0)
+            }
+        }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Override region n Configuration register"]
@@ -14846,6 +20120,35 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> OverrideConfig {
                 OverrideConfig(0)
+            }
+        }
+        impl core::fmt::Debug for OverrideConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("OverrideConfig")
+                    .field("slavenumber", &self.slavenumber())
+                    .field("lock", &self.lock())
+                    .field("enable", &self.enable())
+                    .field("securemask", &self.securemask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for OverrideConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct OverrideConfig {
+                    slavenumber: u8,
+                    lock: bool,
+                    enable: bool,
+                    securemask: bool,
+                }
+                let proxy = OverrideConfig {
+                    slavenumber: self.slavenumber(),
+                    lock: self.lock(),
+                    enable: self.enable(),
+                    securemask: self.securemask(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Override region n local master enable"]
@@ -15025,6 +20328,68 @@ pub mod mpc {
                 OverrideMasterport(0)
             }
         }
+        impl core::fmt::Debug for OverrideMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("OverrideMasterport")
+                    .field("enable0", &self.enable0())
+                    .field("enable1", &self.enable1())
+                    .field("enable2", &self.enable2())
+                    .field("enable3", &self.enable3())
+                    .field("enable4", &self.enable4())
+                    .field("enable5", &self.enable5())
+                    .field("enable6", &self.enable6())
+                    .field("enable7", &self.enable7())
+                    .field("enable8", &self.enable8())
+                    .field("enable9", &self.enable9())
+                    .field("enable10", &self.enable10())
+                    .field("enable11", &self.enable11())
+                    .field("enable12", &self.enable12())
+                    .field("enable13", &self.enable13())
+                    .field("enable14", &self.enable14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for OverrideMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct OverrideMasterport {
+                    enable0: bool,
+                    enable1: bool,
+                    enable2: bool,
+                    enable3: bool,
+                    enable4: bool,
+                    enable5: bool,
+                    enable6: bool,
+                    enable7: bool,
+                    enable8: bool,
+                    enable9: bool,
+                    enable10: bool,
+                    enable11: bool,
+                    enable12: bool,
+                    enable13: bool,
+                    enable14: bool,
+                }
+                let proxy = OverrideMasterport {
+                    enable0: self.enable0(),
+                    enable1: self.enable1(),
+                    enable2: self.enable2(),
+                    enable3: self.enable3(),
+                    enable4: self.enable4(),
+                    enable5: self.enable5(),
+                    enable6: self.enable6(),
+                    enable7: self.enable7(),
+                    enable8: self.enable8(),
+                    enable9: self.enable9(),
+                    enable10: self.enable10(),
+                    enable11: self.enable11(),
+                    enable12: self.enable12(),
+                    enable13: self.enable13(),
+                    enable14: self.enable14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Owner for override region"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15046,6 +20411,26 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Owner {
                 Owner(0)
+            }
+        }
+        impl core::fmt::Debug for Owner {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Owner")
+                    .field("ownerid", &self.ownerid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Owner {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Owner {
+                    ownerid: u8,
+                }
+                let proxy = Owner {
+                    ownerid: self.ownerid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Permission settings for override region n"]
@@ -15104,6 +20489,35 @@ pub mod mpc {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secattr: bool,
+                }
+                let proxy = Perm {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Masks permission setting fields from register OVERRIDE.PERM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15158,6 +20572,35 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> Permmask {
                 Permmask(0)
+            }
+        }
+        impl core::fmt::Debug for Permmask {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Permmask")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Permmask {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Permmask {
+                    read: super::vals::PermmaskRead,
+                    write: super::vals::PermmaskWrite,
+                    execute: super::vals::PermmaskExecute,
+                    secattr: super::vals::PermmaskSecattr,
+                }
+                let proxy = Permmask {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Slave region n Configuration register"]
@@ -15258,6 +20701,47 @@ pub mod mpc {
             #[inline(always)]
             fn default() -> RegionConfig {
                 RegionConfig(0)
+            }
+        }
+        impl core::fmt::Debug for RegionConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionConfig")
+                    .field("slavenumber", &self.slavenumber())
+                    .field("lock", &self.lock())
+                    .field("enable", &self.enable())
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secattr", &self.secattr())
+                    .field("ownerid", &self.ownerid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionConfig {
+                    slavenumber: u8,
+                    lock: bool,
+                    enable: bool,
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secattr: bool,
+                    ownerid: u8,
+                }
+                let proxy = RegionConfig {
+                    slavenumber: self.slavenumber(),
+                    lock: self.lock(),
+                    enable: self.enable(),
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secattr: self.secattr(),
+                    ownerid: self.ownerid(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Region n local master enable"]
@@ -15437,10 +20921,73 @@ pub mod mpc {
                 RegionMasterport(0)
             }
         }
+        impl core::fmt::Debug for RegionMasterport {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionMasterport")
+                    .field("enable0", &self.enable0())
+                    .field("enable1", &self.enable1())
+                    .field("enable2", &self.enable2())
+                    .field("enable3", &self.enable3())
+                    .field("enable4", &self.enable4())
+                    .field("enable5", &self.enable5())
+                    .field("enable6", &self.enable6())
+                    .field("enable7", &self.enable7())
+                    .field("enable8", &self.enable8())
+                    .field("enable9", &self.enable9())
+                    .field("enable10", &self.enable10())
+                    .field("enable11", &self.enable11())
+                    .field("enable12", &self.enable12())
+                    .field("enable13", &self.enable13())
+                    .field("enable14", &self.enable14())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionMasterport {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionMasterport {
+                    enable0: bool,
+                    enable1: bool,
+                    enable2: bool,
+                    enable3: bool,
+                    enable4: bool,
+                    enable5: bool,
+                    enable6: bool,
+                    enable7: bool,
+                    enable8: bool,
+                    enable9: bool,
+                    enable10: bool,
+                    enable11: bool,
+                    enable12: bool,
+                    enable13: bool,
+                    enable14: bool,
+                }
+                let proxy = RegionMasterport {
+                    enable0: self.enable0(),
+                    enable1: self.enable1(),
+                    enable2: self.enable2(),
+                    enable3: self.enable3(),
+                    enable4: self.enable4(),
+                    enable5: self.enable5(),
+                    enable6: self.enable6(),
+                    enable7: self.enable7(),
+                    enable8: self.enable8(),
+                    enable9: self.enable9(),
+                    enable10: self.enable10(),
+                    enable11: self.enable11(),
+                    enable12: self.enable12(),
+                    enable13: self.enable13(),
+                    enable14: self.enable14(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Errorsource {
             #[doc = "Error was triggered by an AXI slave"]
             SLAVE = 0x0,
@@ -15470,7 +21017,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskExecute {
             #[doc = "Permission setting EXECUTE in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -15500,7 +21048,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskRead {
             #[doc = "Permission setting READ in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -15530,7 +21079,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskSecattr {
             #[doc = "Permission setting SECATTR in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -15560,7 +21110,8 @@ pub mod mpc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PermmaskWrite {
             #[doc = "Permission setting WRITE in OVERRIDE register will not be applied"]
             MASKED = 0x0,
@@ -16155,6 +21706,24 @@ pub mod nfct {
                 Autocolresconfig(0)
             }
         }
+        impl core::fmt::Debug for Autocolresconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Autocolresconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Autocolresconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Autocolresconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Autocolresconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC Error Status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16176,6 +21745,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Errorstatus {
                 Errorstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Errorstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorstatus")
+                    .field("framedelaytimeout", &self.framedelaytimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorstatus {
+                    framedelaytimeout: bool,
+                }
+                let proxy = Errorstatus {
+                    framedelaytimeout: self.framedelaytimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Indicates the presence or not of a valid field"]
@@ -16212,6 +21801,29 @@ pub mod nfct {
                 Fieldpresent(0)
             }
         }
+        impl core::fmt::Debug for Fieldpresent {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Fieldpresent")
+                    .field("fieldpresent", &self.fieldpresent())
+                    .field("lockdetect", &self.lockdetect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Fieldpresent {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Fieldpresent {
+                    fieldpresent: bool,
+                    lockdetect: bool,
+                }
+                let proxy = Fieldpresent {
+                    fieldpresent: self.fieldpresent(),
+                    lockdetect: self.lockdetect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum frame delay"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16234,6 +21846,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymax {
                 Framedelaymax(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymax {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymax")
+                    .field("framedelaymax", &self.framedelaymax())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymax {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymax {
+                    framedelaymax: u32,
+                }
+                let proxy = Framedelaymax {
+                    framedelaymax: self.framedelaymax(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Minimum frame delay"]
@@ -16259,6 +21891,26 @@ pub mod nfct {
                 Framedelaymin(0)
             }
         }
+        impl core::fmt::Debug for Framedelaymin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymin")
+                    .field("framedelaymin", &self.framedelaymin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymin {
+                    framedelaymin: u16,
+                }
+                let proxy = Framedelaymin {
+                    framedelaymin: self.framedelaymin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the Frame Delay Timer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16280,6 +21932,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Framedelaymode {
                 Framedelaymode(0)
+            }
+        }
+        impl core::fmt::Debug for Framedelaymode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Framedelaymode")
+                    .field("framedelaymode", &self.framedelaymode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Framedelaymode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Framedelaymode {
+                    framedelaymode: super::vals::Framedelaymode,
+                }
+                let proxy = Framedelaymode {
+                    framedelaymode: self.framedelaymode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -16459,6 +22131,68 @@ pub mod nfct {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("fielddetected", &self.fielddetected())
+                    .field("fieldlost", &self.fieldlost())
+                    .field("txframestart", &self.txframestart())
+                    .field("txframeend", &self.txframeend())
+                    .field("rxframestart", &self.rxframestart())
+                    .field("rxframeend", &self.rxframeend())
+                    .field("error", &self.error())
+                    .field("rxerror", &self.rxerror())
+                    .field("endrx", &self.endrx())
+                    .field("endtx", &self.endtx())
+                    .field("autocolresstarted", &self.autocolresstarted())
+                    .field("collision", &self.collision())
+                    .field("selected", &self.selected())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    fielddetected: bool,
+                    fieldlost: bool,
+                    txframestart: bool,
+                    txframeend: bool,
+                    rxframestart: bool,
+                    rxframeend: bool,
+                    error: bool,
+                    rxerror: bool,
+                    endrx: bool,
+                    endtx: bool,
+                    autocolresstarted: bool,
+                    collision: bool,
+                    selected: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    fielddetected: self.fielddetected(),
+                    fieldlost: self.fieldlost(),
+                    txframestart: self.txframestart(),
+                    txframeend: self.txframeend(),
+                    rxframestart: self.rxframestart(),
+                    rxframeend: self.rxframeend(),
+                    error: self.error(),
+                    rxerror: self.rxerror(),
+                    endrx: self.endrx(),
+                    endtx: self.endtx(),
+                    autocolresstarted: self.autocolresstarted(),
+                    collision: self.collision(),
+                    selected: self.selected(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Last NFCID1 part (4, 7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16515,6 +22249,35 @@ pub mod nfct {
                 Last(0)
             }
         }
+        impl core::fmt::Debug for Last {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Last")
+                    .field("z", &self.z())
+                    .field("y", &self.y())
+                    .field("x", &self.x())
+                    .field("w", &self.w())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Last {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Last {
+                    z: u8,
+                    y: u8,
+                    x: u8,
+                    w: u8,
+                }
+                let proxy = Last {
+                    z: self.z(),
+                    y: self.y(),
+                    x: self.x(),
+                    w: self.w(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of the RAM buffer allocated to TXD and RXD data storage each"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16536,6 +22299,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Maxlen {
                 Maxlen(0)
+            }
+        }
+        impl core::fmt::Debug for Maxlen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxlen")
+                    .field("maxlen", &self.maxlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxlen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxlen {
+                    maxlen: u16,
+                }
+                let proxy = Maxlen {
+                    maxlen: self.maxlen(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configure EasyDMA mode"]
@@ -16561,6 +22344,22 @@ pub mod nfct {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("lpop", &self.lpop()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    lpop: super::vals::Lpop,
+                }
+                let proxy = Mode { lpop: self.lpop() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enables the modulation output to a GPIO pin which can be connected to a second external antenna."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16582,6 +22381,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Modulationctrl {
                 Modulationctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Modulationctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationctrl")
+                    .field("modulationctrl", &self.modulationctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationctrl {
+                    modulationctrl: super::vals::Modulationctrl,
+                }
+                let proxy = Modulationctrl {
+                    modulationctrl: self.modulationctrl(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Pin select for Modulation control"]
@@ -16630,6 +22449,32 @@ pub mod nfct {
                 Modulationpsel(0)
             }
         }
+        impl core::fmt::Debug for Modulationpsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Modulationpsel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Modulationpsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Modulationpsel {
+                    pin: u8,
+                    port: u8,
+                    connect: super::super::shared::vals::Connect,
+                }
+                let proxy = Modulationpsel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current operating state of NFC tag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16653,6 +22498,26 @@ pub mod nfct {
                 Nfctagstate(0)
             }
         }
+        impl core::fmt::Debug for Nfctagstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nfctagstate")
+                    .field("nfctagstate", &self.nfctagstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nfctagstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nfctagstate {
+                    nfctagstate: super::vals::Nfctagstate,
+                }
+                let proxy = Nfctagstate {
+                    nfctagstate: self.nfctagstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC pad configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16674,6 +22539,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Padconfig {
                 Padconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Padconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Padconfig")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Padconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Padconfig {
+                    enable: bool,
+                }
+                let proxy = Padconfig {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Result of last incoming frame"]
@@ -16721,6 +22606,32 @@ pub mod nfct {
                 Rx(0)
             }
         }
+        impl core::fmt::Debug for Rx {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rx")
+                    .field("crcerror", &self.crcerror())
+                    .field("paritystatus", &self.paritystatus())
+                    .field("overrun", &self.overrun())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rx {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rx {
+                    crcerror: bool,
+                    paritystatus: bool,
+                    overrun: bool,
+                }
+                let proxy = Rx {
+                    crcerror: self.crcerror(),
+                    paritystatus: self.paritystatus(),
+                    overrun: self.overrun(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of last incoming frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16753,6 +22664,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("rxdatabits", &self.rxdatabits())
+                    .field("rxdatabytes", &self.rxdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    rxdatabits: u8,
+                    rxdatabytes: u16,
+                }
+                let proxy = RxdAmount {
+                    rxdatabits: self.rxdatabits(),
+                    rxdatabytes: self.rxdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of incoming frames"]
@@ -16800,6 +22734,32 @@ pub mod nfct {
                 RxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for RxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("sof", &self.sof())
+                    .field("crcmoderx", &self.crcmoderx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdFrameconfig {
+                    parity: bool,
+                    sof: bool,
+                    crcmoderx: bool,
+                }
+                let proxy = RxdFrameconfig {
+                    parity: self.parity(),
+                    sof: self.sof(),
+                    crcmoderx: self.crcmoderx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Second last NFCID1 part (7 or 10 bytes ID)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16843,6 +22803,32 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Secondlast {
                 Secondlast(0)
+            }
+        }
+        impl core::fmt::Debug for Secondlast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Secondlast")
+                    .field("v", &self.v())
+                    .field("u", &self.u())
+                    .field("t", &self.t())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Secondlast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Secondlast {
+                    v: u8,
+                    u: u8,
+                    t: u8,
+                }
+                let proxy = Secondlast {
+                    v: self.v(),
+                    u: self.u(),
+                    t: self.t(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "NFC-A SEL_RES auto-response settings"]
@@ -16912,6 +22898,38 @@ pub mod nfct {
                 Selres(0)
             }
         }
+        impl core::fmt::Debug for Selres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selres")
+                    .field("rfu10", &self.rfu10())
+                    .field("cascade", &self.cascade())
+                    .field("rfu43", &self.rfu43())
+                    .field("protocol", &self.protocol())
+                    .field("rfu7", &self.rfu7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selres {
+                    rfu10: u8,
+                    cascade: bool,
+                    rfu43: u8,
+                    protocol: u8,
+                    rfu7: bool,
+                }
+                let proxy = Selres {
+                    rfu10: self.rfu10(),
+                    cascade: self.cascade(),
+                    rfu43: self.rfu43(),
+                    protocol: self.protocol(),
+                    rfu7: self.rfu7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "NFC-A SENS_RES auto-response settings"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16979,6 +22997,38 @@ pub mod nfct {
                 Sensres(0)
             }
         }
+        impl core::fmt::Debug for Sensres {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sensres")
+                    .field("bitframesdd", &self.bitframesdd())
+                    .field("rfu5", &self.rfu5())
+                    .field("nfcidsize", &self.nfcidsize())
+                    .field("platfconfig", &self.platfconfig())
+                    .field("rfu74", &self.rfu74())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sensres {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sensres {
+                    bitframesdd: super::vals::Bitframesdd,
+                    rfu5: bool,
+                    nfcidsize: super::vals::Nfcidsize,
+                    platfconfig: u8,
+                    rfu74: u8,
+                }
+                let proxy = Sensres {
+                    bitframesdd: self.bitframesdd(),
+                    rfu5: self.rfu5(),
+                    nfcidsize: self.nfcidsize(),
+                    platfconfig: self.platfconfig(),
+                    rfu74: self.rfu74(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17024,6 +23074,32 @@ pub mod nfct {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("fielddetected_activate", &self.fielddetected_activate())
+                    .field("fieldlost_sense", &self.fieldlost_sense())
+                    .field("txframeend_enablerxdata", &self.txframeend_enablerxdata())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    fielddetected_activate: bool,
+                    fieldlost_sense: bool,
+                    txframeend_enablerxdata: bool,
+                }
+                let proxy = Shorts {
+                    fielddetected_activate: self.fielddetected_activate(),
+                    fieldlost_sense: self.fieldlost_sense(),
+                    txframeend_enablerxdata: self.txframeend_enablerxdata(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sleep state during automatic collision resolution"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17045,6 +23121,26 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> Sleepstate {
                 Sleepstate(0)
+            }
+        }
+        impl core::fmt::Debug for Sleepstate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sleepstate")
+                    .field("sleepstate", &self.sleepstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sleepstate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sleepstate {
+                    sleepstate: super::vals::Sleepstate,
+                }
+                let proxy = Sleepstate {
+                    sleepstate: self.sleepstate(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Third last NFCID1 part (10 bytes ID)"]
@@ -17092,6 +23188,32 @@ pub mod nfct {
                 Thirdlast(0)
             }
         }
+        impl core::fmt::Debug for Thirdlast {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Thirdlast")
+                    .field("s", &self.s())
+                    .field("r", &self.r())
+                    .field("q", &self.q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Thirdlast {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Thirdlast {
+                    s: u8,
+                    r: u8,
+                    q: u8,
+                }
+                let proxy = Thirdlast {
+                    s: self.s(),
+                    r: self.r(),
+                    q: self.q(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of outgoing frame"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17124,6 +23246,29 @@ pub mod nfct {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("txdatabits", &self.txdatabits())
+                    .field("txdatabytes", &self.txdatabytes())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    txdatabits: u8,
+                    txdatabytes: u16,
+                }
+                let proxy = TxdAmount {
+                    txdatabits: self.txdatabits(),
+                    txdatabytes: self.txdatabytes(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of outgoing frames"]
@@ -17182,10 +23327,40 @@ pub mod nfct {
                 TxdFrameconfig(0)
             }
         }
+        impl core::fmt::Debug for TxdFrameconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdFrameconfig")
+                    .field("parity", &self.parity())
+                    .field("discardmode", &self.discardmode())
+                    .field("sof", &self.sof())
+                    .field("crcmodetx", &self.crcmodetx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdFrameconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdFrameconfig {
+                    parity: bool,
+                    discardmode: super::vals::Discardmode,
+                    sof: bool,
+                    crcmodetx: bool,
+                }
+                let proxy = TxdFrameconfig {
+                    parity: self.parity(),
+                    discardmode: self.discardmode(),
+                    sof: self.sof(),
+                    crcmodetx: self.crcmodetx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitframesdd {
             #[doc = "SDD pattern 00000"]
             SDD00000 = 0x0,
@@ -17249,7 +23424,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Discardmode {
             #[doc = "Unused bits are discarded at end of frame (EoF)"]
             DISCARD_END = 0x0,
@@ -17279,7 +23455,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framedelaymode {
             #[doc = "Transmission is independent of frame timer and will start when the STARTTX task is triggered. No timeout."]
             FREE_RUN = 0x0,
@@ -17313,7 +23490,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lpop {
             #[doc = "Low-latency operation"]
             LOW_LAT = 0x0,
@@ -17346,7 +23524,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Auto collision resolution enabled"]
             ENABLED = 0x0,
@@ -17376,7 +23555,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Modulationctrl {
             #[doc = "Invalid, defaults to same behaviour as for Internal"]
             INVALID = 0x0,
@@ -17410,7 +23590,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfcidsize {
             #[doc = "NFCID1 size: single (4 bytes)"]
             NFCID1SINGLE = 0x0,
@@ -17443,7 +23624,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Nfctagstate {
             #[doc = "Disabled or sense"]
             DISABLED = 0x0,
@@ -17483,7 +23665,8 @@ pub mod nfct {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleepstate {
             #[doc = "State is IDLE."]
             IDLE = 0x0,
@@ -17664,6 +23847,24 @@ pub mod oscillators {
                 ConfigIntcap(0)
             }
         }
+        impl core::fmt::Debug for ConfigIntcap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ConfigIntcap")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ConfigIntcap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ConfigIntcap {
+                    val: u8,
+                }
+                let proxy = ConfigIntcap { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current speed of MCU power domain, including CPU"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17685,6 +23886,26 @@ pub mod oscillators {
             #[inline(always)]
             fn default() -> Currentfreq {
                 Currentfreq(0)
+            }
+        }
+        impl core::fmt::Debug for Currentfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentfreq")
+                    .field("currentfreq", &self.currentfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentfreq {
+                    currentfreq: super::vals::Currentfreq,
+                }
+                let proxy = Currentfreq {
+                    currentfreq: self.currentfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Set speed of MCU power domain, including CPU"]
@@ -17710,6 +23931,22 @@ pub mod oscillators {
                 Freq(0)
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Freq").field("freq", &self.freq()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Freq {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Freq { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Programmable capacitance of XL1 and XL2"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -17733,10 +23970,29 @@ pub mod oscillators {
                 Xosc32kiIntcap(0)
             }
         }
+        impl core::fmt::Debug for Xosc32kiIntcap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32kiIntcap")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32kiIntcap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32kiIntcap {
+                    val: u8,
+                }
+                let proxy = Xosc32kiIntcap { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Currentfreq {
             _RESERVED_0 = 0x0,
             #[doc = "128 MHz"]
@@ -17768,7 +24024,8 @@ pub mod oscillators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Freq {
             _RESERVED_0 = 0x0,
             #[doc = "128 MHz"]
@@ -18112,6 +24369,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18135,6 +24412,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18156,6 +24453,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -18214,6 +24531,35 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .field("dmabuserror", &self.dmabuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                    dmabuserror: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                    dmabuserror: self.dmabuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18235,6 +24581,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphone signals"]
@@ -18271,6 +24637,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Selects the decimation ratio between PDM_CLK and output sample rate. Change PRESCALER accordingly."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18294,6 +24683,26 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18315,10 +24724,31 @@ pub mod pdm {
                 Terminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -18366,6 +24796,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -18379,7 +24830,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -18409,7 +24861,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 32"]
             RATIO32 = 0x0,
@@ -18585,6 +25038,26 @@ pub mod power {
                 Constlatstat(0)
             }
         }
+        impl core::fmt::Debug for Constlatstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Constlatstat")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Constlatstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Constlatstat {
+                    status: bool,
+                }
+                let proxy = Constlatstat {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -18606,6 +25079,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret {
                 Gpregret(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -18651,6 +25144,32 @@ pub mod power {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -19093,6 +25612,119 @@ pub mod ppib {
             #[inline(always)]
             fn default() -> Send {
                 Send(0)
+            }
+        }
+        impl core::fmt::Debug for Send {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Send")
+                    .field("send_0", &self.send_0())
+                    .field("send_1", &self.send_1())
+                    .field("send_2", &self.send_2())
+                    .field("send_3", &self.send_3())
+                    .field("send_4", &self.send_4())
+                    .field("send_5", &self.send_5())
+                    .field("send_6", &self.send_6())
+                    .field("send_7", &self.send_7())
+                    .field("send_8", &self.send_8())
+                    .field("send_9", &self.send_9())
+                    .field("send_10", &self.send_10())
+                    .field("send_11", &self.send_11())
+                    .field("send_12", &self.send_12())
+                    .field("send_13", &self.send_13())
+                    .field("send_14", &self.send_14())
+                    .field("send_15", &self.send_15())
+                    .field("send_16", &self.send_16())
+                    .field("send_17", &self.send_17())
+                    .field("send_18", &self.send_18())
+                    .field("send_19", &self.send_19())
+                    .field("send_20", &self.send_20())
+                    .field("send_21", &self.send_21())
+                    .field("send_22", &self.send_22())
+                    .field("send_23", &self.send_23())
+                    .field("send_24", &self.send_24())
+                    .field("send_25", &self.send_25())
+                    .field("send_26", &self.send_26())
+                    .field("send_27", &self.send_27())
+                    .field("send_28", &self.send_28())
+                    .field("send_29", &self.send_29())
+                    .field("send_30", &self.send_30())
+                    .field("send_31", &self.send_31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Send {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Send {
+                    send_0: bool,
+                    send_1: bool,
+                    send_2: bool,
+                    send_3: bool,
+                    send_4: bool,
+                    send_5: bool,
+                    send_6: bool,
+                    send_7: bool,
+                    send_8: bool,
+                    send_9: bool,
+                    send_10: bool,
+                    send_11: bool,
+                    send_12: bool,
+                    send_13: bool,
+                    send_14: bool,
+                    send_15: bool,
+                    send_16: bool,
+                    send_17: bool,
+                    send_18: bool,
+                    send_19: bool,
+                    send_20: bool,
+                    send_21: bool,
+                    send_22: bool,
+                    send_23: bool,
+                    send_24: bool,
+                    send_25: bool,
+                    send_26: bool,
+                    send_27: bool,
+                    send_28: bool,
+                    send_29: bool,
+                    send_30: bool,
+                    send_31: bool,
+                }
+                let proxy = Send {
+                    send_0: self.send_0(),
+                    send_1: self.send_1(),
+                    send_2: self.send_2(),
+                    send_3: self.send_3(),
+                    send_4: self.send_4(),
+                    send_5: self.send_5(),
+                    send_6: self.send_6(),
+                    send_7: self.send_7(),
+                    send_8: self.send_8(),
+                    send_9: self.send_9(),
+                    send_10: self.send_10(),
+                    send_11: self.send_11(),
+                    send_12: self.send_12(),
+                    send_13: self.send_13(),
+                    send_14: self.send_14(),
+                    send_15: self.send_15(),
+                    send_16: self.send_16(),
+                    send_17: self.send_17(),
+                    send_18: self.send_18(),
+                    send_19: self.send_19(),
+                    send_20: self.send_20(),
+                    send_21: self.send_21(),
+                    send_22: self.send_22(),
+                    send_23: self.send_23(),
+                    send_24: self.send_24(),
+                    send_25: self.send_25(),
+                    send_26: self.send_26(),
+                    send_27: self.send_27(),
+                    send_28: self.send_28(),
+                    send_29: self.send_29(),
+                    send_30: self.send_30(),
+                    send_31: self.send_31(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -19705,6 +26337,26 @@ pub mod pwm {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19728,6 +26380,26 @@ pub mod pwm {
                 Countertop(0)
             }
         }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of bytes transferred in the current transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19749,6 +26421,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Currentamount {
                 Currentamount(0)
+            }
+        }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -19785,6 +26477,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19806,6 +26521,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -19830,6 +26565,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configure the output value on the PWM channel during idle"]
@@ -19886,6 +26639,35 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Idleout {
                 Idleout(0)
+            }
+        }
+        impl core::fmt::Debug for Idleout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Idleout")
+                    .field("val_0", &self.val_0())
+                    .field("val_1", &self.val_1())
+                    .field("val_2", &self.val_2())
+                    .field("val_3", &self.val_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Idleout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Idleout {
+                    val_0: bool,
+                    val_1: bool,
+                    val_2: bool,
+                    val_3: bool,
+                }
+                let proxy = Idleout {
+                    val_0: self.val_0(),
+                    val_1: self.val_1(),
+                    val_2: self.val_2(),
+                    val_3: self.val_3(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -20069,6 +26851,81 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .field("ramunderflow", &self.ramunderflow())
+                    .field("dmaseq0end", &self.dmaseq0end())
+                    .field("dmaseq0ready", &self.dmaseq0ready())
+                    .field("dmaseq0buserror", &self.dmaseq0buserror())
+                    .field("dmaseq1end", &self.dmaseq1end())
+                    .field("dmaseq1ready", &self.dmaseq1ready())
+                    .field("dmaseq1buserror", &self.dmaseq1buserror())
+                    .field(
+                        "comparematch",
+                        &[
+                            self.comparematch(0usize),
+                            self.comparematch(1usize),
+                            self.comparematch(2usize),
+                            self.comparematch(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                    ramunderflow: bool,
+                    dmaseq0end: bool,
+                    dmaseq0ready: bool,
+                    dmaseq0buserror: bool,
+                    dmaseq1end: bool,
+                    dmaseq1ready: bool,
+                    dmaseq1buserror: bool,
+                    comparematch: [bool; 4usize],
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                    ramunderflow: self.ramunderflow(),
+                    dmaseq0end: self.dmaseq0end(),
+                    dmaseq0ready: self.dmaseq0ready(),
+                    dmaseq0buserror: self.dmaseq0buserror(),
+                    dmaseq1end: self.dmaseq1end(),
+                    dmaseq1ready: self.dmaseq1ready(),
+                    dmaseq1buserror: self.dmaseq1buserror(),
+                    comparematch: [
+                        self.comparematch(0usize),
+                        self.comparematch(1usize),
+                        self.comparematch(2usize),
+                        self.comparematch(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20091,6 +26948,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Maximum number of bytes in channel buffer"]
@@ -20116,6 +26989,26 @@ pub mod pwm {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Selects operating mode of the wave counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20137,6 +27030,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for PWM_CLK"]
@@ -20162,6 +27075,26 @@ pub mod pwm {
                 Prescaler(0)
             }
         }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20184,6 +27117,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -20286,6 +27235,47 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_dma_seq0_start", &self.loopsdone_dma_seq0_start())
+                    .field("loopsdone_dma_seq1_start", &self.loopsdone_dma_seq1_start())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .field("ramunderflow_stop", &self.ramunderflow_stop())
+                    .field("dma_seq0_buserror_stop", &self.dma_seq0_buserror_stop())
+                    .field("dma_seq1_buserror_stop", &self.dma_seq1_buserror_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_dma_seq0_start: bool,
+                    loopsdone_dma_seq1_start: bool,
+                    loopsdone_stop: bool,
+                    ramunderflow_stop: bool,
+                    dma_seq0_buserror_stop: bool,
+                    dma_seq1_buserror_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_dma_seq0_start: self.loopsdone_dma_seq0_start(),
+                    loopsdone_dma_seq1_start: self.loopsdone_dma_seq1_start(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                    ramunderflow_stop: self.ramunderflow_stop(),
+                    dma_seq0_buserror_stop: self.dma_seq0_buserror_stop(),
+                    dma_seq1_buserror_stop: self.dma_seq1_buserror_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20307,10 +27297,31 @@ pub mod pwm {
                 Terminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for Terminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Terminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Terminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Terminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = Terminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -20358,6 +27369,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -20371,7 +27399,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -20401,7 +27430,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -20457,6 +27487,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -20470,7 +27517,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -20770,6 +27818,26 @@ pub mod qdec {
                 Accdbl(0)
             }
         }
+        impl core::fmt::Debug for Accdbl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdbl")
+                    .field("accdbl", &self.accdbl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdbl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdbl {
+                    accdbl: u8,
+                }
+                let proxy = Accdbl {
+                    accdbl: self.accdbl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Snapshot of the ACCDBL, updated by the READCLRACC or RDCLRDBL task"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20791,6 +27859,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Accdblread {
                 Accdblread(0)
+            }
+        }
+        impl core::fmt::Debug for Accdblread {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Accdblread")
+                    .field("accdblread", &self.accdblread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Accdblread {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Accdblread {
+                    accdblread: u8,
+                }
+                let proxy = Accdblread {
+                    accdblread: self.accdblread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable input debounce filters"]
@@ -20816,6 +27904,26 @@ pub mod qdec {
                 Dbfen(0)
             }
         }
+        impl core::fmt::Debug for Dbfen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbfen")
+                    .field("dbfen", &self.dbfen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbfen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbfen {
+                    dbfen: bool,
+                }
+                let proxy = Dbfen {
+                    dbfen: self.dbfen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable the quadrature decoder"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20837,6 +27945,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -20906,6 +28034,38 @@ pub mod qdec {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("samplerdy", &self.samplerdy())
+                    .field("reportrdy", &self.reportrdy())
+                    .field("accof", &self.accof())
+                    .field("dblrdy", &self.dblrdy())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    samplerdy: bool,
+                    reportrdy: bool,
+                    accof: bool,
+                    dblrdy: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    samplerdy: self.samplerdy(),
+                    reportrdy: self.reportrdy(),
+                    accof: self.accof(),
+                    dblrdy: self.dblrdy(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "LED output pin polarity"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20927,6 +28087,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Ledpol {
                 Ledpol(0)
+            }
+        }
+        impl core::fmt::Debug for Ledpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpol")
+                    .field("ledpol", &self.ledpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpol {
+                    ledpol: super::vals::Ledpol,
+                }
+                let proxy = Ledpol {
+                    ledpol: self.ledpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Time period the LED is switched ON prior to sampling"]
@@ -20952,6 +28132,26 @@ pub mod qdec {
                 Ledpre(0)
             }
         }
+        impl core::fmt::Debug for Ledpre {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ledpre")
+                    .field("ledpre", &self.ledpre())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ledpre {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ledpre {
+                    ledpre: u16,
+                }
+                let proxy = Ledpre {
+                    ledpre: self.ledpre(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to be taken before REPORTRDY and DBLRDY events can be generated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20975,6 +28175,26 @@ pub mod qdec {
                 Reportper(0)
             }
         }
+        impl core::fmt::Debug for Reportper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reportper")
+                    .field("reportper", &self.reportper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reportper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reportper {
+                    reportper: super::vals::Reportper,
+                }
+                let proxy = Reportper {
+                    reportper: self.reportper(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Sample period"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -20996,6 +28216,26 @@ pub mod qdec {
             #[inline(always)]
             fn default() -> Sampleper {
                 Sampleper(0)
+            }
+        }
+        impl core::fmt::Debug for Sampleper {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sampleper")
+                    .field("sampleper", &self.sampleper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sampleper {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sampleper {
+                    sampleper: super::vals::Sampleper,
+                }
+                let proxy = Sampleper {
+                    sampleper: self.sampleper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -21087,10 +28327,49 @@ pub mod qdec {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("reportrdy_readclracc", &self.reportrdy_readclracc())
+                    .field("samplerdy_stop", &self.samplerdy_stop())
+                    .field("reportrdy_rdclracc", &self.reportrdy_rdclracc())
+                    .field("reportrdy_stop", &self.reportrdy_stop())
+                    .field("dblrdy_rdclrdbl", &self.dblrdy_rdclrdbl())
+                    .field("dblrdy_stop", &self.dblrdy_stop())
+                    .field("samplerdy_readclracc", &self.samplerdy_readclracc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    reportrdy_readclracc: bool,
+                    samplerdy_stop: bool,
+                    reportrdy_rdclracc: bool,
+                    reportrdy_stop: bool,
+                    dblrdy_rdclrdbl: bool,
+                    dblrdy_stop: bool,
+                    samplerdy_readclracc: bool,
+                }
+                let proxy = Shorts {
+                    reportrdy_readclracc: self.reportrdy_readclracc(),
+                    samplerdy_stop: self.samplerdy_stop(),
+                    reportrdy_rdclracc: self.reportrdy_rdclracc(),
+                    reportrdy_stop: self.reportrdy_stop(),
+                    dblrdy_rdclrdbl: self.dblrdy_rdclrdbl(),
+                    dblrdy_stop: self.dblrdy_stop(),
+                    samplerdy_readclracc: self.samplerdy_readclracc(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ledpol {
             #[doc = "Led active on output pin low"]
             ACTIVE_LOW = 0x0,
@@ -21120,7 +28399,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Reportper {
             #[doc = "10 samples/report"]
             _10SMPL = 0x0,
@@ -21171,7 +28451,8 @@ pub mod qdec {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampleper {
             #[doc = "128 us"]
             _128US = 0x0,
@@ -22196,6 +29477,26 @@ pub mod radio {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 clear channel assessment control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22252,6 +29553,35 @@ pub mod radio {
                 Ccactrl(0)
             }
         }
+        impl core::fmt::Debug for Ccactrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ccactrl")
+                    .field("ccamode", &self.ccamode())
+                    .field("ccaedthres", &self.ccaedthres())
+                    .field("ccacorrthres", &self.ccacorrthres())
+                    .field("ccacorrcnt", &self.ccacorrcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ccactrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ccactrl {
+                    ccamode: super::vals::Ccamode,
+                    ccaedthres: u8,
+                    ccacorrthres: u8,
+                    ccacorrcnt: u8,
+                }
+                let proxy = Ccactrl {
+                    ccamode: self.ccamode(),
+                    ccaedthres: self.ccaedthres(),
+                    ccacorrthres: self.ccacorrthres(),
+                    ccacorrcnt: self.ccacorrcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Cordic output of CnAcc"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22271,6 +29601,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Cfophase {
                 Cfophase(0)
+            }
+        }
+        impl core::fmt::Debug for Cfophase {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cfophase")
+                    .field("cfophase", &self.cfophase())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cfophase {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cfophase {
+                    cfophase: u16,
+                }
+                let proxy = Cfophase {
+                    cfophase: self.cfophase(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear the GPIO pattern array for antenna control"]
@@ -22294,6 +29644,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Clearpattern {
                 Clearpattern(0)
+            }
+        }
+        impl core::fmt::Debug for Clearpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clearpattern")
+                    .field("clearpattern", &self.clearpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clearpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clearpattern {
+                    clearpattern: bool,
+                }
+                let proxy = Clearpattern {
+                    clearpattern: self.clearpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output of the autocorrelation of the accumulated IQ signal"]
@@ -22324,6 +29694,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Cnacc {
                 Cnacc(0)
+            }
+        }
+        impl core::fmt::Debug for Cnacc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnacc")
+                    .field("cnacci", &self.cnacci())
+                    .field("cnaccq", &self.cnaccq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnacc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnacc {
+                    cnacci: u16,
+                    cnaccq: u16,
+                }
+                let proxy = Cnacc {
+                    cnacci: self.cnacci(),
+                    cnaccq: self.cnaccq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RTT Config."]
@@ -22393,6 +29786,38 @@ pub mod radio {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("en", &self.en())
+                    .field("enfullaa", &self.enfullaa())
+                    .field("role", &self.role())
+                    .field("numsegments", &self.numsegments())
+                    .field("efsdelay", &self.efsdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    en: bool,
+                    enfullaa: bool,
+                    role: super::vals::Role,
+                    numsegments: u8,
+                    efsdelay: u16,
+                }
+                let proxy = Config {
+                    en: self.en(),
+                    enfullaa: self.enfullaa(),
+                    role: self.role(),
+                    numsegments: self.numsegments(),
+                    efsdelay: self.efsdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22427,6 +29852,29 @@ pub mod radio {
                 Crccnf(0)
             }
         }
+        impl core::fmt::Debug for Crccnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crccnf")
+                    .field("len", &self.len())
+                    .field("skipaddr", &self.skipaddr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crccnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crccnf {
+                    len: super::vals::Len,
+                    skipaddr: super::vals::Skipaddr,
+                }
+                let proxy = Crccnf {
+                    len: self.len(),
+                    skipaddr: self.skipaddr(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC initial value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22449,6 +29897,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcinit {
                 Crcinit(0)
+            }
+        }
+        impl core::fmt::Debug for Crcinit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcinit")
+                    .field("crcinit", &self.crcinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcinit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcinit {
+                    crcinit: u32,
+                }
+                let proxy = Crcinit {
+                    crcinit: self.crcinit(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "CRC polynomial"]
@@ -22475,6 +29943,26 @@ pub mod radio {
                 Crcpoly(0)
             }
         }
+        impl core::fmt::Debug for Crcpoly {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcpoly")
+                    .field("crcpoly", &self.crcpoly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcpoly {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcpoly {
+                    crcpoly: u32,
+                }
+                let proxy = Crcpoly {
+                    crcpoly: self.crcpoly(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22496,6 +29984,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Crcstatus {
                 Crcstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Crcstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Crcstatus")
+                    .field("crcstatus", &self.crcstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Crcstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Crcstatus {
+                    crcstatus: super::vals::Crcstatus,
+                }
+                let proxy = Crcstatus {
+                    crcstatus: self.crcstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the mode(s) that are activated on the start signal"]
@@ -22530,6 +30038,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> CstonesMode {
                 CstonesMode(0)
+            }
+        }
+        impl core::fmt::Debug for CstonesMode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CstonesMode")
+                    .field("tpm", &self.tpm())
+                    .field("tfm", &self.tfm())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CstonesMode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CstonesMode {
+                    tpm: bool,
+                    tfm: bool,
+                }
+                let proxy = CstonesMode {
+                    tpm: self.tpm(),
+                    tfm: self.tfm(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for CTE inline mode"]
@@ -22634,6 +30165,47 @@ pub mod radio {
                 Cteinlineconf(0)
             }
         }
+        impl core::fmt::Debug for Cteinlineconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cteinlineconf")
+                    .field("cteinlinectrlen", &self.cteinlinectrlen())
+                    .field("cteinfoins1", &self.cteinfoins1())
+                    .field("cteerrorhandling", &self.cteerrorhandling())
+                    .field("ctetimevalidrange", &self.ctetimevalidrange())
+                    .field("cteinlinerxmode1us", &self.cteinlinerxmode1us())
+                    .field("cteinlinerxmode2us", &self.cteinlinerxmode2us())
+                    .field("s0conf", &self.s0conf())
+                    .field("s0mask", &self.s0mask())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cteinlineconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cteinlineconf {
+                    cteinlinectrlen: bool,
+                    cteinfoins1: bool,
+                    cteerrorhandling: bool,
+                    ctetimevalidrange: super::vals::Ctetimevalidrange,
+                    cteinlinerxmode1us: super::vals::Cteinlinerxmode1us,
+                    cteinlinerxmode2us: super::vals::Cteinlinerxmode2us,
+                    s0conf: u8,
+                    s0mask: u8,
+                }
+                let proxy = Cteinlineconf {
+                    cteinlinectrlen: self.cteinlinectrlen(),
+                    cteinfoins1: self.cteinfoins1(),
+                    cteerrorhandling: self.cteerrorhandling(),
+                    ctetimevalidrange: self.ctetimevalidrange(),
+                    cteinlinerxmode1us: self.cteinlinerxmode1us(),
+                    cteinlinerxmode2us: self.cteinlinerxmode2us(),
+                    s0conf: self.s0conf(),
+                    s0mask: self.s0mask(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CTEInfo parsed from received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22679,6 +30251,32 @@ pub mod radio {
                 Ctestatus(0)
             }
         }
+        impl core::fmt::Debug for Ctestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ctestatus")
+                    .field("ctetime", &self.ctetime())
+                    .field("rfu", &self.rfu())
+                    .field("ctetype", &self.ctetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ctestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ctestatus {
+                    ctetime: u8,
+                    rfu: bool,
+                    ctetype: u8,
+                }
+                let proxy = Ctestatus {
+                    ctetime: self.ctetime(),
+                    rfu: self.rfu(),
+                    ctetype: self.ctetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the current transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22700,6 +30298,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Currentamount {
                 Currentamount(0)
+            }
+        }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device address match configuration"]
@@ -22890,6 +30508,71 @@ pub mod radio {
                 Dacnf(0)
             }
         }
+        impl core::fmt::Debug for Dacnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dacnf")
+                    .field("ena0", &self.ena0())
+                    .field("ena1", &self.ena1())
+                    .field("ena2", &self.ena2())
+                    .field("ena3", &self.ena3())
+                    .field("ena4", &self.ena4())
+                    .field("ena5", &self.ena5())
+                    .field("ena6", &self.ena6())
+                    .field("ena7", &self.ena7())
+                    .field("txadd0", &self.txadd0())
+                    .field("txadd1", &self.txadd1())
+                    .field("txadd2", &self.txadd2())
+                    .field("txadd3", &self.txadd3())
+                    .field("txadd4", &self.txadd4())
+                    .field("txadd5", &self.txadd5())
+                    .field("txadd6", &self.txadd6())
+                    .field("txadd7", &self.txadd7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dacnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dacnf {
+                    ena0: bool,
+                    ena1: bool,
+                    ena2: bool,
+                    ena3: bool,
+                    ena4: bool,
+                    ena5: bool,
+                    ena6: bool,
+                    ena7: bool,
+                    txadd0: bool,
+                    txadd1: bool,
+                    txadd2: bool,
+                    txadd3: bool,
+                    txadd4: bool,
+                    txadd5: bool,
+                    txadd6: bool,
+                    txadd7: bool,
+                }
+                let proxy = Dacnf {
+                    ena0: self.ena0(),
+                    ena1: self.ena1(),
+                    ena2: self.ena2(),
+                    ena3: self.ena3(),
+                    ena4: self.ena4(),
+                    ena5: self.ena5(),
+                    ena6: self.ena6(),
+                    ena7: self.ena7(),
+                    txadd0: self.txadd0(),
+                    txadd1: self.txadd1(),
+                    txadd2: self.txadd2(),
+                    txadd3: self.txadd3(),
+                    txadd4: self.txadd4(),
+                    txadd5: self.txadd5(),
+                    txadd6: self.txadd6(),
+                    txadd7: self.txadd7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Device address match index"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22913,6 +30596,22 @@ pub mod radio {
                 Dai(0)
             }
         }
+        impl core::fmt::Debug for Dai {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dai").field("dai", &self.dai()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dai {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dai {
+                    dai: u8,
+                }
+                let proxy = Dai { dai: self.dai() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Device address prefix n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -22934,6 +30633,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dap {
                 Dap(0)
+            }
+        }
+        impl core::fmt::Debug for Dap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dap").field("dap", &self.dap()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dap {
+                    dap: u16,
+                }
+                let proxy = Dap { dap: self.dap() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Data whitening configuration"]
@@ -22968,6 +30683,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Datawhite {
                 Datawhite(0)
+            }
+        }
+        impl core::fmt::Debug for Datawhite {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Datawhite")
+                    .field("iv", &self.iv())
+                    .field("poly", &self.poly())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Datawhite {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Datawhite {
+                    iv: u16,
+                    poly: u16,
+                }
+                let proxy = Datawhite {
+                    iv: self.iv(),
+                    poly: self.poly(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Various configuration for Direction finding"]
@@ -23074,6 +30812,47 @@ pub mod radio {
                 Dfectrl1(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl1")
+                    .field("numberof8us", &self.numberof8us())
+                    .field("dfeinextension", &self.dfeinextension())
+                    .field("tswitchspacing", &self.tswitchspacing())
+                    .field("tsamplespacingref", &self.tsamplespacingref())
+                    .field("sampletype", &self.sampletype())
+                    .field("tsamplespacing", &self.tsamplespacing())
+                    .field("repeatpattern", &self.repeatpattern())
+                    .field("agcbackoffgain", &self.agcbackoffgain())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl1 {
+                    numberof8us: u8,
+                    dfeinextension: super::vals::Dfeinextension,
+                    tswitchspacing: super::vals::Tswitchspacing,
+                    tsamplespacingref: super::vals::Tsamplespacingref,
+                    sampletype: super::vals::Sampletype,
+                    tsamplespacing: super::vals::Tsamplespacing,
+                    repeatpattern: super::vals::Repeatpattern,
+                    agcbackoffgain: u8,
+                }
+                let proxy = Dfectrl1 {
+                    numberof8us: self.numberof8us(),
+                    dfeinextension: self.dfeinextension(),
+                    tswitchspacing: self.tswitchspacing(),
+                    tsamplespacingref: self.tsamplespacingref(),
+                    sampletype: self.sampletype(),
+                    tsamplespacing: self.tsamplespacing(),
+                    repeatpattern: self.repeatpattern(),
+                    agcbackoffgain: self.agcbackoffgain(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start offset for Direction finding"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23108,6 +30887,29 @@ pub mod radio {
                 Dfectrl2(0)
             }
         }
+        impl core::fmt::Debug for Dfectrl2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfectrl2")
+                    .field("tswitchoffset", &self.tswitchoffset())
+                    .field("tsampleoffset", &self.tsampleoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfectrl2 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfectrl2 {
+                    tswitchoffset: u16,
+                    tsampleoffset: u16,
+                }
+                let proxy = Dfectrl2 {
+                    tswitchoffset: self.tswitchoffset(),
+                    tsampleoffset: self.tsampleoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Whether to use Angle-of-Arrival (AOA) or Angle-of-Departure (AOD)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23129,6 +30931,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Dfemode {
                 Dfemode(0)
+            }
+        }
+        impl core::fmt::Debug for Dfemode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfemode")
+                    .field("dfeopmode", &self.dfeopmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfemode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfemode {
+                    dfeopmode: super::vals::Dfeopmode,
+                }
+                let proxy = Dfemode {
+                    dfeopmode: self.dfeopmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DFE status information"]
@@ -23165,6 +30987,29 @@ pub mod radio {
                 Dfestatus(0)
             }
         }
+        impl core::fmt::Debug for Dfestatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dfestatus")
+                    .field("switchingstate", &self.switchingstate())
+                    .field("samplingstate", &self.samplingstate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dfestatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dfestatus {
+                    switchingstate: super::vals::Switchingstate,
+                    samplingstate: super::vals::Samplingstate,
+                }
+                let proxy = Dfestatus {
+                    switchingstate: self.switchingstate(),
+                    samplingstate: self.samplingstate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Turn on/off down sample of input IQ-signals"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23199,6 +31044,29 @@ pub mod radio {
                 Downsample(0)
             }
         }
+        impl core::fmt::Debug for Downsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Downsample")
+                    .field("enablefilter", &self.enablefilter())
+                    .field("rate", &self.rate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Downsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Downsample {
+                    enablefilter: bool,
+                    rate: super::vals::Rate,
+                }
+                let proxy = Downsample {
+                    enablefilter: self.enablefilter(),
+                    rate: self.rate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 energy detect control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23221,6 +31089,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Edctrl {
                 Edctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Edctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edctrl")
+                    .field("edcnt", &self.edcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edctrl {
+                    edcnt: u32,
+                }
+                let proxy = Edctrl {
+                    edcnt: self.edcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "IEEE 802.15.4 energy detect level"]
@@ -23246,6 +31134,26 @@ pub mod radio {
                 Edsample(0)
             }
         }
+        impl core::fmt::Debug for Edsample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Edsample")
+                    .field("edlvl", &self.edlvl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Edsample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Edsample {
+                    edlvl: u8,
+                }
+                let proxy = Edsample {
+                    edlvl: self.edlvl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FAEPEER (Frequency Actuation Error) of peer if known. Used during Mode 0 steps."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23267,6 +31175,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Faepeer {
                 Faepeer(0)
+            }
+        }
+        impl core::fmt::Debug for Faepeer {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Faepeer")
+                    .field("faepeer", &self.faepeer())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Faepeer {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Faepeer {
+                    faepeer: u8,
+                }
+                let proxy = Faepeer {
+                    faepeer: self.faepeer(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Config register"]
@@ -23292,6 +31220,26 @@ pub mod radio {
                 Feconfig(0)
             }
         }
+        impl core::fmt::Debug for Feconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Feconfig")
+                    .field("scalermode", &self.scalermode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Feconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Feconfig {
+                    scalermode: bool,
+                }
+                let proxy = Feconfig {
+                    scalermode: self.scalermode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "FFO estimate"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23313,6 +31261,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ffoest {
                 Ffoest(0)
+            }
+        }
+        impl core::fmt::Debug for Ffoest {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffoest")
+                    .field("ffoest", &self.ffoest())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffoest {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffoest {
+                    ffoest: u16,
+                }
+                let proxy = Ffoest {
+                    ffoest: self.ffoest(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Override value of FFO (Fractional Frequency Offset) if not to be based on the frequency estimate derived from CnAcc (autocorrelation of the scaled input signal) value"]
@@ -23338,6 +31306,26 @@ pub mod radio {
                 Ffoin(0)
             }
         }
+        impl core::fmt::Debug for Ffoin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffoin")
+                    .field("fffin", &self.fffin())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffoin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffoin {
+                    fffin: u16,
+                }
+                let proxy = Ffoin {
+                    fffin: self.fffin(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Source of FFO"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23359,6 +31347,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Ffosource {
                 Ffosource(0)
+            }
+        }
+        impl core::fmt::Debug for Ffosource {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ffosource")
+                    .field("ffosource", &self.ffosource())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ffosource {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ffosource {
+                    ffosource: super::vals::Ffosource,
+                }
+                let proxy = Ffosource {
+                    ffosource: self.ffosource(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of full ADPLL finetune steps"]
@@ -23384,6 +31392,26 @@ pub mod radio {
                 Finetunenext(0)
             }
         }
+        impl core::fmt::Debug for Finetunenext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Finetunenext")
+                    .field("finetunenext", &self.finetunenext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Finetunenext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Finetunenext {
+                    finetunenext: u16,
+                }
+                let proxy = Finetunenext {
+                    finetunenext: self.finetunenext(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frequency offset estimate"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23403,6 +31431,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Freqoffset {
                 Freqoffset(0)
+            }
+        }
+        impl core::fmt::Debug for Freqoffset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Freqoffset")
+                    .field("freqoffset", &self.freqoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freqoffset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Freqoffset {
+                    freqoffset: u16,
+                }
+                let proxy = Freqoffset {
+                    freqoffset: self.freqoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Frequency"]
@@ -23437,6 +31485,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .field("map", &self.map())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: u8,
+                    map: bool,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                    map: self.map(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -23704,6 +31775,92 @@ pub mod radio {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ready", &self.ready())
+                    .field("txready", &self.txready())
+                    .field("rxready", &self.rxready())
+                    .field("address", &self.address())
+                    .field("framestart", &self.framestart())
+                    .field("payload", &self.payload())
+                    .field("end", &self.end())
+                    .field("phyend", &self.phyend())
+                    .field("disabled", &self.disabled())
+                    .field("devmatch", &self.devmatch())
+                    .field("devmiss", &self.devmiss())
+                    .field("crcok", &self.crcok())
+                    .field("crcerror", &self.crcerror())
+                    .field("bcmatch", &self.bcmatch())
+                    .field("edend", &self.edend())
+                    .field("edstopped", &self.edstopped())
+                    .field("ccaidle", &self.ccaidle())
+                    .field("ccabusy", &self.ccabusy())
+                    .field("ccastopped", &self.ccastopped())
+                    .field("rateboost", &self.rateboost())
+                    .field("mhrmatch", &self.mhrmatch())
+                    .field("sync", &self.sync())
+                    .field("ctepresent", &self.ctepresent())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ready: bool,
+                    txready: bool,
+                    rxready: bool,
+                    address: bool,
+                    framestart: bool,
+                    payload: bool,
+                    end: bool,
+                    phyend: bool,
+                    disabled: bool,
+                    devmatch: bool,
+                    devmiss: bool,
+                    crcok: bool,
+                    crcerror: bool,
+                    bcmatch: bool,
+                    edend: bool,
+                    edstopped: bool,
+                    ccaidle: bool,
+                    ccabusy: bool,
+                    ccastopped: bool,
+                    rateboost: bool,
+                    mhrmatch: bool,
+                    sync: bool,
+                    ctepresent: bool,
+                }
+                let proxy = Int {
+                    ready: self.ready(),
+                    txready: self.txready(),
+                    rxready: self.rxready(),
+                    address: self.address(),
+                    framestart: self.framestart(),
+                    payload: self.payload(),
+                    end: self.end(),
+                    phyend: self.phyend(),
+                    disabled: self.disabled(),
+                    devmatch: self.devmatch(),
+                    devmiss: self.devmiss(),
+                    crcok: self.crcok(),
+                    crcerror: self.crcerror(),
+                    bcmatch: self.bcmatch(),
+                    edend: self.edend(),
+                    edstopped: self.edstopped(),
+                    ccaidle: self.ccaidle(),
+                    ccabusy: self.ccabusy(),
+                    ccastopped: self.ccastopped(),
+                    rateboost: self.rateboost(),
+                    mhrmatch: self.mhrmatch(),
+                    sync: self.sync(),
+                    ctepresent: self.ctepresent(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mean of IQ values"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23738,6 +31895,29 @@ pub mod radio {
                 Iqrawmean(0)
             }
         }
+        impl core::fmt::Debug for Iqrawmean {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Iqrawmean")
+                    .field("iqrawmeani", &self.iqrawmeani())
+                    .field("iqrawmeanq", &self.iqrawmeanq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Iqrawmean {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Iqrawmean {
+                    iqrawmeani: u16,
+                    iqrawmeanq: u16,
+                }
+                let proxy = Iqrawmean {
+                    iqrawmeani: self.iqrawmeani(),
+                    iqrawmeanq: self.iqrawmeanq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Quantization error between ADPLL frequency and the desired value of FFO * RF Frequency. Values limited to \\[-64,63\\] with units 7.6294 Hz."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23759,6 +31939,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Lfaenext {
                 Lfaenext(0)
+            }
+        }
+        impl core::fmt::Debug for Lfaenext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfaenext")
+                    .field("lfaenext", &self.lfaenext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfaenext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfaenext {
+                    lfaenext: u8,
+                }
+                let proxy = Lfaenext {
+                    lfaenext: self.lfaenext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mean magnitude and phase of the signal before it is converted to PCT16"]
@@ -23795,6 +31995,29 @@ pub mod radio {
                 Magphasemean(0)
             }
         }
+        impl core::fmt::Debug for Magphasemean {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Magphasemean")
+                    .field("phase", &self.phase())
+                    .field("mag", &self.mag())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Magphasemean {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Magphasemean {
+                    phase: u16,
+                    mag: u16,
+                }
+                let proxy = Magphasemean {
+                    phase: self.phase(),
+                    mag: self.mag(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Magnitude standard deviation approximation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23816,6 +32039,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Magstd {
                 Magstd(0)
+            }
+        }
+        impl core::fmt::Debug for Magstd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Magstd")
+                    .field("magstd", &self.magstd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Magstd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Magstd {
+                    magstd: u16,
+                }
+                let proxy = Magstd {
+                    magstd: self.magstd(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes to transfer"]
@@ -23841,6 +32084,26 @@ pub mod radio {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The value of FREQUENCY that will be used in the next step"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23862,6 +32125,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Nextfrequency {
                 Nextfrequency(0)
+            }
+        }
+        impl core::fmt::Debug for Nextfrequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nextfrequency")
+                    .field("nextfrequency", &self.nextfrequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nextfrequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nextfrequency {
+                    nextfrequency: u8,
+                }
+                let proxy = Nextfrequency {
+                    nextfrequency: self.nextfrequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of input samples at 2MHz sample rate"]
@@ -23887,6 +32170,26 @@ pub mod radio {
                 Numsamples(0)
             }
         }
+        impl core::fmt::Debug for Numsamples {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Numsamples")
+                    .field("numsamples", &self.numsamples())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Numsamples {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Numsamples {
+                    numsamples: u8,
+                }
+                let proxy = Numsamples {
+                    numsamples: self.numsamples(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Parameter used in TPM, provided by software"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -23908,6 +32211,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Numsamplescoeff {
                 Numsamplescoeff(0)
+            }
+        }
+        impl core::fmt::Debug for Numsamplescoeff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Numsamplescoeff")
+                    .field("numsamplescoeff", &self.numsamplescoeff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Numsamplescoeff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Numsamplescoeff {
+                    numsamplescoeff: u16,
+                }
+                let proxy = Numsamplescoeff {
+                    numsamplescoeff: self.numsamplescoeff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Packet configuration register 0"]
@@ -24013,6 +32336,47 @@ pub mod radio {
                 Pcnf0(0)
             }
         }
+        impl core::fmt::Debug for Pcnf0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf0")
+                    .field("lflen", &self.lflen())
+                    .field("s0len", &self.s0len())
+                    .field("s1len", &self.s1len())
+                    .field("s1incl", &self.s1incl())
+                    .field("cilen", &self.cilen())
+                    .field("plen", &self.plen())
+                    .field("crcinc", &self.crcinc())
+                    .field("termlen", &self.termlen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf0 {
+                    lflen: u8,
+                    s0len: bool,
+                    s1len: u8,
+                    s1incl: super::vals::S1incl,
+                    cilen: u8,
+                    plen: super::vals::Plen,
+                    crcinc: super::vals::Crcinc,
+                    termlen: u8,
+                }
+                let proxy = Pcnf0 {
+                    lflen: self.lflen(),
+                    s0len: self.s0len(),
+                    s1len: self.s1len(),
+                    s1incl: self.s1incl(),
+                    cilen: self.cilen(),
+                    plen: self.plen(),
+                    crcinc: self.crcinc(),
+                    termlen: self.termlen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Packet configuration register 1"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24093,6 +32457,41 @@ pub mod radio {
                 Pcnf1(0)
             }
         }
+        impl core::fmt::Debug for Pcnf1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pcnf1")
+                    .field("maxlen", &self.maxlen())
+                    .field("statlen", &self.statlen())
+                    .field("balen", &self.balen())
+                    .field("endian", &self.endian())
+                    .field("whiteen", &self.whiteen())
+                    .field("whiteoffset", &self.whiteoffset())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pcnf1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pcnf1 {
+                    maxlen: u8,
+                    statlen: u8,
+                    balen: u8,
+                    endian: super::vals::Endian,
+                    whiteen: bool,
+                    whiteoffset: super::vals::Whiteoffset,
+                }
+                let proxy = Pcnf1 {
+                    maxlen: self.maxlen(),
+                    statlen: self.statlen(),
+                    balen: self.balen(),
+                    endian: self.endian(),
+                    whiteen: self.whiteen(),
+                    whiteoffset: self.whiteoffset(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Mean magnitude and mean phase converted to IQ. IQ values limited to \\[-1024,1023\\]."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24125,6 +32524,29 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Pct11 {
                 Pct11(0)
+            }
+        }
+        impl core::fmt::Debug for Pct11 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pct11")
+                    .field("pct11i", &self.pct11i())
+                    .field("pct11q", &self.pct11q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pct11 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pct11 {
+                    pct11i: u16,
+                    pct11q: u16,
+                }
+                let proxy = Pct11 {
+                    pct11i: self.pct11i(),
+                    pct11q: self.pct11q(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Mean magnitude and mean phase converted to IQ"]
@@ -24161,6 +32583,29 @@ pub mod radio {
                 Pct16(0)
             }
         }
+        impl core::fmt::Debug for Pct16 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pct16")
+                    .field("pct16i", &self.pct16i())
+                    .field("pct16q", &self.pct16q())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pct16 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pct16 {
+                    pct16i: u16,
+                    pct16q: u16,
+                }
+                let proxy = Pct16 {
+                    pct16i: self.pct16i(),
+                    pct16q: self.pct16q(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Payload status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24195,6 +32640,29 @@ pub mod radio {
                 Pdustat(0)
             }
         }
+        impl core::fmt::Debug for Pdustat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdustat")
+                    .field("pdustat", &self.pdustat())
+                    .field("cistat", &self.cistat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdustat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdustat {
+                    pdustat: super::vals::Pdustat,
+                    cistat: super::vals::Cistat,
+                }
+                let proxy = Pdustat {
+                    pdustat: self.pdustat(),
+                    cistat: self.cistat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Parameter used in TPM, provided by software"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24216,6 +32684,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Phaseshift {
                 Phaseshift(0)
+            }
+        }
+        impl core::fmt::Debug for Phaseshift {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Phaseshift")
+                    .field("phaseshift", &self.phaseshift())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Phaseshift {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Phaseshift {
+                    phaseshift: u16,
+                }
+                let proxy = Phaseshift {
+                    phaseshift: self.phaseshift(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Prefixes bytes for logical addresses 0-3"]
@@ -24274,6 +32762,35 @@ pub mod radio {
                 Prefix0(0)
             }
         }
+        impl core::fmt::Debug for Prefix0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix0")
+                    .field("ap0", &self.ap0())
+                    .field("ap1", &self.ap1())
+                    .field("ap2", &self.ap2())
+                    .field("ap3", &self.ap3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix0 {
+                    ap0: u8,
+                    ap1: u8,
+                    ap2: u8,
+                    ap3: u8,
+                }
+                let proxy = Prefix0 {
+                    ap0: self.ap0(),
+                    ap1: self.ap1(),
+                    ap2: self.ap2(),
+                    ap3: self.ap3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Prefixes bytes for logical addresses 4-7"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24330,6 +32847,35 @@ pub mod radio {
                 Prefix1(0)
             }
         }
+        impl core::fmt::Debug for Prefix1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prefix1")
+                    .field("ap4", &self.ap4())
+                    .field("ap5", &self.ap5())
+                    .field("ap6", &self.ap6())
+                    .field("ap7", &self.ap7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prefix1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prefix1 {
+                    ap4: u8,
+                    ap5: u8,
+                    ap6: u8,
+                    ap7: u8,
+                }
+                let proxy = Prefix1 {
+                    ap4: self.ap4(),
+                    ap5: self.ap5(),
+                    ap6: self.ap6(),
+                    ap7: self.ap7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Data rate and modulation"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24353,6 +32899,24 @@ pub mod radio {
                 RadioMode(0)
             }
         }
+        impl core::fmt::Debug for RadioMode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RadioMode")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RadioMode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RadioMode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = RadioMode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RSSI sample"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24374,6 +32938,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rssisample {
                 Rssisample(0)
+            }
+        }
+        impl core::fmt::Debug for Rssisample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rssisample")
+                    .field("rssisample", &self.rssisample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rssisample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rssisample {
+                    rssisample: u8,
+                }
+                let proxy = Rssisample {
+                    rssisample: self.rssisample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Receive address select"]
@@ -24476,6 +33060,47 @@ pub mod radio {
                 Rxaddresses(0)
             }
         }
+        impl core::fmt::Debug for Rxaddresses {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxaddresses")
+                    .field("addr0", &self.addr0())
+                    .field("addr1", &self.addr1())
+                    .field("addr2", &self.addr2())
+                    .field("addr3", &self.addr3())
+                    .field("addr4", &self.addr4())
+                    .field("addr5", &self.addr5())
+                    .field("addr6", &self.addr6())
+                    .field("addr7", &self.addr7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxaddresses {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxaddresses {
+                    addr0: bool,
+                    addr1: bool,
+                    addr2: bool,
+                    addr3: bool,
+                    addr4: bool,
+                    addr5: bool,
+                    addr6: bool,
+                    addr7: bool,
+                }
+                let proxy = Rxaddresses {
+                    addr0: self.addr0(),
+                    addr1: self.addr1(),
+                    addr2: self.addr2(),
+                    addr3: self.addr3(),
+                    addr4: self.addr4(),
+                    addr5: self.addr5(),
+                    addr6: self.addr6(),
+                    addr7: self.addr7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "CRC field of previously received packet"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24498,6 +33123,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Rxcrc {
                 Rxcrc(0)
+            }
+        }
+        impl core::fmt::Debug for Rxcrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxcrc")
+                    .field("rxcrc", &self.rxcrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxcrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxcrc {
+                    rxcrc: u32,
+                }
+                let proxy = Rxcrc {
+                    rxcrc: self.rxcrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Received address"]
@@ -24523,6 +33168,26 @@ pub mod radio {
                 Rxmatch(0)
             }
         }
+        impl core::fmt::Debug for Rxmatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxmatch")
+                    .field("rxmatch", &self.rxmatch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxmatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxmatch {
+                    rxmatch: u8,
+                }
+                let proxy = Rxmatch {
+                    rxmatch: self.rxmatch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "IEEE 802.15.4 start of frame delimiter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24544,6 +33209,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Sfd {
                 Sfd(0)
+            }
+        }
+        impl core::fmt::Debug for Sfd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sfd").field("sfd", &self.sfd()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sfd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sfd {
+                    sfd: u8,
+                }
+                let proxy = Sfd { sfd: self.sfd() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -24745,6 +33426,74 @@ pub mod radio {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("ready_start", &self.ready_start())
+                    .field("disabled_txen", &self.disabled_txen())
+                    .field("disabled_rxen", &self.disabled_rxen())
+                    .field("address_rssistart", &self.address_rssistart())
+                    .field("end_start", &self.end_start())
+                    .field("address_bcstart", &self.address_bcstart())
+                    .field("rxready_ccastart", &self.rxready_ccastart())
+                    .field("ccaidle_txen", &self.ccaidle_txen())
+                    .field("ccabusy_disable", &self.ccabusy_disable())
+                    .field("framestart_bcstart", &self.framestart_bcstart())
+                    .field("ready_edstart", &self.ready_edstart())
+                    .field("edend_disable", &self.edend_disable())
+                    .field("ccaidle_stop", &self.ccaidle_stop())
+                    .field("txready_start", &self.txready_start())
+                    .field("rxready_start", &self.rxready_start())
+                    .field("phyend_disable", &self.phyend_disable())
+                    .field("phyend_start", &self.phyend_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    ready_start: bool,
+                    disabled_txen: bool,
+                    disabled_rxen: bool,
+                    address_rssistart: bool,
+                    end_start: bool,
+                    address_bcstart: bool,
+                    rxready_ccastart: bool,
+                    ccaidle_txen: bool,
+                    ccabusy_disable: bool,
+                    framestart_bcstart: bool,
+                    ready_edstart: bool,
+                    edend_disable: bool,
+                    ccaidle_stop: bool,
+                    txready_start: bool,
+                    rxready_start: bool,
+                    phyend_disable: bool,
+                    phyend_start: bool,
+                }
+                let proxy = Shorts {
+                    ready_start: self.ready_start(),
+                    disabled_txen: self.disabled_txen(),
+                    disabled_rxen: self.disabled_rxen(),
+                    address_rssistart: self.address_rssistart(),
+                    end_start: self.end_start(),
+                    address_bcstart: self.address_bcstart(),
+                    rxready_ccastart: self.rxready_ccastart(),
+                    ccaidle_txen: self.ccaidle_txen(),
+                    ccabusy_disable: self.ccabusy_disable(),
+                    framestart_bcstart: self.framestart_bcstart(),
+                    ready_edstart: self.ready_edstart(),
+                    edend_disable: self.edend_disable(),
+                    ccaidle_stop: self.ccaidle_stop(),
+                    txready_start: self.txready_start(),
+                    rxready_start: self.rxready_start(),
+                    phyend_disable: self.phyend_disable(),
+                    phyend_start: self.phyend_start(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current radio state"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24766,6 +33515,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> State {
                 State(0)
+            }
+        }
+        impl core::fmt::Debug for State {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("State")
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for State {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct State {
+                    state: super::vals::State,
+                }
+                let proxy = State {
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "GPIO patterns to be used for each antenna"]
@@ -24791,6 +33560,26 @@ pub mod radio {
                 Switchpattern(0)
             }
         }
+        impl core::fmt::Debug for Switchpattern {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Switchpattern")
+                    .field("switchpattern", &self.switchpattern())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Switchpattern {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Switchpattern {
+                    switchpattern: u8,
+                }
+                let proxy = Switchpattern {
+                    switchpattern: self.switchpattern(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Interframe spacing in us"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24812,6 +33601,22 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Tifs {
                 Tifs(0)
+            }
+        }
+        impl core::fmt::Debug for Tifs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tifs").field("tifs", &self.tifs()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tifs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tifs {
+                    tifs: u16,
+                }
+                let proxy = Tifs { tifs: self.tifs() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Timing"]
@@ -24837,6 +33642,22 @@ pub mod radio {
                 Timing(0)
             }
         }
+        impl core::fmt::Debug for Timing {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Timing").field("ru", &self.ru()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Timing {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Timing {
+                    ru: super::vals::Ru,
+                }
+                let proxy = Timing { ru: self.ru() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmit address select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -24858,6 +33679,26 @@ pub mod radio {
             #[inline(always)]
             fn default() -> Txaddress {
                 Txaddress(0)
+            }
+        }
+        impl core::fmt::Debug for Txaddress {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txaddress")
+                    .field("txaddress", &self.txaddress())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txaddress {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txaddress {
+                    txaddress: u8,
+                }
+                let proxy = Txaddress {
+                    txaddress: self.txaddress(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Output power"]
@@ -24884,10 +33725,31 @@ pub mod radio {
                 Txpower(0)
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txpower")
+                    .field("txpower", &self.txpower())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txpower {
+                    txpower: super::vals::Txpower,
+                }
+                let proxy = Txpower {
+                    txpower: self.txpower(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ccamode {
             #[doc = "Energy above threshold"]
             ED_MODE = 0x0,
@@ -24926,7 +33788,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cistat {
             #[doc = "Frame is received at 125 kbps"]
             LR125KBIT = 0x0,
@@ -24958,7 +33821,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcinc {
             #[doc = "LENGTH does not contain CRC"]
             EXCLUDE = 0x0,
@@ -24988,7 +33852,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Crcstatus {
             #[doc = "Packet received with CRC error"]
             CRCERROR = 0x0,
@@ -25018,7 +33883,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode1us {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -25058,7 +33924,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cteinlinerxmode2us {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -25098,7 +33965,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ctetimevalidrange {
             #[doc = "20 in 8us unit (default) Set to 20 if parsed CTETime is larger han 20"]
             _20 = 0x0,
@@ -25131,7 +33999,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeinextension {
             #[doc = "Antenna switching/sampling is done in the packet payload"]
             PAYLOAD = 0x0,
@@ -25161,7 +34030,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dfeopmode {
             #[doc = "Direction finding mode disabled"]
             DISABLED = 0x0,
@@ -25194,7 +34064,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Least significant bit on air first"]
             LITTLE = 0x0,
@@ -25224,7 +34095,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ffosource {
             #[doc = "Use FFOIN"]
             EXTERNAL = 0x0,
@@ -25254,7 +34126,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Len {
             #[doc = "CRC length is zero and CRC calculation is disabled"]
             DISABLED = 0x0,
@@ -25288,7 +34161,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "1 Mbps Nordic proprietary radio mode"]
             NRF_1MBIT = 0x0,
@@ -25339,7 +34213,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pdustat {
             #[doc = "Payload less than PCNF1.MAXLEN"]
             LESS_THAN = 0x0,
@@ -25369,7 +34244,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Plen {
             #[doc = "8-bit preamble"]
             _8BIT = 0x0,
@@ -25403,7 +34279,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Rate {
             #[doc = "Radio mode BLE1M is used"]
             BLE1M = 0x0,
@@ -25433,7 +34310,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Repeatpattern {
             #[doc = "Do not repeat (1 time in total)"]
             NO_REPEAT = 0x0,
@@ -25476,7 +34354,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Role {
             #[doc = "Initiator"]
             INITIATOR = 0x0,
@@ -25506,7 +34385,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ru {
             #[doc = "Legacy ramp-up time"]
             LEGACY = 0x0,
@@ -25536,7 +34416,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum S1incl {
             #[doc = "Include S1 field in RAM only if S1LEN &gt; 0"]
             AUTOMATIC = 0x0,
@@ -25568,7 +34449,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sampletype {
             #[doc = "Complex samples in I and Q"]
             IQ = 0x0,
@@ -25598,7 +34480,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Samplingstate {
             #[doc = "Sampling state Idle"]
             IDLE = 0x0,
@@ -25628,7 +34511,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Skipaddr {
             #[doc = "CRC calculation includes address field"]
             INCLUDE = 0x0,
@@ -25667,7 +34551,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "RADIO is in the DISABLED state"]
             DISABLED = 0x0,
@@ -25718,7 +34603,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Switchingstate {
             #[doc = "Switching state Idle"]
             IDLE = 0x0,
@@ -25758,7 +34644,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacing {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -25798,7 +34685,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tsamplespacingref {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -25838,7 +34726,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tswitchspacing {
             _RESERVED_0 = 0x0,
             #[doc = "4us"]
@@ -25943,6 +34832,77 @@ pub mod radio {
                 self.0
             }
         }
+        impl core::fmt::Debug for Txpower {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x01 => f.write_str("NEG28_DBM"),
+                    0x02 => f.write_str("NEG20_DBM"),
+                    0x02 => f.write_str("NEG22_DBM"),
+                    0x03 => f.write_str("NEG18_DBM"),
+                    0x04 => f.write_str("NEG16_DBM"),
+                    0x05 => f.write_str("NEG14_DBM"),
+                    0x06 => f.write_str("NEG12_DBM"),
+                    0x07 => f.write_str("NEG10_DBM"),
+                    0x08 => f.write_str("NEG9_DBM"),
+                    0x09 => f.write_str("NEG8_DBM"),
+                    0x0a => f.write_str("NEG7_DBM"),
+                    0x0b => f.write_str("NEG6_DBM"),
+                    0x0d => f.write_str("NEG5_DBM"),
+                    0x0f => f.write_str("NEG4_DBM"),
+                    0x11 => f.write_str("NEG3_DBM"),
+                    0x13 => f.write_str("NEG2_DBM"),
+                    0x15 => f.write_str("NEG1_DBM"),
+                    0x18 => f.write_str("_0_DBM"),
+                    0x1b => f.write_str("POS1_DBM"),
+                    0x1f => f.write_str("POS2_DBM"),
+                    0x23 => f.write_str("POS3_DBM"),
+                    0x28 => f.write_str("POS4_DBM"),
+                    0x2d => f.write_str("POS5_DBM"),
+                    0x33 => f.write_str("POS6_DBM"),
+                    0x39 => f.write_str("POS7_DBM"),
+                    0x3f => f.write_str("POS8_DBM"),
+                    0x0110 => f.write_str("NEG46_DBM"),
+                    0x0130 => f.write_str("NEG40_DBM"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txpower {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x01 => defmt::write!(f, "NEG28_DBM"),
+                    0x02 => defmt::write!(f, "NEG20_DBM"),
+                    0x02 => defmt::write!(f, "NEG22_DBM"),
+                    0x03 => defmt::write!(f, "NEG18_DBM"),
+                    0x04 => defmt::write!(f, "NEG16_DBM"),
+                    0x05 => defmt::write!(f, "NEG14_DBM"),
+                    0x06 => defmt::write!(f, "NEG12_DBM"),
+                    0x07 => defmt::write!(f, "NEG10_DBM"),
+                    0x08 => defmt::write!(f, "NEG9_DBM"),
+                    0x09 => defmt::write!(f, "NEG8_DBM"),
+                    0x0a => defmt::write!(f, "NEG7_DBM"),
+                    0x0b => defmt::write!(f, "NEG6_DBM"),
+                    0x0d => defmt::write!(f, "NEG5_DBM"),
+                    0x0f => defmt::write!(f, "NEG4_DBM"),
+                    0x11 => defmt::write!(f, "NEG3_DBM"),
+                    0x13 => defmt::write!(f, "NEG2_DBM"),
+                    0x15 => defmt::write!(f, "NEG1_DBM"),
+                    0x18 => defmt::write!(f, "_0_DBM"),
+                    0x1b => defmt::write!(f, "POS1_DBM"),
+                    0x1f => defmt::write!(f, "POS2_DBM"),
+                    0x23 => defmt::write!(f, "POS3_DBM"),
+                    0x28 => defmt::write!(f, "POS4_DBM"),
+                    0x2d => defmt::write!(f, "POS5_DBM"),
+                    0x33 => defmt::write!(f, "POS6_DBM"),
+                    0x39 => defmt::write!(f, "POS7_DBM"),
+                    0x3f => defmt::write!(f, "POS8_DBM"),
+                    0x0110 => defmt::write!(f, "NEG46_DBM"),
+                    0x0130 => defmt::write!(f, "NEG40_DBM"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for Txpower {
             #[inline(always)]
             fn from(val: u16) -> Txpower {
@@ -25956,7 +34916,8 @@ pub mod radio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Whiteoffset {
             #[doc = "S0 included in whitening"]
             INCLUDE = 0x0,
@@ -26103,6 +35064,22 @@ pub mod regulators {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen").field("val", &self.val()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    val: bool,
+                }
+                let proxy = Dcdcen { val: self.val() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable register for VREGM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26126,6 +35103,26 @@ pub mod regulators {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "VREGMAIN inductor detection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26145,6 +35142,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Inductordet {
                 Inductordet(0)
+            }
+        }
+        impl core::fmt::Debug for Inductordet {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Inductordet")
+                    .field("detected", &self.detected())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Inductordet {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Inductordet {
+                    detected: super::vals::Detected,
+                }
+                let proxy = Inductordet {
+                    detected: self.detected(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power-fail comparator configuration"]
@@ -26192,6 +35209,32 @@ pub mod regulators {
                 Pofcon(0)
             }
         }
+        impl core::fmt::Debug for Pofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofcon")
+                    .field("pof", &self.pof())
+                    .field("threshold", &self.threshold())
+                    .field("eventdisable", &self.eventdisable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofcon {
+                    pof: bool,
+                    threshold: super::vals::Threshold,
+                    eventdisable: super::vals::Eventdisable,
+                }
+                let proxy = Pofcon {
+                    pof: self.pof(),
+                    threshold: self.threshold(),
+                    eventdisable: self.eventdisable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Power-fail comparator status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26213,6 +35256,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Pofstat {
                 Pofstat(0)
+            }
+        }
+        impl core::fmt::Debug for Pofstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pofstat")
+                    .field("comparator", &self.comparator())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pofstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pofstat {
+                    comparator: super::vals::Comparator,
+                }
+                let proxy = Pofstat {
+                    comparator: self.comparator(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System OFF register"]
@@ -26238,10 +35301,31 @@ pub mod regulators {
                 Systemoff(0)
             }
         }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Comparator {
             #[doc = "Voltage detected above VPOF threshold"]
             ABOVE = 0x0,
@@ -26271,7 +35355,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detected {
             #[doc = "VREGMAIN inductor not detected"]
             INDUCTOR_NOT_DETECTED = 0x0,
@@ -26301,7 +35386,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Eventdisable {
             #[doc = "POFWARN event is generated"]
             ENABLED = 0x0,
@@ -26331,7 +35417,8 @@ pub mod regulators {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Threshold {
             #[doc = "Set threshold to 1.7 V"]
             V17 = 0x0,
@@ -26574,6 +35661,65 @@ pub mod reset {
             #[inline(always)]
             fn default() -> Resetreas {
                 Resetreas(0)
+            }
+        }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog0", &self.dog0())
+                    .field("dog1", &self.dog1())
+                    .field("ctrlapsoft", &self.ctrlapsoft())
+                    .field("ctrlaphard", &self.ctrlaphard())
+                    .field("ctrlappin", &self.ctrlappin())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("off", &self.off())
+                    .field("lpcomp", &self.lpcomp())
+                    .field("dif", &self.dif())
+                    .field("grtc", &self.grtc())
+                    .field("nfc", &self.nfc())
+                    .field("sectamper", &self.sectamper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog0: bool,
+                    dog1: bool,
+                    ctrlapsoft: bool,
+                    ctrlaphard: bool,
+                    ctrlappin: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    off: bool,
+                    lpcomp: bool,
+                    dif: bool,
+                    grtc: bool,
+                    nfc: bool,
+                    sectamper: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog0: self.dog0(),
+                    dog1: self.dog1(),
+                    ctrlapsoft: self.ctrlapsoft(),
+                    ctrlaphard: self.ctrlaphard(),
+                    ctrlappin: self.ctrlappin(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    off: self.off(),
+                    lpcomp: self.lpcomp(),
+                    dif: self.dif(),
+                    grtc: self.grtc(),
+                    nfc: self.nfc(),
+                    sectamper: self.sectamper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -26873,6 +36019,26 @@ pub mod rramc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("erase", &self.erase())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    erase: super::vals::Erase,
+                }
+                let proxy = Eraseall {
+                    erase: self.erase(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26940,6 +36106,38 @@ pub mod rramc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("wokenup", &self.wokenup())
+                    .field("ready", &self.ready())
+                    .field("readynext", &self.readynext())
+                    .field("accesserror", &self.accesserror())
+                    .field("eccerror", &self.eccerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    wokenup: bool,
+                    ready: bool,
+                    readynext: bool,
+                    accesserror: bool,
+                    eccerror: bool,
+                }
+                let proxy = Int {
+                    wokenup: self.wokenup(),
+                    ready: self.ready(),
+                    readynext: self.readynext(),
+                    accesserror: self.accesserror(),
+                    eccerror: self.eccerror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Low power mode configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -26961,6 +36159,24 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Lowpowerconfig {
                 Lowpowerconfig(0)
+            }
+        }
+        impl core::fmt::Debug for Lowpowerconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lowpowerconfig")
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lowpowerconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lowpowerconfig {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Lowpowerconfig { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Power configuration"]
@@ -26998,6 +36214,29 @@ pub mod rramc {
                 PowerConfig(0)
             }
         }
+        impl core::fmt::Debug for PowerConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PowerConfig")
+                    .field("accesstimeout", &self.accesstimeout())
+                    .field("pof", &self.pof())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PowerConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PowerConfig {
+                    accesstimeout: u16,
+                    pof: super::vals::Pof,
+                }
+                let proxy = PowerConfig {
+                    accesstimeout: self.accesstimeout(),
+                    pof: self.pof(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "RRAMC ready status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27021,6 +36260,26 @@ pub mod rramc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready next flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27042,6 +36301,26 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Readynext {
                 Readynext(0)
+            }
+        }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration for ready next timeout counter, in units of AXI clock frequency"]
@@ -27076,6 +36355,29 @@ pub mod rramc {
             #[inline(always)]
             fn default() -> Readynexttimeout {
                 Readynexttimeout(0)
+            }
+        }
+        impl core::fmt::Debug for Readynexttimeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynexttimeout")
+                    .field("value", &self.value())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynexttimeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynexttimeout {
+                    value: u16,
+                    en: bool,
+                }
+                let proxy = Readynexttimeout {
+                    value: self.value(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Region configuration"]
@@ -27178,6 +36480,47 @@ pub mod rramc {
                 RegionConfig(0)
             }
         }
+        impl core::fmt::Debug for RegionConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RegionConfig")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("owner", &self.owner())
+                    .field("writeonce", &self.writeonce())
+                    .field("lock", &self.lock())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RegionConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RegionConfig {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    owner: super::vals::Owner,
+                    writeonce: bool,
+                    lock: bool,
+                    size: u8,
+                }
+                let proxy = RegionConfig {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    owner: self.owner(),
+                    writeonce: self.writeonce(),
+                    lock: self.lock(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27212,6 +36555,29 @@ pub mod rramc {
                 RramcConfig(0)
             }
         }
+        impl core::fmt::Debug for RramcConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RramcConfig")
+                    .field("wen", &self.wen())
+                    .field("writebufsize", &self.writebufsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RramcConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RramcConfig {
+                    wen: bool,
+                    writebufsize: super::vals::Writebufsize,
+                }
+                let proxy = RramcConfig {
+                    wen: self.wen(),
+                    writebufsize: self.writebufsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Internal write-buffer is empty"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27233,10 +36599,31 @@ pub mod rramc {
                 Writebufempty(0)
             }
         }
+        impl core::fmt::Debug for Writebufempty {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writebufempty")
+                    .field("empty", &self.empty())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writebufempty {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writebufempty {
+                    empty: bool,
+                }
+                let proxy = Writebufempty {
+                    empty: self.empty(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Erase {
             #[doc = "No operation"]
             NO_OPERATION = 0x0,
@@ -27266,7 +36653,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "The RRAM goes into power down mode"]
             POWER_DOWN = 0x0,
@@ -27300,7 +36688,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Owner {
             #[doc = "Owner ID protection is not enforced"]
             NOT_ENFORCED = 0x0,
@@ -27343,7 +36732,8 @@ pub mod rramc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pof {
             #[doc = "Wait until the current RRAM write finishes"]
             WAIT = 0x0,
@@ -27385,6 +36775,23 @@ pub mod rramc {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Writebufsize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("UNBUFFERED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writebufsize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "UNBUFFERED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for Writebufsize {
@@ -27592,6 +36999,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27614,6 +37041,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -27665,6 +37112,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27714,6 +37200,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768 / (PRESCALER + 1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -27735,6 +37260,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -27762,6 +37307,39 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "comparen_clear",
+                        &[
+                            self.comparen_clear(0usize),
+                            self.comparen_clear(1usize),
+                            self.comparen_clear(2usize),
+                            self.comparen_clear(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    comparen_clear: [bool; 4usize],
+                }
+                let proxy = Shorts {
+                    comparen_clear: [
+                        self.comparen_clear(0usize),
+                        self.comparen_clear(1usize),
+                        self.comparen_clear(2usize),
+                        self.comparen_clear(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -28161,6 +37739,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28241,6 +37839,41 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("gain", &self.gain())
+                    .field("burst", &self.burst())
+                    .field("refsel", &self.refsel())
+                    .field("mode", &self.mode())
+                    .field("tacq", &self.tacq())
+                    .field("tconv", &self.tconv())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    gain: super::vals::Gain,
+                    burst: bool,
+                    refsel: super::vals::Refsel,
+                    mode: super::vals::ConfigMode,
+                    tacq: u16,
+                    tconv: u8,
+                }
+                let proxy = Config {
+                    gain: self.gain(),
+                    burst: self.burst(),
+                    refsel: self.refsel(),
+                    mode: self.mode(),
+                    tacq: self.tacq(),
+                    tconv: self.tconv(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of buffer bytes transferred since last START, continuously updated"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28264,6 +37897,26 @@ pub mod saadc {
                 Currentamount(0)
             }
         }
+        impl core::fmt::Debug for Currentamount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Currentamount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Currentamount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Currentamount {
+                    amount: u16,
+                }
+                let proxy = Currentamount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28285,6 +37938,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -28395,6 +38068,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28429,6 +38185,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Linearity calibration coefficient"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28450,6 +38229,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Lincalcoeff {
                 Lincalcoeff(0)
+            }
+        }
+        impl core::fmt::Debug for Lincalcoeff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lincalcoeff")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lincalcoeff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lincalcoeff {
+                    val: u16,
+                }
+                let proxy = Lincalcoeff { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of buffer bytes to transfer"]
@@ -28475,6 +38272,26 @@ pub mod saadc {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable noise shaping"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28498,6 +38315,26 @@ pub mod saadc {
                 Noiseshape(0)
             }
         }
+        impl core::fmt::Debug for Noiseshape {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Noiseshape")
+                    .field("noiseshape", &self.noiseshape())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Noiseshape {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Noiseshape {
+                    noiseshape: super::vals::Noiseshape,
+                }
+                let proxy = Noiseshape {
+                    noiseshape: self.noiseshape(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28519,6 +38356,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Oversample {
                 Oversample(0)
+            }
+        }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
@@ -28565,6 +38422,32 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pin: u8,
+                    port: u8,
+                    connect: super::vals::PselnConnect,
+                }
+                let proxy = Pseln {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -28625,6 +38508,35 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("internal", &self.internal())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pin: u8,
+                    port: u8,
+                    internal: super::vals::Internal,
+                    connect: super::vals::PselpConnect,
+                }
+                let proxy = Pselp {
+                    pin: self.pin(),
+                    port: self.port(),
+                    internal: self.internal(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28646,6 +38558,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -28683,6 +38613,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -28706,10 +38659,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -28739,7 +38713,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "2"]
             GAIN2 = 0x0,
@@ -28781,7 +38756,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Internal {
             #[doc = "Connected to the internal 0.9V analog supply rail"]
             AVDD = 0x0,
@@ -28814,7 +38790,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Noiseshape {
             #[doc = "Disable noiseshaping. Oversampling based on accumulate and average."]
             DISABLE = 0x0,
@@ -28847,7 +38824,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -28898,7 +38876,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselnConnect {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -28930,7 +38909,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PselpConnect {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -28963,7 +38943,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (1.024 V)"]
             INTERNAL = 0x0,
@@ -28993,7 +38974,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -29023,7 +39005,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -29053,7 +39036,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -29140,6 +39124,32 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("port", &self.port())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    port: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    port: self.port(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event END"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -29170,6 +39180,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task START"]
@@ -29204,10 +39237,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -30016,6 +40073,26 @@ pub mod spim {
                 Csndur(0)
             }
         }
+        impl core::fmt::Debug for Csndur {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csndur")
+                    .field("csndur", &self.csndur())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csndur {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csndur {
+                    csndur: u8,
+                }
+                let proxy = Csndur {
+                    csndur: self.csndur(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Polarity of CSN output"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30037,6 +40114,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Csnpol {
                 Csnpol(0)
+            }
+        }
+        impl core::fmt::Debug for Csnpol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Csnpol")
+                    .field("csnpol_0", &self.csnpol_0())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Csnpol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Csnpol {
+                    csnpol_0: super::vals::Csnpol0,
+                }
+                let proxy = Csnpol {
+                    csnpol_0: self.csnpol_0(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DCX configuration"]
@@ -30062,6 +40159,26 @@ pub mod spim {
                 Dcxcnt(0)
             }
         }
+        impl core::fmt::Debug for Dcxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcxcnt")
+                    .field("dcxcnt", &self.dcxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcxcnt {
+                    dcxcnt: u8,
+                }
+                let proxy = Dcxcnt {
+                    dcxcnt: self.dcxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30083,6 +40200,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -30211,6 +40348,66 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field(
+                        "dmarxmatch",
+                        &[
+                            self.dmarxmatch(0usize),
+                            self.dmarxmatch(1usize),
+                            self.dmarxmatch(2usize),
+                            self.dmarxmatch(3usize),
+                        ],
+                    )
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch: [bool; 4usize],
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch: [
+                        self.dmarxmatch(0usize),
+                        self.dmarxmatch(1usize),
+                        self.dmarxmatch(2usize),
+                        self.dmarxmatch(3usize),
+                    ],
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30315,6 +40512,47 @@ pub mod spim {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Byte transmitted after TXD.MAXCNT bytes have been transmitted in the case when RXD.MAXCNT is greater than TXD.MAXCNT"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30336,6 +40574,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The prescaler is used to set the SPI frequency."]
@@ -30361,6 +40615,26 @@ pub mod spim {
                 Prescaler(0)
             }
         }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("divisor", &self.divisor())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    divisor: u8,
+                }
+                let proxy = Prescaler {
+                    divisor: self.divisor(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30382,6 +40656,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -30407,6 +40701,26 @@ pub mod spim {
                 RxList(0)
             }
         }
+        impl core::fmt::Debug for RxList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxList")
+                    .field("type_", &self.type_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxList {
+                    type_: super::vals::RxListType,
+                }
+                let proxy = RxList {
+                    type_: self.type_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30430,6 +40744,26 @@ pub mod spim {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30449,6 +40783,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample delay for input serial data on MISO"]
@@ -30472,6 +40826,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Rxdelay {
                 Rxdelay(0)
+            }
+        }
+        impl core::fmt::Debug for Rxdelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxdelay")
+                    .field("rxdelay", &self.rxdelay())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxdelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxdelay {
+                    rxdelay: u8,
+                }
+                let proxy = Rxdelay {
+                    rxdelay: self.rxdelay(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -30585,6 +40959,74 @@ pub mod spim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30630,6 +41072,32 @@ pub mod spim {
                 SpimConfig(0)
             }
         }
+        impl core::fmt::Debug for SpimConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpimConfig")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpimConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpimConfig {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = SpimConfig {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30651,6 +41119,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -30676,6 +41164,26 @@ pub mod spim {
                 TxList(0)
             }
         }
+        impl core::fmt::Debug for TxList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxList")
+                    .field("type_", &self.type_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxList {
+                    type_: super::vals::TxListType,
+                }
+                let proxy = TxList {
+                    type_: self.type_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30699,6 +41207,26 @@ pub mod spim {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -30720,10 +41248,31 @@ pub mod spim {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -30753,7 +41302,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -30783,7 +41333,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Csnpol0 {
             #[doc = "Active low (idle state high)"]
             LOW = 0x0,
@@ -30813,7 +41364,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -30857,7 +41409,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -30887,7 +41440,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -30917,7 +41471,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -30947,7 +41502,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -30977,7 +41533,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -31007,7 +41564,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxListType {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -31043,7 +41601,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxListType {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -31751,6 +42310,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31772,6 +42347,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -31889,6 +42484,63 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("acquired", &self.acquired())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field(
+                        "dmarxmatch",
+                        &[
+                            self.dmarxmatch(0usize),
+                            self.dmarxmatch(1usize),
+                            self.dmarxmatch(2usize),
+                            self.dmarxmatch(3usize),
+                        ],
+                    )
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    acquired: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch: [bool; 4usize],
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    acquired: self.acquired(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch: [
+                        self.dmarxmatch(0usize),
+                        self.dmarxmatch(1usize),
+                        self.dmarxmatch(2usize),
+                        self.dmarxmatch(3usize),
+                    ],
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -31993,6 +42645,47 @@ pub mod spis {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32014,6 +42707,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -32039,6 +42748,26 @@ pub mod spis {
                 RxAmount(0)
             }
         }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32062,6 +42791,26 @@ pub mod spis {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32081,6 +42830,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Semaphore status register"]
@@ -32104,6 +42873,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Semstat {
                 Semstat(0)
+            }
+        }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -32217,6 +43006,74 @@ pub mod spis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32262,6 +43119,32 @@ pub mod spis {
                 SpisConfig(0)
             }
         }
+        impl core::fmt::Debug for SpisConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpisConfig")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpisConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpisConfig {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = SpisConfig {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status from last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32296,6 +43179,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32317,6 +43223,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -32342,6 +43268,26 @@ pub mod spis {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32363,10 +43309,31 @@ pub mod spis {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -32396,7 +43363,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -32426,7 +43394,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -32470,7 +43439,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -32500,7 +43470,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -32530,7 +43501,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -32560,7 +43532,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -32590,7 +43563,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -32620,7 +43594,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -32979,6 +43954,26 @@ pub mod spu {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u16,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for CC n of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33011,6 +44006,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Cc {
                 Cc(0)
+            }
+        }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Cc {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for channel group n of DPPIC"]
@@ -33047,6 +44065,29 @@ pub mod spu {
                 Chg(0)
             }
         }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Chg {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of features for CLKOUT/CLKCFG of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33079,6 +44120,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Clk {
                 Clk(0)
+            }
+        }
+        impl core::fmt::Debug for Clk {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Clk")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Clk {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Clk {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Clk {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for channel n of DPPIC"]
@@ -33115,6 +44179,29 @@ pub mod spu {
                 DppicCh(0)
             }
         }
+        impl core::fmt::Debug for DppicCh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppicCh")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppicCh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppicCh {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = DppicCh {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for channel o of GPIOTE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33147,6 +44234,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> GpioteCh {
                 GpioteCh(0)
+            }
+        }
+        impl core::fmt::Debug for GpioteCh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioteCh")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioteCh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioteCh {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GpioteCh {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of features for interrupt o of GPIOTE\\[n\\]"]
@@ -33183,6 +44293,29 @@ pub mod spu {
                 GpioteInterrupt(0)
             }
         }
+        impl core::fmt::Debug for GpioteInterrupt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioteInterrupt")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioteInterrupt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioteInterrupt {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GpioteInterrupt {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for interrupt n of GRTC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33217,6 +44350,29 @@ pub mod spu {
                 GrtcInterrupt(0)
             }
         }
+        impl core::fmt::Debug for GrtcInterrupt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GrtcInterrupt")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GrtcInterrupt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GrtcInterrupt {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = GrtcInterrupt {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33238,6 +44394,26 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("periphaccerr", &self.periphaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    periphaccerr: bool,
+                }
+                let proxy = Int {
+                    periphaccerr: self.periphaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Get and set the applicable access permissions for the peripheral slave index n"]
@@ -33319,6 +44495,41 @@ pub mod spu {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("securemapping", &self.securemapping())
+                    .field("dma", &self.dma())
+                    .field("secattr", &self.secattr())
+                    .field("dmasec", &self.dmasec())
+                    .field("lock", &self.lock())
+                    .field("present", &self.present())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    securemapping: super::vals::Securemapping,
+                    dma: super::vals::Dma,
+                    secattr: bool,
+                    dmasec: bool,
+                    lock: bool,
+                    present: super::vals::Present,
+                }
+                let proxy = Perm {
+                    securemapping: self.securemapping(),
+                    dma: self.dma(),
+                    secattr: self.secattr(),
+                    dmasec: self.dmasec(),
+                    lock: self.lock(),
+                    present: self.present(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Configuration of features for GPIO\\[n\\] PIN\\[o\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33351,6 +44562,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Pin {
                 Pin(0)
+            }
+        }
+        impl core::fmt::Debug for Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pin")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pin {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pin {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Pin {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of feature for PWMCONFIG of GRTC"]
@@ -33387,6 +44621,29 @@ pub mod spu {
                 Pwmconfig(0)
             }
         }
+        impl core::fmt::Debug for Pwmconfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pwmconfig")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pwmconfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pwmconfig {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Pwmconfig {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for CRACEN SEED"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33419,6 +44676,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Seed {
                 Seed(0)
+            }
+        }
+        impl core::fmt::Debug for Seed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Seed")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Seed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Seed {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Seed {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of features for SYSCOUNTERL/SYSCOUNTERH of GRTC"]
@@ -33455,10 +44735,34 @@ pub mod spu {
                 Syscounter(0)
             }
         }
+        impl core::fmt::Debug for Syscounter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syscounter")
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syscounter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syscounter {
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = Syscounter {
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dma {
             #[doc = "Peripheral has no DMA capability"]
             NO_DMA = 0x0,
@@ -33491,7 +44795,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "Peripheral is not present"]
             NOT_PRESENT = 0x0,
@@ -33521,7 +44826,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Securemapping {
             #[doc = "This peripheral is always accessible as a non-secure peripheral"]
             NON_SECURE = 0x0,
@@ -33625,6 +44931,26 @@ pub mod tad {
                 Dbgpwrupreq(0)
             }
         }
+        impl core::fmt::Debug for Dbgpwrupreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dbgpwrupreq")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dbgpwrupreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dbgpwrupreq {
+                    active: bool,
+                }
+                let proxy = Dbgpwrupreq {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable debug domain and aquire selected GPIOs"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33644,6 +44970,26 @@ pub mod tad {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System power-up request"]
@@ -33669,6 +45015,26 @@ pub mod tad {
                 Syspwrupreq(0)
             }
         }
+        impl core::fmt::Debug for Syspwrupreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Syspwrupreq")
+                    .field("active", &self.active())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Syspwrupreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Syspwrupreq {
+                    active: bool,
+                }
+                let proxy = Syspwrupreq {
+                    active: self.active(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SW-DP Target instance"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -33690,6 +45056,26 @@ pub mod tad {
             #[inline(always)]
             fn default() -> Tinstance {
                 Tinstance(0)
+            }
+        }
+        impl core::fmt::Debug for Tinstance {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tinstance")
+                    .field("tinstance", &self.tinstance())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tinstance {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tinstance {
+                    tinstance: u8,
+                }
+                let proxy = Tinstance {
+                    tinstance: self.tinstance(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Trace port speed"]
@@ -33715,10 +45101,31 @@ pub mod tad {
                 Traceportspeed(0)
             }
         }
+        impl core::fmt::Debug for Traceportspeed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceportspeed")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceportspeed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceportspeed {
+                    traceportspeed: super::vals::Traceportspeed,
+                }
+                let proxy = Traceportspeed {
+                    traceportspeed: self.traceportspeed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "Trace port speed equals CPU clock"]
             DIV1 = 0x0,
@@ -34360,6 +45767,35 @@ pub mod tampc {
                 ActiveshieldCtrl(0)
             }
         }
+        impl core::fmt::Debug for ActiveshieldCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ActiveshieldCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ActiveshieldCtrl {
+                    value: super::vals::ActiveshieldCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ActiveshieldCtrlWriteprotection,
+                    key: super::vals::ActiveshieldCtrlKey,
+                }
+                let proxy = ActiveshieldCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for active shield detector enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34381,6 +45817,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ActiveshieldStatus {
                 ActiveshieldStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ActiveshieldStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ActiveshieldStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ActiveshieldStatus {
+                    error: bool,
+                }
+                let proxy = ActiveshieldStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register to enable invasive (halting) debug in domain n's access port."]
@@ -34440,6 +45896,35 @@ pub mod tampc {
                 ApDbgenCtrl(0)
             }
         }
+        impl core::fmt::Debug for ApDbgenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApDbgenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApDbgenCtrl {
+                    value: super::vals::ApDbgenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ApDbgenCtrlWriteprotection,
+                    key: super::vals::ApDbgenCtrlKey,
+                }
+                let proxy = ApDbgenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for invasive (halting) debug enable for domain n's access port."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34461,6 +45946,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ApDbgenStatus {
                 ApDbgenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ApDbgenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApDbgenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApDbgenStatus {
+                    error: bool,
+                }
+                let proxy = ApDbgenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Active shield detector channel enable register."]
@@ -34488,6 +45993,39 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> Chen {
                 Chen(0)
+            }
+        }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 4usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for CRACEN tamper detector enable signal."]
@@ -34547,6 +46085,35 @@ pub mod tampc {
                 CracentampCtrl(0)
             }
         }
+        impl core::fmt::Debug for CracentampCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CracentampCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CracentampCtrl {
+                    value: super::vals::CracentampCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::CracentampCtrlWriteprotection,
+                    key: super::vals::CracentampCtrlKey,
+                }
+                let proxy = CracentampCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for CRACEN tamper detector enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34568,6 +46135,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> CracentampStatus {
                 CracentampStatus(0)
+            }
+        }
+        impl core::fmt::Debug for CracentampStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("CracentampStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct CracentampStatus {
+                    error: bool,
+                }
+                let proxy = CracentampStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for invasive (halting) debug enable for the local debug components within domain n."]
@@ -34630,6 +46217,35 @@ pub mod tampc {
                 DomainDbgenCtrl(0)
             }
         }
+        impl core::fmt::Debug for DomainDbgenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DomainDbgenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DomainDbgenCtrl {
+                    value: super::vals::DomainDbgenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::DomainDbgenCtrlWriteprotection,
+                    key: super::vals::DomainDbgenCtrlKey,
+                }
+                let proxy = DomainDbgenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for invasive (halting) debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34651,6 +46267,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> DomainDbgenStatus {
                 DomainDbgenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for DomainDbgenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DomainDbgenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DomainDbgenStatus {
+                    error: bool,
+                }
+                let proxy = DomainDbgenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for erase protection."]
@@ -34713,6 +46349,35 @@ pub mod tampc {
                 EraseprotectCtrl(0)
             }
         }
+        impl core::fmt::Debug for EraseprotectCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectCtrl {
+                    value: super::vals::EraseprotectCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::EraseprotectCtrlWriteprotection,
+                    key: super::vals::EraseprotectCtrlKey,
+                }
+                let proxy = EraseprotectCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for eraseprotect."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34734,6 +46399,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> EraseprotectStatus {
                 EraseprotectStatus(0)
+            }
+        }
+        impl core::fmt::Debug for EraseprotectStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectStatus {
+                    error: bool,
+                }
+                let proxy = EraseprotectStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for external tamper reset enable signal."]
@@ -34793,6 +46478,35 @@ pub mod tampc {
                 ExtresetenCtrl(0)
             }
         }
+        impl core::fmt::Debug for ExtresetenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtresetenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtresetenCtrl {
+                    value: super::vals::ExtresetenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::ExtresetenCtrlWriteprotection,
+                    key: super::vals::ExtresetenCtrlKey,
+                }
+                let proxy = ExtresetenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for external tamper reset enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34814,6 +46528,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> ExtresetenStatus {
                 ExtresetenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for ExtresetenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtresetenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtresetenStatus {
+                    error: bool,
+                }
+                let proxy = ExtresetenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for fast domain glitch detectors enable signal."]
@@ -34878,6 +46612,35 @@ pub mod tampc {
                 GlitchfastdomainCtrl(0)
             }
         }
+        impl core::fmt::Debug for GlitchfastdomainCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchfastdomainCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchfastdomainCtrl {
+                    value: super::vals::GlitchfastdomainCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::GlitchfastdomainCtrlWriteprotection,
+                    key: super::vals::GlitchfastdomainCtrlKey,
+                }
+                let proxy = GlitchfastdomainCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for fast domain glitch detectors enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34899,6 +46662,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> GlitchfastdomainStatus {
                 GlitchfastdomainStatus(0)
+            }
+        }
+        impl core::fmt::Debug for GlitchfastdomainStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchfastdomainStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchfastdomainStatus {
+                    error: bool,
+                }
+                let proxy = GlitchfastdomainStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for slow domain glitch detectors enable signal."]
@@ -34963,6 +46746,35 @@ pub mod tampc {
                 GlitchslowdomainCtrl(0)
             }
         }
+        impl core::fmt::Debug for GlitchslowdomainCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchslowdomainCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchslowdomainCtrl {
+                    value: super::vals::GlitchslowdomainCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::GlitchslowdomainCtrlWriteprotection,
+                    key: super::vals::GlitchslowdomainCtrlKey,
+                }
+                let proxy = GlitchslowdomainCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for slow domain glitch detectors enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -34984,6 +46796,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> GlitchslowdomainStatus {
                 GlitchslowdomainStatus(0)
+            }
+        }
+        impl core::fmt::Debug for GlitchslowdomainStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GlitchslowdomainStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GlitchslowdomainStatus {
+                    error: bool,
+                }
+                let proxy = GlitchslowdomainStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -35018,6 +46850,29 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tamper", &self.tamper())
+                    .field("writeerror", &self.writeerror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tamper: bool,
+                    writeerror: bool,
+                }
+                let proxy = Int {
+                    tamper: self.tamper(),
+                    writeerror: self.writeerror(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Control register for internal tamper reset enable signal."]
@@ -35077,6 +46932,35 @@ pub mod tampc {
                 IntresetenCtrl(0)
             }
         }
+        impl core::fmt::Debug for IntresetenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IntresetenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IntresetenCtrl {
+                    value: super::vals::IntresetenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::IntresetenCtrlWriteprotection,
+                    key: super::vals::IntresetenCtrlKey,
+                }
+                let proxy = IntresetenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register for internal tamper reset enable signal."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35098,6 +46982,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> IntresetenStatus {
                 IntresetenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for IntresetenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("IntresetenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct IntresetenStatus {
+                    error: bool,
+                }
+                let proxy = IntresetenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for non-invasive debug enable for the local debug components within domain n."]
@@ -35157,6 +47061,35 @@ pub mod tampc {
                 NidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for NidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NidenCtrl {
+                    value: super::vals::NidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::NidenCtrlWriteprotection,
+                    key: super::vals::NidenCtrlKey,
+                }
+                let proxy = NidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for non-invasive debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35178,6 +47111,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> NidenStatus {
                 NidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for NidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("NidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct NidenStatus {
+                    error: bool,
+                }
+                let proxy = NidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for secure priviliged invasive (halting) debug enable for the local debug components within domain n."]
@@ -35237,6 +47190,35 @@ pub mod tampc {
                 SpidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for SpidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpidenCtrl {
+                    value: super::vals::SpidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::SpidenCtrlWriteprotection,
+                    key: super::vals::SpidenCtrlKey,
+                }
+                let proxy = SpidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for secure priviliged invasive (halting) debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35258,6 +47240,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> SpidenStatus {
                 SpidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for SpidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpidenStatus {
+                    error: bool,
+                }
+                let proxy = SpidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Control register for secure priviliged non-invasive debug enable for the local debug components within domain n."]
@@ -35317,6 +47319,35 @@ pub mod tampc {
                 SpnidenCtrl(0)
             }
         }
+        impl core::fmt::Debug for SpnidenCtrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpnidenCtrl")
+                    .field("value", &self.value())
+                    .field("lock", &self.lock())
+                    .field("writeprotection", &self.writeprotection())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenCtrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpnidenCtrl {
+                    value: super::vals::SpnidenCtrlValue,
+                    lock: bool,
+                    writeprotection: super::vals::SpnidenCtrlWriteprotection,
+                    key: super::vals::SpnidenCtrlKey,
+                }
+                let proxy = SpnidenCtrl {
+                    value: self.value(),
+                    lock: self.lock(),
+                    writeprotection: self.writeprotection(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Status register for secure priviliged non-invasive debug enable for domain n."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -35338,6 +47369,26 @@ pub mod tampc {
             #[inline(always)]
             fn default() -> SpnidenStatus {
                 SpnidenStatus(0)
+            }
+        }
+        impl core::fmt::Debug for SpnidenStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SpnidenStatus")
+                    .field("error", &self.error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SpnidenStatus {
+                    error: bool,
+                }
+                let proxy = SpnidenStatus {
+                    error: self.error(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The tamper controller status."]
@@ -35415,6 +47466,51 @@ pub mod tampc {
                 TampcStatus(0)
             }
         }
+        impl core::fmt::Debug for TampcStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TampcStatus")
+                    .field("activeshield", &self.activeshield())
+                    .field("protect", &self.protect())
+                    .field("cracentamp", &self.cracentamp())
+                    .field("glitchslowdomain", &[self.glitchslowdomain(0usize)])
+                    .field(
+                        "glitchfastdomain",
+                        &[
+                            self.glitchfastdomain(0usize),
+                            self.glitchfastdomain(1usize),
+                            self.glitchfastdomain(2usize),
+                            self.glitchfastdomain(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TampcStatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TampcStatus {
+                    activeshield: bool,
+                    protect: bool,
+                    cracentamp: bool,
+                    glitchslowdomain: [bool; 1usize],
+                    glitchfastdomain: [bool; 4usize],
+                }
+                let proxy = TampcStatus {
+                    activeshield: self.activeshield(),
+                    protect: self.protect(),
+                    cracentamp: self.cracentamp(),
+                    glitchslowdomain: [self.glitchslowdomain(0usize)],
+                    glitchfastdomain: [
+                        self.glitchfastdomain(0usize),
+                        self.glitchfastdomain(1usize),
+                        self.glitchfastdomain(2usize),
+                        self.glitchfastdomain(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -35432,6 +47528,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ActiveshieldCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ActiveshieldCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ActiveshieldCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ActiveshieldCtrlKey {
@@ -35445,7 +47558,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ActiveshieldCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35475,7 +47589,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ActiveshieldCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -35534,6 +47649,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ApDbgenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApDbgenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ApDbgenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ApDbgenCtrlKey {
@@ -35547,7 +47679,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ApDbgenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35577,7 +47710,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ApDbgenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -35636,6 +47770,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for CracentampCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CracentampCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CracentampCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> CracentampCtrlKey {
@@ -35649,7 +47800,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CracentampCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35679,7 +47831,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CracentampCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -35738,6 +47891,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for DomainDbgenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DomainDbgenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for DomainDbgenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> DomainDbgenCtrlKey {
@@ -35751,7 +47921,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DomainDbgenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35781,7 +47952,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum DomainDbgenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -35840,6 +48012,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for EraseprotectCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> EraseprotectCtrlKey {
@@ -35853,7 +48042,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EraseprotectCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35883,7 +48073,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum EraseprotectCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -35942,6 +48133,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for ExtresetenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtresetenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for ExtresetenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> ExtresetenCtrlKey {
@@ -35955,7 +48163,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtresetenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -35985,7 +48194,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtresetenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36044,6 +48254,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for GlitchfastdomainCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchfastdomainCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for GlitchfastdomainCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> GlitchfastdomainCtrlKey {
@@ -36057,7 +48284,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchfastdomainCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36087,7 +48315,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchfastdomainCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36146,6 +48375,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for GlitchslowdomainCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GlitchslowdomainCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for GlitchslowdomainCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> GlitchslowdomainCtrlKey {
@@ -36159,7 +48405,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchslowdomainCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36189,7 +48436,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum GlitchslowdomainCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36248,6 +48496,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for IntresetenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for IntresetenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for IntresetenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> IntresetenCtrlKey {
@@ -36261,7 +48526,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum IntresetenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36291,7 +48557,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum IntresetenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36350,6 +48617,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for NidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for NidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for NidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> NidenCtrlKey {
@@ -36363,7 +48647,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36393,7 +48678,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum NidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36452,6 +48738,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for SpidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for SpidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> SpidenCtrlKey {
@@ -36465,7 +48768,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36495,7 +48799,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36554,6 +48859,23 @@ pub mod tampc {
                 self.0
             }
         }
+        impl core::fmt::Debug for SpnidenCtrlKey {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x50fa => f.write_str("KEY"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SpnidenCtrlKey {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x50fa => defmt::write!(f, "KEY"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for SpnidenCtrlKey {
             #[inline(always)]
             fn from(val: u16) -> SpnidenCtrlKey {
@@ -36567,7 +48889,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpnidenCtrlValue {
             #[doc = "Signal is logic 0."]
             LOW = 0x0,
@@ -36597,7 +48920,8 @@ pub mod tampc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpnidenCtrlWriteprotection {
             #[doc = "Read: Write protection is disabled."]
             DISABLED = 0x0,
@@ -36752,6 +49076,26 @@ pub mod temp {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("datardy", &self.datardy())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    datardy: bool,
+                }
+                let proxy = Int {
+                    datardy: self.datardy(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -36938,6 +49282,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36965,6 +49329,47 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                            self.compare(6usize),
+                            self.compare(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 8usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                        self.compare(6usize),
+                        self.compare(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -36986,6 +49391,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -37011,6 +49432,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -37032,6 +49473,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -37076,10 +49537,76 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                            self.compare_clear(6usize),
+                            self.compare_clear(7usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                            self.compare_stop(6usize),
+                            self.compare_stop(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 8usize],
+                    compare_stop: [bool; 8usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                        self.compare_clear(6usize),
+                        self.compare_clear(7usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                        self.compare_stop(6usize),
+                        self.compare_stop(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -37113,7 +49640,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -37939,6 +50467,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38043,6 +50591,47 @@ pub mod twim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = Config {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38064,6 +50653,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -38111,6 +50720,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38133,6 +50768,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -38312,6 +50967,68 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38333,6 +51050,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -38358,6 +51095,26 @@ pub mod twim {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38377,6 +51134,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -38534,6 +51311,86 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_dma_rx_start", &self.lasttx_dma_rx_start())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_dma_tx_start", &self.lastrx_dma_tx_start())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_dma_rx_start: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_dma_tx_start: bool,
+                    lastrx_stop: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_dma_rx_start: self.lasttx_dma_rx_start(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_dma_tx_start: self.lastrx_dma_tx_start(),
+                    lastrx_stop: self.lastrx_stop(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38555,6 +51412,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -38580,6 +51457,26 @@ pub mod twim {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -38601,10 +51498,31 @@ pub mod twim {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -38666,6 +51584,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -38679,7 +51618,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -38709,7 +51649,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -38739,7 +51680,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -38769,7 +51711,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -39526,6 +52469,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39547,6 +52510,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -39592,6 +52575,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -39760,6 +52769,65 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    write: bool,
+                    read: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    write: self.write(),
+                    read: self.read(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39864,6 +52932,47 @@ pub mod twis {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39885,6 +52994,22 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -39910,6 +53035,26 @@ pub mod twis {
                 RxAmount(0)
             }
         }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39933,6 +53078,26 @@ pub mod twis {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -39952,6 +53117,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -40076,6 +53261,77 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40110,6 +53366,29 @@ pub mod twis {
                 TwisConfig(0)
             }
         }
+        impl core::fmt::Debug for TwisConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TwisConfig")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TwisConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TwisConfig {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = TwisConfig {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40131,6 +53410,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TwisMatch {
                 TwisMatch(0)
+            }
+        }
+        impl core::fmt::Debug for TwisMatch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TwisMatch")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TwisMatch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TwisMatch {
+                    match_: bool,
+                }
+                let proxy = TwisMatch {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
@@ -40156,6 +53455,26 @@ pub mod twis {
                 TxAmount(0)
             }
         }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in channel buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40179,6 +53498,26 @@ pub mod twis {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -40200,10 +53539,31 @@ pub mod twis {
                 TxTerminateonbuserror(0)
             }
         }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -40247,7 +53607,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -40277,7 +53638,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -40307,7 +53669,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -40337,7 +53700,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -41194,6 +54558,26 @@ pub mod uarte {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Baud rate. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41218,6 +54602,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41239,6 +54643,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -41297,6 +54721,35 @@ pub mod uarte {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set the number of UARTE bits to count before triggering packet timeout."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41318,6 +54771,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Frametimeout {
                 Frametimeout(0)
+            }
+        }
+        impl core::fmt::Debug for Frametimeout {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frametimeout")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frametimeout {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frametimeout {
+                    countertop: u16,
+                }
+                let proxy = Frametimeout {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -41530,6 +55003,77 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("txstopped", &self.txstopped())
+                    .field("dmarxend", &self.dmarxend())
+                    .field("dmarxready", &self.dmarxready())
+                    .field("dmarxbuserror", &self.dmarxbuserror())
+                    .field("dmarxmatch0", &self.dmarxmatch0())
+                    .field("dmarxmatch1", &self.dmarxmatch1())
+                    .field("dmarxmatch2", &self.dmarxmatch2())
+                    .field("dmarxmatch3", &self.dmarxmatch3())
+                    .field("dmatxend", &self.dmatxend())
+                    .field("dmatxready", &self.dmatxready())
+                    .field("dmatxbuserror", &self.dmatxbuserror())
+                    .field("frametimeout", &self.frametimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    txdrdy: bool,
+                    rxdrdy: bool,
+                    error: bool,
+                    rxto: bool,
+                    txstopped: bool,
+                    dmarxend: bool,
+                    dmarxready: bool,
+                    dmarxbuserror: bool,
+                    dmarxmatch0: bool,
+                    dmarxmatch1: bool,
+                    dmarxmatch2: bool,
+                    dmarxmatch3: bool,
+                    dmatxend: bool,
+                    dmatxready: bool,
+                    dmatxbuserror: bool,
+                    frametimeout: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    txdrdy: self.txdrdy(),
+                    rxdrdy: self.rxdrdy(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    txstopped: self.txstopped(),
+                    dmarxend: self.dmarxend(),
+                    dmarxready: self.dmarxready(),
+                    dmarxbuserror: self.dmarxbuserror(),
+                    dmarxmatch0: self.dmarxmatch0(),
+                    dmarxmatch1: self.dmarxmatch1(),
+                    dmarxmatch2: self.dmarxmatch2(),
+                    dmarxmatch3: self.dmarxmatch3(),
+                    dmatxend: self.dmatxend(),
+                    dmatxready: self.dmatxready(),
+                    dmatxbuserror: self.dmatxbuserror(),
+                    frametimeout: self.frametimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configure individual match events"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41634,6 +55178,47 @@ pub mod uarte {
                 MatchConfig(0)
             }
         }
+        impl core::fmt::Debug for MatchConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("MatchConfig")
+                    .field("enable_0", &self.enable_0())
+                    .field("enable_1", &self.enable_1())
+                    .field("enable_2", &self.enable_2())
+                    .field("enable_3", &self.enable_3())
+                    .field("oneshot_0", &self.oneshot_0())
+                    .field("oneshot_1", &self.oneshot_1())
+                    .field("oneshot_2", &self.oneshot_2())
+                    .field("oneshot_3", &self.oneshot_3())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for MatchConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct MatchConfig {
+                    enable_0: bool,
+                    enable_1: bool,
+                    enable_2: bool,
+                    enable_3: bool,
+                    oneshot_0: super::vals::Oneshot0,
+                    oneshot_1: super::vals::Oneshot1,
+                    oneshot_2: super::vals::Oneshot2,
+                    oneshot_3: super::vals::Oneshot3,
+                }
+                let proxy = MatchConfig {
+                    enable_0: self.enable_0(),
+                    enable_1: self.enable_1(),
+                    enable_2: self.enable_2(),
+                    enable_3: self.enable_3(),
+                    oneshot_0: self.oneshot_0(),
+                    oneshot_1: self.oneshot_1(),
+                    oneshot_2: self.oneshot_2(),
+                    oneshot_3: self.oneshot_3(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41655,6 +55240,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxAmount {
                 RxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxAmount {
+                    amount: u16,
+                }
+                let proxy = RxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -41680,6 +55285,26 @@ pub mod uarte {
                 RxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41699,6 +55324,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxTerminateonbuserror {
                 RxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for RxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = RxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -41845,6 +55490,83 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("dma_rx_end_dma_rx_start", &self.dma_rx_end_dma_rx_start())
+                    .field("dma_rx_end_dma_rx_stop", &self.dma_rx_end_dma_rx_stop())
+                    .field("dma_tx_end_dma_tx_stop", &self.dma_tx_end_dma_tx_stop())
+                    .field(
+                        "dma_rx_match0_dma_rx_enablematch1",
+                        &self.dma_rx_match0_dma_rx_enablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_enablematch2",
+                        &self.dma_rx_match1_dma_rx_enablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_enablematch3",
+                        &self.dma_rx_match2_dma_rx_enablematch3(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_enablematch0",
+                        &self.dma_rx_match3_dma_rx_enablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match0_dma_rx_disablematch0",
+                        &self.dma_rx_match0_dma_rx_disablematch0(),
+                    )
+                    .field(
+                        "dma_rx_match1_dma_rx_disablematch1",
+                        &self.dma_rx_match1_dma_rx_disablematch1(),
+                    )
+                    .field(
+                        "dma_rx_match2_dma_rx_disablematch2",
+                        &self.dma_rx_match2_dma_rx_disablematch2(),
+                    )
+                    .field(
+                        "dma_rx_match3_dma_rx_disablematch3",
+                        &self.dma_rx_match3_dma_rx_disablematch3(),
+                    )
+                    .field("frametimeout_dma_rx_stop", &self.frametimeout_dma_rx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    dma_rx_end_dma_rx_start: bool,
+                    dma_rx_end_dma_rx_stop: bool,
+                    dma_tx_end_dma_tx_stop: bool,
+                    dma_rx_match0_dma_rx_enablematch1: bool,
+                    dma_rx_match1_dma_rx_enablematch2: bool,
+                    dma_rx_match2_dma_rx_enablematch3: bool,
+                    dma_rx_match3_dma_rx_enablematch0: bool,
+                    dma_rx_match0_dma_rx_disablematch0: bool,
+                    dma_rx_match1_dma_rx_disablematch1: bool,
+                    dma_rx_match2_dma_rx_disablematch2: bool,
+                    dma_rx_match3_dma_rx_disablematch3: bool,
+                    frametimeout_dma_rx_stop: bool,
+                }
+                let proxy = Shorts {
+                    dma_rx_end_dma_rx_start: self.dma_rx_end_dma_rx_start(),
+                    dma_rx_end_dma_rx_stop: self.dma_rx_end_dma_rx_stop(),
+                    dma_tx_end_dma_tx_stop: self.dma_tx_end_dma_tx_stop(),
+                    dma_rx_match0_dma_rx_enablematch1: self.dma_rx_match0_dma_rx_enablematch1(),
+                    dma_rx_match1_dma_rx_enablematch2: self.dma_rx_match1_dma_rx_enablematch2(),
+                    dma_rx_match2_dma_rx_enablematch3: self.dma_rx_match2_dma_rx_enablematch3(),
+                    dma_rx_match3_dma_rx_enablematch0: self.dma_rx_match3_dma_rx_enablematch0(),
+                    dma_rx_match0_dma_rx_disablematch0: self.dma_rx_match0_dma_rx_disablematch0(),
+                    dma_rx_match1_dma_rx_disablematch1: self.dma_rx_match1_dma_rx_disablematch1(),
+                    dma_rx_match2_dma_rx_disablematch2: self.dma_rx_match2_dma_rx_disablematch2(),
+                    dma_rx_match3_dma_rx_disablematch3: self.dma_rx_match3_dma_rx_disablematch3(),
+                    frametimeout_dma_rx_stop: self.frametimeout_dma_rx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction, updated after the END event. Also updated after each MATCH event."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41866,6 +55588,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxAmount {
                 TxAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxAmount {
+                    amount: u16,
+                }
+                let proxy = TxAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in channel buffer"]
@@ -41891,6 +55633,26 @@ pub mod uarte {
                 TxMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Terminate the transaction if a BUSERROR event is detected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -41910,6 +55672,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxTerminateonbuserror {
                 TxTerminateonbuserror(0)
+            }
+        }
+        impl core::fmt::Debug for TxTerminateonbuserror {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxTerminateonbuserror")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxTerminateonbuserror {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxTerminateonbuserror {
+                    enable: bool,
+                }
+                let proxy = TxTerminateonbuserror {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of parity, hardware flow control, framesize, and packet timeout."]
@@ -42002,6 +55784,44 @@ pub mod uarte {
                 UarteConfig(0)
             }
         }
+        impl core::fmt::Debug for UarteConfig {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("UarteConfig")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .field("paritytype", &self.paritytype())
+                    .field("framesize", &self.framesize())
+                    .field("endian", &self.endian())
+                    .field("frametimeout", &self.frametimeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for UarteConfig {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct UarteConfig {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::ConfigStop,
+                    paritytype: super::vals::Paritytype,
+                    framesize: super::vals::Framesize,
+                    endian: super::vals::Endian,
+                    frametimeout: bool,
+                }
+                let proxy = UarteConfig {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                    paritytype: self.paritytype(),
+                    framesize: self.framesize(),
+                    endian: self.endian(),
+                    frametimeout: self.frametimeout(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -42053,6 +55873,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -42066,7 +55937,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -42102,7 +55974,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigStop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -42132,7 +56005,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -42176,7 +56050,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Endian {
             #[doc = "Data is trimmed from MSB end."]
             MSB = 0x0,
@@ -42206,7 +56081,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Framesize {
             _RESERVED_0 = 0x0,
             _RESERVED_1 = 0x01,
@@ -42254,7 +56130,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot0 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -42284,7 +56161,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot1 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -42314,7 +56192,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot2 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -42344,7 +56223,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oneshot3 {
             #[doc = "Match filter stays enabled until disabled by task"]
             CONTINUOUS = 0x0,
@@ -42374,7 +56254,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Paritytype {
             #[doc = "Even parity"]
             EVEN = 0x0,
@@ -42725,6 +56606,24 @@ pub mod uicr {
                 ApprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for ApprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectProtect0 {
+                    pall: super::vals::ApprotectProtect0Pall,
+                }
+                let proxy = ApprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42745,6 +56644,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> ApprotectProtect1 {
                 ApprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for ApprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectProtect1 {
+                    pall: super::vals::ApprotectProtect1Pall,
+                }
+                let proxy = ApprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Revocation status for RoT authenticated operation public key generation \\[n\\]."]
@@ -42771,6 +56688,26 @@ pub mod uicr {
                 AuthopkeyRevoke(0)
             }
         }
+        impl core::fmt::Debug for AuthopkeyRevoke {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuthopkeyRevoke")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuthopkeyRevoke {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuthopkeyRevoke {
+                    status: super::vals::AuthopkeyRevokeStatus,
+                }
+                let proxy = AuthopkeyRevoke {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42793,6 +56730,24 @@ pub mod uicr {
                 AuxapprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for AuxapprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuxapprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuxapprotectProtect0 {
+                    pall: super::vals::AuxapprotectProtect0Pall,
+                }
+                let proxy = AuxapprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42813,6 +56768,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> AuxapprotectProtect1 {
                 AuxapprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for AuxapprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("AuxapprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct AuxapprotectProtect1 {
+                    pall: super::vals::AuxapprotectProtect1Pall,
+                }
+                let proxy = AuxapprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Immutable boot region configuration."]
@@ -42904,6 +56877,44 @@ pub mod uicr {
                 Bootconf(0)
             }
         }
+        impl core::fmt::Debug for Bootconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bootconf")
+                    .field("read", &self.read())
+                    .field("write", &self.write())
+                    .field("execute", &self.execute())
+                    .field("secure", &self.secure())
+                    .field("writeonce", &self.writeonce())
+                    .field("lock", &self.lock())
+                    .field("size", &self.size())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bootconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bootconf {
+                    read: bool,
+                    write: bool,
+                    execute: bool,
+                    secure: bool,
+                    writeonce: bool,
+                    lock: bool,
+                    size: u8,
+                }
+                let proxy = Bootconf {
+                    read: self.read(),
+                    write: self.write(),
+                    execute: self.execute(),
+                    secure: self.secure(),
+                    writeonce: self.writeonce(),
+                    lock: self.lock(),
+                    size: self.size(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42926,6 +56937,24 @@ pub mod uicr {
                 EraseprotectProtect0(0)
             }
         }
+        impl core::fmt::Debug for EraseprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectProtect0 {
+                    pall: super::vals::EraseprotectProtect0Pall,
+                }
+                let proxy = EraseprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Erase protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42946,6 +56975,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> EraseprotectProtect1 {
                 EraseprotectProtect1(0)
+            }
+        }
+        impl core::fmt::Debug for EraseprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("EraseprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct EraseprotectProtect1 {
+                    pall: super::vals::EraseprotectProtect1Pall,
+                }
+                let proxy = EraseprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Revocation status for RoT public key generation \\[n\\]."]
@@ -42972,6 +57019,26 @@ pub mod uicr {
                 PubkeyRevoke(0)
             }
         }
+        impl core::fmt::Debug for PubkeyRevoke {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PubkeyRevoke")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PubkeyRevoke {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PubkeyRevoke {
+                    status: super::vals::PubkeyRevokeStatus,
+                }
+                let proxy = PubkeyRevoke {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -42992,6 +57059,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> SecureapprotectProtect0 {
                 SecureapprotectProtect0(0)
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectProtect0 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectProtect0")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect0 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectProtect0 {
+                    pall: super::vals::SecureapprotectProtect0Pall,
+                }
+                let proxy = SecureapprotectProtect0 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access port protection register"]
@@ -43016,6 +57101,24 @@ pub mod uicr {
                 SecureapprotectProtect1(0)
             }
         }
+        impl core::fmt::Debug for SecureapprotectProtect1 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectProtect1")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect1 {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectProtect1 {
+                    pall: super::vals::SecureapprotectProtect1Pall,
+                }
+                let proxy = SecureapprotectProtect1 { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -43031,6 +57134,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectProtect0Pall {
@@ -43060,6 +57180,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for ApprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for ApprotectProtect1Pall {
             #[inline(always)]
             fn from(val: u32) -> ApprotectProtect1Pall {
@@ -43085,6 +57222,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for AuthopkeyRevokeStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("NOT_REVOKED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuthopkeyRevokeStatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "NOT_REVOKED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for AuthopkeyRevokeStatus {
@@ -43114,6 +57268,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for AuxapprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for AuxapprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> AuxapprotectProtect0Pall {
@@ -43139,6 +57310,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for AuxapprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for AuxapprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for AuxapprotectProtect1Pall {
@@ -43168,6 +57356,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for EraseprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> EraseprotectProtect0Pall {
@@ -43193,6 +57398,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for EraseprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for EraseprotectProtect1Pall {
@@ -43222,6 +57444,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for PubkeyRevokeStatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("NOT_REVOKED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PubkeyRevokeStatus {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "NOT_REVOKED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for PubkeyRevokeStatus {
             #[inline(always)]
             fn from(val: u32) -> PubkeyRevokeStatus {
@@ -43249,6 +57488,23 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for SecureapprotectProtect0Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect0Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for SecureapprotectProtect0Pall {
             #[inline(always)]
             fn from(val: u32) -> SecureapprotectProtect0Pall {
@@ -43274,6 +57530,23 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectProtect1Pall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectProtect1Pall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for SecureapprotectProtect1Pall {
@@ -43567,6 +57840,29 @@ pub mod vpr {
                 Abstractauto(0)
             }
         }
+        impl core::fmt::Debug for Abstractauto {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractauto")
+                    .field("autoexecdata", &self.autoexecdata())
+                    .field("autoexecprogbuf", &self.autoexecprogbuf())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractauto {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractauto {
+                    autoexecdata: u16,
+                    autoexecprogbuf: u16,
+                }
+                let proxy = Abstractauto {
+                    autoexecdata: self.autoexecdata(),
+                    autoexecprogbuf: self.autoexecprogbuf(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Abstract command"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43601,6 +57897,29 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Abstractcmd {
                 Abstractcmd(0)
+            }
+        }
+        impl core::fmt::Debug for Abstractcmd {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractcmd")
+                    .field("control", &self.control())
+                    .field("cmdtype", &self.cmdtype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractcmd {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractcmd {
+                    control: u32,
+                    cmdtype: super::vals::Cmdtype,
+                }
+                let proxy = Abstractcmd {
+                    control: self.control(),
+                    cmdtype: self.cmdtype(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Abstract Control and Status"]
@@ -43659,6 +57978,35 @@ pub mod vpr {
                 Abstractcs(0)
             }
         }
+        impl core::fmt::Debug for Abstractcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Abstractcs")
+                    .field("datacount", &self.datacount())
+                    .field("cmderr", &self.cmderr())
+                    .field("busy", &self.busy())
+                    .field("progbufsize", &self.progbufsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Abstractcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Abstractcs {
+                    datacount: u8,
+                    cmderr: super::vals::Cmderr,
+                    busy: bool,
+                    progbufsize: u8,
+                }
+                let proxy = Abstractcs {
+                    datacount: self.datacount(),
+                    cmderr: self.cmderr(),
+                    busy: self.busy(),
+                    progbufsize: self.progbufsize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "State of the CPU after a core reset"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -43680,6 +58028,22 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Cpurun {
                 Cpurun(0)
+            }
+        }
+        impl core::fmt::Debug for Cpurun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cpurun").field("en", &self.en()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cpurun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cpurun {
+                    en: super::vals::CpurunEn,
+                }
+                let proxy = Cpurun { en: self.en() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Debug Module Control"]
@@ -43817,6 +58181,56 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Dmcontrol {
                 Dmcontrol(0)
+            }
+        }
+        impl core::fmt::Debug for Dmcontrol {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dmcontrol")
+                    .field("dmactive", &self.dmactive())
+                    .field("ndmreset", &self.ndmreset())
+                    .field("clrresethaltreq", &self.clrresethaltreq())
+                    .field("setresethaltreq", &self.setresethaltreq())
+                    .field("hartselhi", &self.hartselhi())
+                    .field("hartsello", &self.hartsello())
+                    .field("hasel", &self.hasel())
+                    .field("ackhavereset", &self.ackhavereset())
+                    .field("hartreset", &self.hartreset())
+                    .field("resumereq", &self.resumereq())
+                    .field("haltreq", &self.haltreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dmcontrol {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dmcontrol {
+                    dmactive: bool,
+                    ndmreset: bool,
+                    clrresethaltreq: super::vals::Clrresethaltreq,
+                    setresethaltreq: super::vals::Setresethaltreq,
+                    hartselhi: u16,
+                    hartsello: u16,
+                    hasel: super::vals::Hasel,
+                    ackhavereset: super::vals::Ackhavereset,
+                    hartreset: bool,
+                    resumereq: super::vals::Resumereq,
+                    haltreq: super::vals::Haltreq,
+                }
+                let proxy = Dmcontrol {
+                    dmactive: self.dmactive(),
+                    ndmreset: self.ndmreset(),
+                    clrresethaltreq: self.clrresethaltreq(),
+                    setresethaltreq: self.setresethaltreq(),
+                    hartselhi: self.hartselhi(),
+                    hartsello: self.hartsello(),
+                    hasel: self.hasel(),
+                    ackhavereset: self.ackhavereset(),
+                    hartreset: self.hartreset(),
+                    resumereq: self.resumereq(),
+                    haltreq: self.haltreq(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Debug Module Status"]
@@ -44029,6 +58443,77 @@ pub mod vpr {
                 Dmstatus(0)
             }
         }
+        impl core::fmt::Debug for Dmstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dmstatus")
+                    .field("version", &self.version())
+                    .field("confstrptrvalid", &self.confstrptrvalid())
+                    .field("hasresethaltreq", &self.hasresethaltreq())
+                    .field("authbusy", &self.authbusy())
+                    .field("authenticated", &self.authenticated())
+                    .field("anyhalted", &self.anyhalted())
+                    .field("allhalted", &self.allhalted())
+                    .field("anyrunning", &self.anyrunning())
+                    .field("allrunning", &self.allrunning())
+                    .field("anyunavail", &self.anyunavail())
+                    .field("allunavail", &self.allunavail())
+                    .field("anynonexistent", &self.anynonexistent())
+                    .field("allnonexistent", &self.allnonexistent())
+                    .field("anyresumeack", &self.anyresumeack())
+                    .field("allresumeack", &self.allresumeack())
+                    .field("anyhavereset", &self.anyhavereset())
+                    .field("allhavereset", &self.allhavereset())
+                    .field("impebreak", &self.impebreak())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dmstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dmstatus {
+                    version: super::vals::Version,
+                    confstrptrvalid: super::vals::Confstrptrvalid,
+                    hasresethaltreq: bool,
+                    authbusy: bool,
+                    authenticated: bool,
+                    anyhalted: bool,
+                    allhalted: bool,
+                    anyrunning: bool,
+                    allrunning: bool,
+                    anyunavail: bool,
+                    allunavail: bool,
+                    anynonexistent: bool,
+                    allnonexistent: bool,
+                    anyresumeack: bool,
+                    allresumeack: bool,
+                    anyhavereset: bool,
+                    allhavereset: bool,
+                    impebreak: bool,
+                }
+                let proxy = Dmstatus {
+                    version: self.version(),
+                    confstrptrvalid: self.confstrptrvalid(),
+                    hasresethaltreq: self.hasresethaltreq(),
+                    authbusy: self.authbusy(),
+                    authenticated: self.authenticated(),
+                    anyhalted: self.anyhalted(),
+                    allhalted: self.allhalted(),
+                    anyrunning: self.anyrunning(),
+                    allrunning: self.allrunning(),
+                    anyunavail: self.anyunavail(),
+                    allunavail: self.allunavail(),
+                    anynonexistent: self.anynonexistent(),
+                    allnonexistent: self.allnonexistent(),
+                    anyresumeack: self.anyresumeack(),
+                    allresumeack: self.allresumeack(),
+                    anyhavereset: self.anyhavereset(),
+                    allhavereset: self.allhavereset(),
+                    impebreak: self.impebreak(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hart Information"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44085,6 +58570,35 @@ pub mod vpr {
                 Hartinfo(0)
             }
         }
+        impl core::fmt::Debug for Hartinfo {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hartinfo")
+                    .field("dataaddr", &self.dataaddr())
+                    .field("datasize", &self.datasize())
+                    .field("dataaccess", &self.dataaccess())
+                    .field("nscratch", &self.nscratch())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hartinfo {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hartinfo {
+                    dataaddr: u16,
+                    datasize: u8,
+                    dataaccess: bool,
+                    nscratch: u8,
+                }
+                let proxy = Hartinfo {
+                    dataaddr: self.dataaddr(),
+                    datasize: self.datasize(),
+                    dataaccess: self.dataaccess(),
+                    nscratch: self.nscratch(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Hart Array Window Select"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -44106,6 +58620,26 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Hawindowsel {
                 Hawindowsel(0)
+            }
+        }
+        impl core::fmt::Debug for Hawindowsel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hawindowsel")
+                    .field("hawindowsel", &self.hawindowsel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hawindowsel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hawindowsel {
+                    hawindowsel: u16,
+                }
+                let proxy = Hawindowsel {
+                    hawindowsel: self.hawindowsel(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -44195,6 +58729,44 @@ pub mod vpr {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("triggered16", &self.triggered16())
+                    .field("triggered17", &self.triggered17())
+                    .field("triggered18", &self.triggered18())
+                    .field("triggered19", &self.triggered19())
+                    .field("triggered20", &self.triggered20())
+                    .field("triggered21", &self.triggered21())
+                    .field("triggered22", &self.triggered22())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered16: bool,
+                    triggered17: bool,
+                    triggered18: bool,
+                    triggered19: bool,
+                    triggered20: bool,
+                    triggered21: bool,
+                    triggered22: bool,
+                }
+                let proxy = Int {
+                    triggered16: self.triggered16(),
+                    triggered17: self.triggered17(),
+                    triggered18: self.triggered18(),
+                    triggered19: self.triggered19(),
+                    triggered20: self.triggered20(),
+                    triggered21: self.triggered21(),
+                    triggered22: self.triggered22(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "System Bus Access Control and Status"]
@@ -44340,10 +58912,70 @@ pub mod vpr {
                 Sbcs(0)
             }
         }
+        impl core::fmt::Debug for Sbcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Sbcs")
+                    .field("sbaccess8", &self.sbaccess8())
+                    .field("sbaccess16", &self.sbaccess16())
+                    .field("sbaccess32", &self.sbaccess32())
+                    .field("sbaccess64", &self.sbaccess64())
+                    .field("sbaccess128", &self.sbaccess128())
+                    .field("sbasize", &self.sbasize())
+                    .field("sberror", &self.sberror())
+                    .field("sbreadondata", &self.sbreadondata())
+                    .field("sbautoincrement", &self.sbautoincrement())
+                    .field("sbaccess", &self.sbaccess())
+                    .field("sbreadonaddr", &self.sbreadonaddr())
+                    .field("sbbusy", &self.sbbusy())
+                    .field("sbbusyerror", &self.sbbusyerror())
+                    .field("sbversion", &self.sbversion())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Sbcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Sbcs {
+                    sbaccess8: bool,
+                    sbaccess16: bool,
+                    sbaccess32: bool,
+                    sbaccess64: bool,
+                    sbaccess128: bool,
+                    sbasize: u8,
+                    sberror: super::vals::Sberror,
+                    sbreadondata: bool,
+                    sbautoincrement: bool,
+                    sbaccess: super::vals::Sbaccess,
+                    sbreadonaddr: bool,
+                    sbbusy: bool,
+                    sbbusyerror: bool,
+                    sbversion: super::vals::Sbversion,
+                }
+                let proxy = Sbcs {
+                    sbaccess8: self.sbaccess8(),
+                    sbaccess16: self.sbaccess16(),
+                    sbaccess32: self.sbaccess32(),
+                    sbaccess64: self.sbaccess64(),
+                    sbaccess128: self.sbaccess128(),
+                    sbasize: self.sbasize(),
+                    sberror: self.sberror(),
+                    sbreadondata: self.sbreadondata(),
+                    sbautoincrement: self.sbautoincrement(),
+                    sbaccess: self.sbaccess(),
+                    sbreadonaddr: self.sbreadonaddr(),
+                    sbbusy: self.sbbusy(),
+                    sbbusyerror: self.sbbusyerror(),
+                    sbversion: self.sbversion(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ackhavereset {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -44373,7 +59005,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Clrresethaltreq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -44403,7 +59036,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cmderr {
             #[doc = "No error."]
             NO_ERROR = 0x0,
@@ -44462,6 +59096,27 @@ pub mod vpr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Cmdtype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("REGACCESS"),
+                    0x01 => f.write_str("QUICKACCESS"),
+                    0x02 => f.write_str("MEMACCESS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cmdtype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "REGACCESS"),
+                    0x01 => defmt::write!(f, "QUICKACCESS"),
+                    0x02 => defmt::write!(f, "MEMACCESS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Cmdtype {
             #[inline(always)]
             fn from(val: u8) -> Cmdtype {
@@ -44475,7 +59130,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Confstrptrvalid {
             #[doc = "The confstrptr0..confstrptr3 holds information which is not relevant to the configuration string."]
             NOT_RELEVANT = 0x0,
@@ -44505,7 +59161,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum CpurunEn {
             #[doc = "CPU stopped. If this is the CPU state after a core reset, setting this bit will change the CPU state to CPU running."]
             STOPPED = 0x0,
@@ -44535,7 +59192,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Haltreq {
             #[doc = "Clears halt request bit for all currently selected harts."]
             CLEAR = 0x0,
@@ -44565,7 +59223,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hasel {
             #[doc = "Single hart selected."]
             SINGLE = 0x0,
@@ -44595,7 +59254,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resumereq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -44625,7 +59285,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sbaccess {
             #[doc = "8-bit."]
             SIZE8 = 0x0,
@@ -44664,7 +59325,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sberror {
             #[doc = "There was no bus error."]
             NORMAL = 0x0,
@@ -44704,7 +59366,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sbversion {
             #[doc = "The System Bus interface conforms to mainline drafts of thia RISC-V External Debug Support spec older than 1 January, 2018."]
             VERSION0 = 0x0,
@@ -44740,7 +59403,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Setresethaltreq {
             #[doc = "No operation when written 0."]
             NO_OPERATION = 0x0,
@@ -44770,7 +59434,8 @@ pub mod vpr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Version {
             #[doc = "Debug module not present."]
             NOT_PRESENT = 0x0,
@@ -44985,6 +59650,32 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .field("stopen", &self.stopen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                    stopen: bool,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                    stopen: self.stopen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -45017,6 +59708,29 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -45053,6 +59767,29 @@ pub mod wdt {
                 Nmi(0)
             }
         }
+        impl core::fmt::Debug for Nmi {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Nmi")
+                    .field("timeout", &self.timeout())
+                    .field("stopped", &self.stopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Nmi {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Nmi {
+                    timeout: bool,
+                    stopped: bool,
+                }
+                let proxy = Nmi {
+                    timeout: self.timeout(),
+                    stopped: self.stopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Request status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -45080,6 +59817,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -45102,6 +59880,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -45131,6 +59925,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -45152,6 +59987,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Runstatus {
                 Runstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Task stop enable"]
@@ -45178,10 +60033,27 @@ pub mod wdt {
                 Tsen(0)
             }
         }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Tsen").field("tsen", &self.tsen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Tsen {
+                    tsen: super::vals::Tsen,
+                }
+                let proxy = Tsen { tsen: self.tsen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause WDT while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -45225,6 +60097,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -45238,7 +60127,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause WDT while the CPU is sleeping"]
             PAUSE = 0x0,
@@ -45280,6 +60170,23 @@ pub mod wdt {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Tsen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("ENABLE"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Tsen {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "ENABLE"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Tsen {

--- a/src/chips/nrf9120/pac.rs
+++ b/src/chips/nrf9120/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "3 - SPU"]
     SPU = 3,
@@ -527,6 +528,26 @@ pub mod approtect {
                 ApprotectDisable(0)
             }
         }
+        impl core::fmt::Debug for ApprotectDisable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectDisable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectDisable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectDisable {
+                    disable: super::vals::ApprotectDisableDisable,
+                }
+                let proxy = ApprotectDisable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force APPROTECT mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -548,6 +569,26 @@ pub mod approtect {
             #[inline(always)]
             fn default() -> ApprotectForceprotect {
                 ApprotectForceprotect(0)
+            }
+        }
+        impl core::fmt::Debug for ApprotectForceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ApprotectForceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectForceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ApprotectForceprotect {
+                    forceprotect: bool,
+                }
+                let proxy = ApprotectForceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Software disable SECUREAPPROTECT mechanism"]
@@ -573,6 +614,26 @@ pub mod approtect {
                 SecureapprotectDisable(0)
             }
         }
+        impl core::fmt::Debug for SecureapprotectDisable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectDisable")
+                    .field("disable", &self.disable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectDisable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectDisable {
+                    disable: super::vals::SecureapprotectDisableDisable,
+                }
+                let proxy = SecureapprotectDisable {
+                    disable: self.disable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Software force SECUREAPPROTECT mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -596,6 +657,26 @@ pub mod approtect {
                 SecureapprotectForceprotect(0)
             }
         }
+        impl core::fmt::Debug for SecureapprotectForceprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SecureapprotectForceprotect")
+                    .field("forceprotect", &self.forceprotect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectForceprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SecureapprotectForceprotect {
+                    forceprotect: bool,
+                }
+                let proxy = SecureapprotectForceprotect {
+                    forceprotect: self.forceprotect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -611,6 +692,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectDisableDisable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectDisableDisable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for ApprotectDisableDisable {
@@ -638,6 +736,23 @@ pub mod approtect {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for SecureapprotectDisableDisable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x5a => f.write_str("SW_UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectDisableDisable {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x5a => defmt::write!(f, "SW_UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for SecureapprotectDisableDisable {
@@ -735,6 +850,26 @@ pub mod cc_host_rgf {
                 HostCryptokeySel(0)
             }
         }
+        impl core::fmt::Debug for HostCryptokeySel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostCryptokeySel")
+                    .field("host_cryptokey_sel", &self.host_cryptokey_sel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostCryptokeySel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostCryptokeySel {
+                    host_cryptokey_sel: super::vals::HostCryptokeySel,
+                }
+                let proxy = HostCryptokeySel {
+                    host_cryptokey_sel: self.host_cryptokey_sel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This write-once register is the K_PRTL lock register. When this register is set, K_PRTL cannot be used and a zeroed key will be used instead. The value of this register is saved in the CRYPTOCELL AO power domain."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -756,6 +891,26 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> HostIotKprtlLock {
                 HostIotKprtlLock(0)
+            }
+        }
+        impl core::fmt::Debug for HostIotKprtlLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotKprtlLock")
+                    .field("host_iot_kprtl_lock", &self.host_iot_kprtl_lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotKprtlLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotKprtlLock {
+                    host_iot_kprtl_lock: bool,
+                }
+                let proxy = HostIotKprtlLock {
+                    host_iot_kprtl_lock: self.host_iot_kprtl_lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls lifecycle state (LCS) for CRYPTOCELL subsystem"]
@@ -792,10 +947,34 @@ pub mod cc_host_rgf {
                 HostIotLcs(0)
             }
         }
+        impl core::fmt::Debug for HostIotLcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotLcs")
+                    .field("lcs", &self.lcs())
+                    .field("lcs_is_valid", &self.lcs_is_valid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotLcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotLcs {
+                    lcs: super::vals::Lcs,
+                    lcs_is_valid: bool,
+                }
+                let proxy = HostIotLcs {
+                    lcs: self.lcs(),
+                    lcs_is_valid: self.lcs_is_valid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HostCryptokeySel {
             #[doc = "Use device root key K_DR from CRYPTOCELL AO power domain"]
             K_DR = 0x0,
@@ -828,7 +1007,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lcs {
             #[doc = "CC310 operates in debug mode"]
             DEBUG = 0x0,
@@ -1031,6 +1211,26 @@ pub mod clock {
                 Hfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The register shows if HFXO has been requested by triggering HFCLKSTART task and if it has been started (STATE)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1063,6 +1263,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -1099,6 +1322,29 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1120,6 +1366,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK. LFCLKSTART task starts starts a clock source selected with this register."]
@@ -1145,6 +1411,24 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set after LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1166,6 +1450,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The register shows which LFCLK source has been requested (SRC) when triggering LFCLKSTART task and if the source has been started (STATE)"]
@@ -1202,10 +1504,34 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "HFINT - 64 MHz on-chip oscillator"]
             HFINT = 0x0,
@@ -1235,7 +1561,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "Reserved for future use (equals selecting LFRC)"]
             RFU = 0x0,
@@ -1393,6 +1720,26 @@ pub mod cryptocell {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod ctrlapperi {
@@ -1511,6 +1858,22 @@ pub mod ctrlapperi {
                 Lock(0)
             }
         }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if data sent from the debugger to the CPU has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1534,6 +1897,26 @@ pub mod ctrlapperi {
                 Rxstatus(0)
             }
         }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if the data sent from the CPU to the debugger has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1555,6 +1938,26 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Txstatus {
                 Txstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -1696,6 +2099,63 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 16usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1721,6 +2181,63 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 16usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -1817,6 +2334,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -2068,6 +2642,26 @@ pub mod ficr {
                 Codepagesize(0)
             }
         }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codepagesize")
+                    .field("codepagesize", &self.codepagesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codepagesize {
+                    codepagesize: super::vals::Codepagesize,
+                }
+                let proxy = Codepagesize {
+                    codepagesize: self.codepagesize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Code memory size"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2090,6 +2684,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Codesize {
                 Codesize(0)
+            }
+        }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codesize")
+                    .field("codesize", &self.codesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codesize {
+                    codesize: super::vals::Codesize,
+                }
+                let proxy = Codesize {
+                    codesize: self.codesize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device type"]
@@ -2116,6 +2730,26 @@ pub mod ficr {
                 Devicetype(0)
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devicetype")
+                    .field("devicetype", &self.devicetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devicetype {
+                    devicetype: super::vals::Devicetype,
+                }
+                let proxy = Devicetype {
+                    devicetype: self.devicetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Flash variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2138,6 +2772,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Flash {
                 Flash(0)
+            }
+        }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part Variant, Hardware version and Production configuration"]
@@ -2164,6 +2818,26 @@ pub mod ficr {
                 InfoVariant(0)
             }
         }
+        impl core::fmt::Debug for InfoVariant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("InfoVariant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for InfoVariant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct InfoVariant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = InfoVariant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2186,6 +2860,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -2212,6 +2906,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SIP part number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2232,6 +2942,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Partno {
                 Partno(0)
+            }
+        }
+        impl core::fmt::Debug for Partno {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Partno")
+                    .field("partno", &self.partno())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Partno {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Partno {
+                    partno: super::vals::Partno,
+                }
+                let proxy = Partno {
+                    partno: self.partno(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -2258,6 +2988,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -2273,6 +3019,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x1000 => f.write_str("K4096"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x1000 => defmt::write!(f, "K4096"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codepagesize {
@@ -2300,6 +3063,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("P256"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "P256"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codesize {
@@ -2331,6 +3111,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DIE"),
+                    0xffff_ffff => f.write_str("FPGA"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DIE"),
+                    0xffff_ffff => defmt::write!(f, "FPGA"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Devicetype {
             #[inline(always)]
             fn from(val: u32) -> Devicetype {
@@ -2358,6 +3157,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0400 => f.write_str("K1024"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0400 => defmt::write!(f, "K1024"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -2383,6 +3199,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2002 => f.write_str("CF"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2002 => defmt::write!(f, "CF"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -2414,6 +3247,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x9120 => f.write_str("N9120"),
+                    0x9160 => f.write_str("N9160"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x9120 => defmt::write!(f, "N9120"),
+                    0x9160 => defmt::write!(f, "N9160"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -2439,6 +3291,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Partno {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x9160 => f.write_str("_9160"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Partno {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x9160 => defmt::write!(f, "_9160"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Partno {
@@ -2468,6 +3337,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -2501,6 +3389,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -2644,6 +3555,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select between default DETECT signal behavior and LDETECT mode (For secure pin only)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2665,6 +3596,26 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> DetectmodeSec {
                 DetectmodeSec(0)
+            }
+        }
+        impl core::fmt::Debug for DetectmodeSec {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DetectmodeSec")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DetectmodeSec {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DetectmodeSec {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = DetectmodeSec {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Direction of GPIO pins"]
@@ -2694,6 +3645,95 @@ pub mod gpio {
                 Dir(0)
             }
         }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR clear register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2719,6 +3759,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirclr {
                 Dirclr(0)
+            }
+        }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR set register"]
@@ -2748,6 +3877,95 @@ pub mod gpio {
                 Dirset(0)
             }
         }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2773,6 +3991,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> In {
                 In(0)
+            }
+        }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
@@ -2802,6 +4109,95 @@ pub mod gpio {
                 Latch(0)
             }
         }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2827,6 +4223,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Out {
                 Out(0)
+            }
+        }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear individual bits in GPIO port"]
@@ -2856,6 +4341,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2881,6 +4455,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -2951,10 +4614,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -2984,7 +4680,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -3014,7 +4711,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -3056,7 +4754,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -3086,7 +4785,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -3119,7 +4819,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -3318,6 +5019,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3356,10 +5086,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -3392,7 +5167,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -3422,7 +5198,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -3785,6 +5562,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3806,6 +5603,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module."]
@@ -3831,6 +5648,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3852,6 +5689,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -3899,6 +5756,32 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3922,6 +5805,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3943,6 +5846,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Master clock generator frequency."]
@@ -3969,6 +5892,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3990,6 +5933,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio."]
@@ -4015,6 +5974,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4036,6 +6015,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width."]
@@ -4061,6 +6056,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4084,10 +6099,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -4117,7 +6149,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -4150,7 +6183,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -4218,6 +6252,47 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -4231,7 +6306,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -4261,7 +6337,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -4312,7 +6389,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit."]
             _8BIT = 0x0,
@@ -4539,6 +6617,47 @@ pub mod ipc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("receive0", &self.receive0())
+                    .field("receive1", &self.receive1())
+                    .field("receive2", &self.receive2())
+                    .field("receive3", &self.receive3())
+                    .field("receive4", &self.receive4())
+                    .field("receive5", &self.receive5())
+                    .field("receive6", &self.receive6())
+                    .field("receive7", &self.receive7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    receive0: bool,
+                    receive1: bool,
+                    receive2: bool,
+                    receive3: bool,
+                    receive4: bool,
+                    receive5: bool,
+                    receive6: bool,
+                    receive7: bool,
+                }
+                let proxy = Int {
+                    receive0: self.receive0(),
+                    receive1: self.receive1(),
+                    receive2: self.receive2(),
+                    receive3: self.receive3(),
+                    receive4: self.receive4(),
+                    receive5: self.receive5(),
+                    receive6: self.receive6(),
+                    receive7: self.receive7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Receive event configuration for EVENTS_RECEIVE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4639,6 +6758,47 @@ pub mod ipc {
                 ReceiveCnf(0)
             }
         }
+        impl core::fmt::Debug for ReceiveCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReceiveCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReceiveCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReceiveCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                }
+                let proxy = ReceiveCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Send event configuration for TASKS_SEND\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4737,6 +6897,47 @@ pub mod ipc {
             #[inline(always)]
             fn default() -> SendCnf {
                 SendCnf(0)
+            }
+        }
+        impl core::fmt::Debug for SendCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SendCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SendCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SendCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                }
+                let proxy = SendCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4857,6 +7058,32 @@ pub mod kmu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("keyslot_pushed", &self.keyslot_pushed())
+                    .field("keyslot_revoked", &self.keyslot_revoked())
+                    .field("keyslot_error", &self.keyslot_error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    keyslot_pushed: bool,
+                    keyslot_revoked: bool,
+                    keyslot_error: bool,
+                }
+                let proxy = Int {
+                    keyslot_pushed: self.keyslot_pushed(),
+                    keyslot_revoked: self.keyslot_revoked(),
+                    keyslot_error: self.keyslot_error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select key slot to be read over AHB or pushed over secure APB when TASKS_PUSH_KEYSLOT is started"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4878,6 +7105,24 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Selectkeyslot {
                 Selectkeyslot(0)
+            }
+        }
+        impl core::fmt::Debug for Selectkeyslot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selectkeyslot")
+                    .field("id", &self.id())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selectkeyslot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selectkeyslot {
+                    id: u8,
+                }
+                let proxy = Selectkeyslot { id: self.id() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status bits for KMU operation"]
@@ -4912,6 +7157,29 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Status {
                 Status(0)
+            }
+        }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("selected", &self.selected())
+                    .field("blocked", &self.blocked())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    selected: bool,
+                    blocked: bool,
+                }
+                let proxy = Status {
+                    selected: self.selected(),
+                    blocked: self.blocked(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -5010,6 +7278,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Unspecified"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5031,6 +7315,24 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Configns {
                 Configns(0)
+            }
+        }
+        impl core::fmt::Debug for Configns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configns")
+                    .field("wen", &self.wen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configns {
+                    wen: super::vals::ConfignsWen,
+                }
+                let proxy = Configns { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for erasing all non-volatile user memory"]
@@ -5056,6 +7358,26 @@ pub mod nvmc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for partial erase configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5077,6 +7399,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Erasepagepartialcfg {
                 Erasepagepartialcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-code cache configuration register"]
@@ -5113,6 +7455,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5136,6 +7501,26 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5157,6 +7542,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Readynext {
                 Readynext(0)
+            }
+        }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Non-secure APPROTECT enable register"]
@@ -5194,10 +7599,34 @@ pub mod nvmc {
                 Writeuicrns(0)
             }
         }
+        impl core::fmt::Debug for Writeuicrns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writeuicrns")
+                    .field("set", &self.set())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writeuicrns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writeuicrns {
+                    set: bool,
+                    key: super::vals::Key,
+                }
+                let proxy = Writeuicrns {
+                    set: self.set(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfignsWen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5244,6 +7673,23 @@ pub mod nvmc {
                 self.0
             }
         }
+        impl core::fmt::Debug for Key {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0afb_e5a7 => f.write_str("KEYVALID"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Key {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0afb_e5a7 => defmt::write!(f, "KEYVALID"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Key {
             #[inline(always)]
             fn from(val: u32) -> Key {
@@ -5257,7 +7703,8 @@ pub mod nvmc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5507,6 +7954,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5530,6 +7997,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5551,6 +8038,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5598,6 +8105,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5619,6 +8152,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -5655,6 +8208,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5677,6 +8253,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Pdmclkctrl {
                 Pdmclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the ratio between PDM_CLK and output sample rate. Change PDMCLKCTRL accordingly."]
@@ -5702,10 +8296,31 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -5759,6 +8374,33 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    0x0980_0000 => f.write_str("_1231K"),
+                    0x0a00_0000 => f.write_str("_1280K"),
+                    0x0a80_0000 => f.write_str("_1333K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    0x0980_0000 => defmt::write!(f, "_1231K"),
+                    0x0a00_0000 => defmt::write!(f, "_1280K"),
+                    0x0a80_0000 => defmt::write!(f, "_1333K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -5790,6 +8432,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -5803,7 +8466,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -5833,7 +8497,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 64"]
             RATIO64 = 0x0,
@@ -6056,6 +8721,26 @@ pub mod power {
                 Forceoff(0)
             }
         }
+        impl core::fmt::Debug for Forceoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceoff")
+                    .field("forceoff", &self.forceoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceoff {
+                    forceoff: super::vals::Forceoff,
+                }
+                let proxy = Forceoff {
+                    forceoff: self.forceoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6077,6 +8762,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret {
                 Gpregret(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6124,6 +8829,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Modem domain power status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6145,6 +8876,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("ltemodem", &self.ltemodem())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    ltemodem: bool,
+                }
+                let proxy = Power {
+                    ltemodem: self.ltemodem(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -6236,6 +8987,44 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("ctrlap", &self.ctrlap())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    off: bool,
+                    dif: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    ctrlap: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    off: self.off(),
+                    dif: self.dif(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    ctrlap: self.ctrlap(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start LTE modem"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6259,10 +9048,31 @@ pub mod power {
                 Startn(0)
             }
         }
+        impl core::fmt::Debug for Startn {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Startn")
+                    .field("startn", &self.startn())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Startn {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Startn {
+                    startn: super::vals::Startn,
+                }
+                let proxy = Startn {
+                    startn: self.startn(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Forceoff {
             #[doc = "Release force off"]
             RELEASE = 0x0,
@@ -6292,7 +9102,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Startn {
             #[doc = "Start LTE modem"]
             START = 0x0,
@@ -6598,6 +9409,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6619,6 +9446,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -6655,6 +9502,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6676,6 +9546,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -6700,6 +9590,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6791,6 +9699,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6813,6 +9759,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -6838,6 +9800,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6859,6 +9841,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -6883,6 +9885,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6952,6 +9970,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -6969,6 +10019,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -6982,7 +10049,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -7030,6 +10098,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -7043,7 +10128,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -7073,7 +10159,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -7129,6 +10216,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -7142,7 +10246,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -7230,6 +10335,26 @@ pub mod regulators {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External power failure warning configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7253,6 +10378,24 @@ pub mod regulators {
                 Extpofcon(0)
             }
         }
+        impl core::fmt::Debug for Extpofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extpofcon")
+                    .field("pof", &self.pof())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extpofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extpofcon {
+                    pof: bool,
+                }
+                let proxy = Extpofcon { pof: self.pof() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7274,6 +10417,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7449,6 +10612,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7471,6 +10654,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -7522,6 +10725,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7571,6 +10813,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768/(PRESCALER+1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7592,6 +10873,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7948,6 +11249,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8040,6 +11361,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8061,6 +11420,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -8171,6 +11550,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8205,6 +11667,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8226,6 +11711,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -8251,6 +11756,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8272,6 +11797,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -8297,6 +11842,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8318,6 +11883,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -8355,6 +11938,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8378,10 +11984,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -8411,7 +12038,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -8453,7 +12081,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -8504,7 +12133,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -8572,7 +12202,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -8602,7 +12233,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -8636,7 +12268,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -8670,7 +12303,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -8700,7 +12334,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -8730,7 +12365,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -8770,7 +12406,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -8846,6 +12483,29 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event HFCLKSTARTED"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8876,6 +12536,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task HFCLKSTART"]
@@ -8910,10 +12593,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -9276,6 +12983,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9297,6 +13030,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -9321,6 +13074,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -9390,6 +13163,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case an over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9411,6 +13216,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -9436,6 +13257,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9457,6 +13298,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -9482,6 +13341,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9503,6 +13382,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -9528,6 +13427,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9549,6 +13468,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -9574,10 +13511,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -9607,7 +13565,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -9637,7 +13596,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -9707,6 +13667,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -9720,7 +13709,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -9750,7 +13740,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -9782,7 +13773,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -10114,6 +14106,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10137,6 +14155,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10158,6 +14192,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -10205,6 +14259,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10226,6 +14306,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -10251,6 +14347,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10272,6 +14388,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -10297,6 +14431,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10320,6 +14474,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10341,6 +14515,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -10377,6 +14571,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10398,6 +14615,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -10423,6 +14660,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10446,10 +14701,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -10479,7 +14755,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -10509,7 +14786,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -10553,7 +14831,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -10583,7 +14862,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -10615,7 +14895,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -10649,7 +14930,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -11024,6 +15306,22 @@ pub mod spu {
                 Cap(0)
             }
         }
+        impl core::fmt::Debug for Cap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cap").field("tzm", &self.tzm()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cap {
+                    tzm: super::vals::Tzm,
+                }
+                let proxy = Cap { tzm: self.tzm() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11043,6 +15341,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> DppiLock {
                 DppiLock(0)
+            }
+        }
+        impl core::fmt::Debug for DppiLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiLock {
+                    lock: bool,
+                }
+                let proxy = DppiLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for the DPPI channels."]
@@ -11233,6 +15549,71 @@ pub mod spu {
                 DppiPerm(0)
             }
         }
+        impl core::fmt::Debug for DppiPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiPerm")
+                    .field("channel0", &self.channel0())
+                    .field("channel1", &self.channel1())
+                    .field("channel2", &self.channel2())
+                    .field("channel3", &self.channel3())
+                    .field("channel4", &self.channel4())
+                    .field("channel5", &self.channel5())
+                    .field("channel6", &self.channel6())
+                    .field("channel7", &self.channel7())
+                    .field("channel8", &self.channel8())
+                    .field("channel9", &self.channel9())
+                    .field("channel10", &self.channel10())
+                    .field("channel11", &self.channel11())
+                    .field("channel12", &self.channel12())
+                    .field("channel13", &self.channel13())
+                    .field("channel14", &self.channel14())
+                    .field("channel15", &self.channel15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiPerm {
+                    channel0: bool,
+                    channel1: bool,
+                    channel2: bool,
+                    channel3: bool,
+                    channel4: bool,
+                    channel5: bool,
+                    channel6: bool,
+                    channel7: bool,
+                    channel8: bool,
+                    channel9: bool,
+                    channel10: bool,
+                    channel11: bool,
+                    channel12: bool,
+                    channel13: bool,
+                    channel14: bool,
+                    channel15: bool,
+                }
+                let proxy = DppiPerm {
+                    channel0: self.channel0(),
+                    channel1: self.channel1(),
+                    channel2: self.channel2(),
+                    channel3: self.channel3(),
+                    channel4: self.channel4(),
+                    channel5: self.channel5(),
+                    channel6: self.channel6(),
+                    channel7: self.channel7(),
+                    channel8: self.channel8(),
+                    channel9: self.channel9(),
+                    channel10: self.channel10(),
+                    channel11: self.channel11(),
+                    channel12: self.channel12(),
+                    channel13: self.channel13(),
+                    channel14: self.channel14(),
+                    channel15: self.channel15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access for bus access generated from the external domain n List capabilities of the external domain n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11276,6 +15657,32 @@ pub mod spu {
                 ExtdomainPerm(0)
             }
         }
+        impl core::fmt::Debug for ExtdomainPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtdomainPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtdomainPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtdomainPerm {
+                    securemapping: super::vals::ExtdomainPermSecuremapping,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = ExtdomainPerm {
+                    securemapping: self.securemapping(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which flash region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11308,6 +15715,29 @@ pub mod spu {
                 FlashnscRegion(0)
             }
         }
+        impl core::fmt::Debug for FlashnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = FlashnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11338,6 +15768,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> FlashnscSize {
                 FlashnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for FlashnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscSize {
+                    size: super::vals::FlashnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = FlashnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for flash region n"]
@@ -11405,6 +15858,38 @@ pub mod spu {
                 FlashregionPerm(0)
             }
         }
+        impl core::fmt::Debug for FlashregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = FlashregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11424,6 +15909,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> GpioportLock {
                 GpioportLock(0)
+            }
+        }
+        impl core::fmt::Debug for GpioportLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportLock {
+                    lock: bool,
+                }
+                let proxy = GpioportLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for pins 0 to 31 of port n."]
@@ -11790,6 +16293,119 @@ pub mod spu {
                 GpioportPerm(0)
             }
         }
+        impl core::fmt::Debug for GpioportPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportPerm")
+                    .field("pin0", &self.pin0())
+                    .field("pin1", &self.pin1())
+                    .field("pin2", &self.pin2())
+                    .field("pin3", &self.pin3())
+                    .field("pin4", &self.pin4())
+                    .field("pin5", &self.pin5())
+                    .field("pin6", &self.pin6())
+                    .field("pin7", &self.pin7())
+                    .field("pin8", &self.pin8())
+                    .field("pin9", &self.pin9())
+                    .field("pin10", &self.pin10())
+                    .field("pin11", &self.pin11())
+                    .field("pin12", &self.pin12())
+                    .field("pin13", &self.pin13())
+                    .field("pin14", &self.pin14())
+                    .field("pin15", &self.pin15())
+                    .field("pin16", &self.pin16())
+                    .field("pin17", &self.pin17())
+                    .field("pin18", &self.pin18())
+                    .field("pin19", &self.pin19())
+                    .field("pin20", &self.pin20())
+                    .field("pin21", &self.pin21())
+                    .field("pin22", &self.pin22())
+                    .field("pin23", &self.pin23())
+                    .field("pin24", &self.pin24())
+                    .field("pin25", &self.pin25())
+                    .field("pin26", &self.pin26())
+                    .field("pin27", &self.pin27())
+                    .field("pin28", &self.pin28())
+                    .field("pin29", &self.pin29())
+                    .field("pin30", &self.pin30())
+                    .field("pin31", &self.pin31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportPerm {
+                    pin0: bool,
+                    pin1: bool,
+                    pin2: bool,
+                    pin3: bool,
+                    pin4: bool,
+                    pin5: bool,
+                    pin6: bool,
+                    pin7: bool,
+                    pin8: bool,
+                    pin9: bool,
+                    pin10: bool,
+                    pin11: bool,
+                    pin12: bool,
+                    pin13: bool,
+                    pin14: bool,
+                    pin15: bool,
+                    pin16: bool,
+                    pin17: bool,
+                    pin18: bool,
+                    pin19: bool,
+                    pin20: bool,
+                    pin21: bool,
+                    pin22: bool,
+                    pin23: bool,
+                    pin24: bool,
+                    pin25: bool,
+                    pin26: bool,
+                    pin27: bool,
+                    pin28: bool,
+                    pin29: bool,
+                    pin30: bool,
+                    pin31: bool,
+                }
+                let proxy = GpioportPerm {
+                    pin0: self.pin0(),
+                    pin1: self.pin1(),
+                    pin2: self.pin2(),
+                    pin3: self.pin3(),
+                    pin4: self.pin4(),
+                    pin5: self.pin5(),
+                    pin6: self.pin6(),
+                    pin7: self.pin7(),
+                    pin8: self.pin8(),
+                    pin9: self.pin9(),
+                    pin10: self.pin10(),
+                    pin11: self.pin11(),
+                    pin12: self.pin12(),
+                    pin13: self.pin13(),
+                    pin14: self.pin14(),
+                    pin15: self.pin15(),
+                    pin16: self.pin16(),
+                    pin17: self.pin17(),
+                    pin18: self.pin18(),
+                    pin19: self.pin19(),
+                    pin20: self.pin20(),
+                    pin21: self.pin21(),
+                    pin22: self.pin22(),
+                    pin23: self.pin23(),
+                    pin24: self.pin24(),
+                    pin25: self.pin25(),
+                    pin26: self.pin26(),
+                    pin27: self.pin27(),
+                    pin28: self.pin28(),
+                    pin29: self.pin29(),
+                    pin30: self.pin30(),
+                    pin31: self.pin31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11833,6 +16449,32 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ramaccerr", &self.ramaccerr())
+                    .field("flashaccerr", &self.flashaccerr())
+                    .field("periphaccerr", &self.periphaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ramaccerr: bool,
+                    flashaccerr: bool,
+                    periphaccerr: bool,
+                }
+                let proxy = Int {
+                    ramaccerr: self.ramaccerr(),
+                    flashaccerr: self.flashaccerr(),
+                    periphaccerr: self.periphaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: List capabilities and access permissions for the peripheral with ID n"]
@@ -11912,6 +16554,41 @@ pub mod spu {
                 PeriphidPerm(0)
             }
         }
+        impl core::fmt::Debug for PeriphidPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PeriphidPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("dma", &self.dma())
+                    .field("secattr", &self.secattr())
+                    .field("dmasec", &self.dmasec())
+                    .field("lock", &self.lock())
+                    .field("present", &self.present())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PeriphidPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PeriphidPerm {
+                    securemapping: super::vals::PeriphidPermSecuremapping,
+                    dma: super::vals::Dma,
+                    secattr: bool,
+                    dmasec: bool,
+                    lock: bool,
+                    present: super::vals::Present,
+                }
+                let proxy = PeriphidPerm {
+                    securemapping: self.securemapping(),
+                    dma: self.dma(),
+                    secattr: self.secattr(),
+                    dmasec: self.dmasec(),
+                    lock: self.lock(),
+                    present: self.present(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which RAM region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11944,6 +16621,29 @@ pub mod spu {
                 RamnscRegion(0)
             }
         }
+        impl core::fmt::Debug for RamnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = RamnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11974,6 +16674,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> RamnscSize {
                 RamnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for RamnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscSize {
+                    size: super::vals::RamnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = RamnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for RAM region n"]
@@ -12041,10 +16764,43 @@ pub mod spu {
                 RamregionPerm(0)
             }
         }
+        impl core::fmt::Debug for RamregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = RamregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dma {
             #[doc = "Peripheral has no DMA capability"]
             NO_DMA = 0x0,
@@ -12077,7 +16833,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtdomainPermSecuremapping {
             #[doc = "The bus access from this external domain always have the non-secure attribute set"]
             NON_SECURE = 0x0,
@@ -12110,7 +16867,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum FlashnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -12161,7 +16919,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PeriphidPermSecuremapping {
             #[doc = "This peripheral is always accessible as a non-secure peripheral"]
             NON_SECURE = 0x0,
@@ -12195,7 +16954,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "Peripheral is not present"]
             NOT_PRESENT = 0x0,
@@ -12225,7 +16985,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RamnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -12276,7 +17037,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tzm {
             #[doc = "ARM TrustZone support not available"]
             NOT_AVAILABLE = 0x0,
@@ -12426,6 +17188,26 @@ pub mod tad {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clocking options for the Trace Port debug interface Reset behavior is the same as debug components"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12449,6 +17231,26 @@ pub mod tad {
                 Traceportspeed(0)
             }
         }
+        impl core::fmt::Debug for Traceportspeed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceportspeed")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceportspeed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceportspeed {
+                    traceportspeed: super::vals::Traceportspeed,
+                }
+                let proxy = Traceportspeed {
+                    traceportspeed: self.traceportspeed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -12464,6 +17266,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTraceclkPin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x15 => f.write_str("TRACECLK"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTraceclkPin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x15 => defmt::write!(f, "TRACECLK"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTraceclkPin {
@@ -12493,6 +17312,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata0Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x16 => f.write_str("TRACEDATA0"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata0Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x16 => defmt::write!(f, "TRACEDATA0"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata0Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata0Pin {
@@ -12518,6 +17354,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTracedata1Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x17 => f.write_str("TRACEDATA1"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata1Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x17 => defmt::write!(f, "TRACEDATA1"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTracedata1Pin {
@@ -12547,6 +17400,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata2Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x18 => f.write_str("TRACEDATA2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata2Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x18 => defmt::write!(f, "TRACEDATA2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata2Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata2Pin {
@@ -12574,6 +17444,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata3Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x19 => f.write_str("TRACEDATA3"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata3Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x19 => defmt::write!(f, "TRACEDATA3"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata3Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata3Pin {
@@ -12587,7 +17474,8 @@ pub mod tad {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "Trace Port clock is: 32MHz"]
             _32MHZ = 0x0,
@@ -12799,6 +17687,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12826,6 +17734,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12847,6 +17792,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -12872,6 +17833,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12893,6 +17874,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12937,10 +17938,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -12974,7 +18033,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -13350,6 +18410,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13371,6 +18451,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -13418,6 +18518,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13440,6 +18566,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -13531,6 +18677,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13552,6 +18736,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13577,6 +18781,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13598,6 +18820,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13667,6 +18909,38 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13688,6 +18962,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13713,6 +19007,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13736,10 +19048,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -13801,6 +19134,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -13814,7 +19168,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13846,7 +19201,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14223,6 +19579,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14257,6 +19633,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14278,6 +19677,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14323,6 +19742,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14403,6 +19848,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14424,6 +19904,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -14449,6 +19949,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14470,6 +19986,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14495,6 +20031,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14516,6 +20070,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14552,6 +20126,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14573,6 +20170,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14598,6 +20215,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14621,10 +20256,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -14668,7 +20324,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14700,7 +20357,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -15124,6 +20782,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15169,6 +20847,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15190,6 +20894,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -15246,6 +20970,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15381,6 +21134,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15404,6 +21207,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15425,6 +21248,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15461,6 +21304,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15484,6 +21350,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15505,6 +21391,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -15558,6 +21464,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -15571,7 +21528,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -15607,7 +21565,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -15651,7 +21610,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -15860,6 +21820,26 @@ pub mod uicr {
                 Appnvmcpofguard(0)
             }
         }
+        impl core::fmt::Debug for Appnvmcpofguard {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Appnvmcpofguard")
+                    .field("nvmcpofguarden", &self.nvmcpofguarden())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Appnvmcpofguard {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Appnvmcpofguard {
+                    nvmcpofguarden: bool,
+                }
+                let proxy = Appnvmcpofguard {
+                    nvmcpofguarden: self.nvmcpofguarden(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15882,6 +21862,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Approtect {
                 Approtect(0)
+            }
+        }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::ApprotectPall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Erase protection"]
@@ -15908,6 +21906,24 @@ pub mod uicr {
                 Eraseprotect(0)
             }
         }
+        impl core::fmt::Debug for Eraseprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseprotect {
+                    pall: super::vals::EraseprotectPall,
+                }
+                let proxy = Eraseprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO startup counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15931,6 +21947,26 @@ pub mod uicr {
                 Hfxocnt(0)
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxocnt")
+                    .field("hfxocnt", &self.hfxocnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxocnt {
+                    hfxocnt: super::vals::Hfxocnt,
+                }
+                let proxy = Hfxocnt {
+                    hfxocnt: self.hfxocnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO clock source selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15952,6 +21988,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Hfxosrc {
                 Hfxosrc(0)
+            }
+        }
+        impl core::fmt::Debug for Hfxosrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxosrc")
+                    .field("hfxosrc", &self.hfxosrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxosrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxosrc {
+                    hfxosrc: super::vals::Hfxosrc,
+                }
+                let proxy = Hfxosrc {
+                    hfxosrc: self.hfxosrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: One time programmable memory"]
@@ -15986,6 +22042,29 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Otp {
                 Otp(0)
+            }
+        }
+        impl core::fmt::Debug for Otp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Otp")
+                    .field("lower", &self.lower())
+                    .field("upper", &self.upper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Otp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Otp {
+                    lower: u16,
+                    upper: u16,
+                }
+                let proxy = Otp {
+                    lower: self.lower(),
+                    upper: self.upper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Define permissions for the key slot. Bits 0-15 and 16-31 can only be written when equal to 0xFFFF."]
@@ -16045,6 +22124,35 @@ pub mod uicr {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("push", &self.push())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: bool,
+                    read: bool,
+                    push: bool,
+                    state: super::vals::State,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                    push: self.push(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Polarity of PMIC polarity configuration signals."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16066,6 +22174,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Pmicconf {
                 Pmicconf(0)
+            }
+        }
+        impl core::fmt::Debug for Pmicconf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pmicconf")
+                    .field("pmicfpwmpol", &self.pmicfpwmpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pmicconf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pmicconf {
+                    pmicfpwmpol: super::vals::Pmicfpwmpol,
+                }
+                let proxy = Pmicconf {
+                    pmicfpwmpol: self.pmicfpwmpol(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Secure access port protection"]
@@ -16092,6 +22220,24 @@ pub mod uicr {
                 Secureapprotect(0)
             }
         }
+        impl core::fmt::Debug for Secureapprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Secureapprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Secureapprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Secureapprotect {
+                    pall: super::vals::SecureapprotectPall,
+                }
+                let proxy = Secureapprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Oscillator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16115,6 +22261,24 @@ pub mod uicr {
                 Xosc32m(0)
             }
         }
+        impl core::fmt::Debug for Xosc32m {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32m")
+                    .field("ctrl", &self.ctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32m {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32m {
+                    ctrl: u8,
+                }
+                let proxy = Xosc32m { ctrl: self.ctrl() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -16132,6 +22296,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0x50fa_50fa => f.write_str("HW_UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0x50fa_50fa => defmt::write!(f, "HW_UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectPall {
@@ -16163,6 +22346,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for EraseprotectPall {
             #[inline(always)]
             fn from(val: u32) -> EraseprotectPall {
@@ -16192,6 +22394,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_DEBOUNCE_TIME"),
+                    0xff => f.write_str("MAX_DEBOUNCE_TIME"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_DEBOUNCE_TIME"),
+                    0xff => defmt::write!(f, "MAX_DEBOUNCE_TIME"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxocnt {
             #[inline(always)]
             fn from(val: u8) -> Hfxocnt {
@@ -16205,7 +22426,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hfxosrc {
             #[doc = "32 MHz temperature compensated crystal oscillator (TCXO)"]
             TCXO = 0x0,
@@ -16235,7 +22457,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pmicfpwmpol {
             #[doc = "PMIC_FPWM output signal is active-low"]
             ACTIVE_LOW = 0x0,
@@ -16281,6 +22504,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for SecureapprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0x50fa_50fa => f.write_str("HW_UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0x50fa_50fa => defmt::write!(f, "HW_UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for SecureapprotectPall {
             #[inline(always)]
             fn from(val: u32) -> SecureapprotectPall {
@@ -16294,7 +22536,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Key value registers can no longer be read or pushed"]
             REVOKED = 0x0,
@@ -16424,6 +22667,55 @@ pub mod vmc {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "spower",
+                        &[
+                            self.spower(0usize),
+                            self.spower(1usize),
+                            self.spower(2usize),
+                            self.spower(3usize),
+                        ],
+                    )
+                    .field(
+                        "sretention",
+                        &[
+                            self.sretention(0usize),
+                            self.sretention(1usize),
+                            self.sretention(2usize),
+                            self.sretention(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    spower: [bool; 4usize],
+                    sretention: [bool; 4usize],
+                }
+                let proxy = Power {
+                    spower: [
+                        self.spower(0usize),
+                        self.spower(1usize),
+                        self.spower(2usize),
+                        self.spower(3usize),
+                    ],
+                    sretention: [
+                        self.sretention(0usize),
+                        self.sretention(1usize),
+                        self.sretention(2usize),
+                        self.sretention(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod wdt {
@@ -16544,6 +22836,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16565,6 +22880,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -16594,6 +22929,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16616,6 +22992,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -16645,6 +23037,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16668,10 +23101,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -16715,6 +23169,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -16728,7 +23199,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,

--- a/src/chips/nrf9160/pac.rs
+++ b/src/chips/nrf9160/pac.rs
@@ -1,5 +1,6 @@
-#![doc = "Peripheral access API (generated using chiptool v0.1.0 (4d62dd5 2024-11-15))"]
+#![doc = "Peripheral access API (generated using chiptool v0.1.0 (e09c27d 2025-01-02))"]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Interrupt {
     #[doc = "3 - SPU"]
     SPU = 3,
@@ -490,6 +491,26 @@ pub mod cc_host_rgf {
                 HostCryptokeySel(0)
             }
         }
+        impl core::fmt::Debug for HostCryptokeySel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostCryptokeySel")
+                    .field("host_cryptokey_sel", &self.host_cryptokey_sel())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostCryptokeySel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostCryptokeySel {
+                    host_cryptokey_sel: super::vals::HostCryptokeySel,
+                }
+                let proxy = HostCryptokeySel {
+                    host_cryptokey_sel: self.host_cryptokey_sel(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This write-once register is the K_PRTL lock register. When this register is set, K_PRTL cannot be used and a zeroed key will be used instead. The value of this register is saved in the CRYPTOCELL AO power domain."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -511,6 +532,26 @@ pub mod cc_host_rgf {
             #[inline(always)]
             fn default() -> HostIotKprtlLock {
                 HostIotKprtlLock(0)
+            }
+        }
+        impl core::fmt::Debug for HostIotKprtlLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotKprtlLock")
+                    .field("host_iot_kprtl_lock", &self.host_iot_kprtl_lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotKprtlLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotKprtlLock {
+                    host_iot_kprtl_lock: bool,
+                }
+                let proxy = HostIotKprtlLock {
+                    host_iot_kprtl_lock: self.host_iot_kprtl_lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls lifecycle state (LCS) for CRYPTOCELL subsystem"]
@@ -547,10 +588,34 @@ pub mod cc_host_rgf {
                 HostIotLcs(0)
             }
         }
+        impl core::fmt::Debug for HostIotLcs {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("HostIotLcs")
+                    .field("lcs", &self.lcs())
+                    .field("lcs_is_valid", &self.lcs_is_valid())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for HostIotLcs {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct HostIotLcs {
+                    lcs: super::vals::Lcs,
+                    lcs_is_valid: bool,
+                }
+                let proxy = HostIotLcs {
+                    lcs: self.lcs(),
+                    lcs_is_valid: self.lcs_is_valid(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HostCryptokeySel {
             #[doc = "Use device root key K_DR from CRYPTOCELL AO power domain"]
             K_DR = 0x0,
@@ -583,7 +648,8 @@ pub mod cc_host_rgf {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lcs {
             #[doc = "CC310 operates in debug mode"]
             DEBUG = 0x0,
@@ -786,6 +852,26 @@ pub mod clock {
                 Hfclkrun(0)
             }
         }
+        impl core::fmt::Debug for Hfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkrun {
+                    status: bool,
+                }
+                let proxy = Hfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "The register shows if HFXO has been requested by triggering HFCLKSTART task and if it has been started (STATE)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -818,6 +904,29 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Hfclkstat {
                 Hfclkstat(0)
+            }
+        }
+        impl core::fmt::Debug for Hfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfclkstat {
+                    src: super::vals::HfclkstatSrc,
+                    state: bool,
+                }
+                let proxy = Hfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -854,6 +963,29 @@ pub mod clock {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("hfclkstarted", &self.hfclkstarted())
+                    .field("lfclkstarted", &self.lfclkstarted())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    hfclkstarted: bool,
+                    lfclkstarted: bool,
+                }
+                let proxy = Int {
+                    hfclkstarted: self.hfclkstarted(),
+                    lfclkstarted: self.lfclkstarted(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status indicating that LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -875,6 +1007,26 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclkrun {
                 Lfclkrun(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclkrun {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkrun")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkrun {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkrun {
+                    status: bool,
+                }
+                let proxy = Lfclkrun {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clock source for the LFCLK. LFCLKSTART task starts starts a clock source selected with this register."]
@@ -900,6 +1052,24 @@ pub mod clock {
                 Lfclksrc(0)
             }
         }
+        impl core::fmt::Debug for Lfclksrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrc")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrc {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrc { src: self.src() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Copy of LFCLKSRC register, set after LFCLKSTART task has been triggered"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -921,6 +1091,24 @@ pub mod clock {
             #[inline(always)]
             fn default() -> Lfclksrccopy {
                 Lfclksrccopy(0)
+            }
+        }
+        impl core::fmt::Debug for Lfclksrccopy {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclksrccopy")
+                    .field("src", &self.src())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclksrccopy {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclksrccopy {
+                    src: super::vals::Lfclksrc,
+                }
+                let proxy = Lfclksrccopy { src: self.src() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "The register shows which LFCLK source has been requested (SRC) when triggering LFCLKSTART task and if the source has been started (STATE)"]
@@ -957,10 +1145,34 @@ pub mod clock {
                 Lfclkstat(0)
             }
         }
+        impl core::fmt::Debug for Lfclkstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lfclkstat")
+                    .field("src", &self.src())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lfclkstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lfclkstat {
+                    src: super::vals::Lfclksrc,
+                    state: bool,
+                }
+                let proxy = Lfclkstat {
+                    src: self.src(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum HfclkstatSrc {
             #[doc = "HFINT - 64 MHz on-chip oscillator"]
             HFINT = 0x0,
@@ -990,7 +1202,8 @@ pub mod clock {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Lfclksrc {
             #[doc = "Reserved for future use (equals selecting LFRC)"]
             RFU = 0x0,
@@ -1148,6 +1361,26 @@ pub mod cryptocell {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod ctrlapperi {
@@ -1266,6 +1499,22 @@ pub mod ctrlapperi {
                 Lock(0)
             }
         }
+        impl core::fmt::Debug for Lock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Lock").field("lock", &self.lock()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Lock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Lock {
+                    lock: bool,
+                }
+                let proxy = Lock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if data sent from the debugger to the CPU has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1289,6 +1538,26 @@ pub mod ctrlapperi {
                 Rxstatus(0)
             }
         }
+        impl core::fmt::Debug for Rxstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxstatus")
+                    .field("rxstatus", &self.rxstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxstatus {
+                    rxstatus: bool,
+                }
+                let proxy = Rxstatus {
+                    rxstatus: self.rxstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "This register shows a status that indicates if the data sent from the CPU to the debugger has been read."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1310,6 +1579,26 @@ pub mod ctrlapperi {
             #[inline(always)]
             fn default() -> Txstatus {
                 Txstatus(0)
+            }
+        }
+        impl core::fmt::Debug for Txstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txstatus")
+                    .field("txstatus", &self.txstatus())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txstatus {
+                    txstatus: bool,
+                }
+                let proxy = Txstatus {
+                    txstatus: self.txstatus(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -1451,6 +1740,63 @@ pub mod dppic {
                 Chen(0)
             }
         }
+        impl core::fmt::Debug for Chen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chen")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chen {
+                    ch: [bool; 16usize],
+                }
+                let proxy = Chen {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Channel group n Note: Writes to this register are ignored if either SUBSCRIBE_CHG\\[n\\].EN or SUBSCRIBE_CHG\\[n\\].DIS is enabled"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1476,6 +1822,63 @@ pub mod dppic {
             #[inline(always)]
             fn default() -> Chg {
                 Chg(0)
+            }
+        }
+        impl core::fmt::Debug for Chg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Chg")
+                    .field(
+                        "ch",
+                        &[
+                            self.ch(0usize),
+                            self.ch(1usize),
+                            self.ch(2usize),
+                            self.ch(3usize),
+                            self.ch(4usize),
+                            self.ch(5usize),
+                            self.ch(6usize),
+                            self.ch(7usize),
+                            self.ch(8usize),
+                            self.ch(9usize),
+                            self.ch(10usize),
+                            self.ch(11usize),
+                            self.ch(12usize),
+                            self.ch(13usize),
+                            self.ch(14usize),
+                            self.ch(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Chg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Chg {
+                    ch: [bool; 16usize],
+                }
+                let proxy = Chg {
+                    ch: [
+                        self.ch(0usize),
+                        self.ch(1usize),
+                        self.ch(2usize),
+                        self.ch(3usize),
+                        self.ch(4usize),
+                        self.ch(5usize),
+                        self.ch(6usize),
+                        self.ch(7usize),
+                        self.ch(8usize),
+                        self.ch(9usize),
+                        self.ch(10usize),
+                        self.ch(11usize),
+                        self.ch(12usize),
+                        self.ch(13usize),
+                        self.ch(14usize),
+                        self.ch(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -1572,6 +1975,63 @@ pub mod egu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "triggered",
+                        &[
+                            self.triggered(0usize),
+                            self.triggered(1usize),
+                            self.triggered(2usize),
+                            self.triggered(3usize),
+                            self.triggered(4usize),
+                            self.triggered(5usize),
+                            self.triggered(6usize),
+                            self.triggered(7usize),
+                            self.triggered(8usize),
+                            self.triggered(9usize),
+                            self.triggered(10usize),
+                            self.triggered(11usize),
+                            self.triggered(12usize),
+                            self.triggered(13usize),
+                            self.triggered(14usize),
+                            self.triggered(15usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    triggered: [bool; 16usize],
+                }
+                let proxy = Int {
+                    triggered: [
+                        self.triggered(0usize),
+                        self.triggered(1usize),
+                        self.triggered(2usize),
+                        self.triggered(3usize),
+                        self.triggered(4usize),
+                        self.triggered(5usize),
+                        self.triggered(6usize),
+                        self.triggered(7usize),
+                        self.triggered(8usize),
+                        self.triggered(9usize),
+                        self.triggered(10usize),
+                        self.triggered(11usize),
+                        self.triggered(12usize),
+                        self.triggered(13usize),
+                        self.triggered(14usize),
+                        self.triggered(15usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -1823,6 +2283,26 @@ pub mod ficr {
                 Codepagesize(0)
             }
         }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codepagesize")
+                    .field("codepagesize", &self.codepagesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codepagesize {
+                    codepagesize: super::vals::Codepagesize,
+                }
+                let proxy = Codepagesize {
+                    codepagesize: self.codepagesize(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Code memory size"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1845,6 +2325,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Codesize {
                 Codesize(0)
+            }
+        }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Codesize")
+                    .field("codesize", &self.codesize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Codesize {
+                    codesize: super::vals::Codesize,
+                }
+                let proxy = Codesize {
+                    codesize: self.codesize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Device type"]
@@ -1871,6 +2371,26 @@ pub mod ficr {
                 Devicetype(0)
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Devicetype")
+                    .field("devicetype", &self.devicetype())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Devicetype {
+                    devicetype: super::vals::Devicetype,
+                }
+                let proxy = Devicetype {
+                    devicetype: self.devicetype(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Flash variant"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1893,6 +2413,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Flash {
                 Flash(0)
+            }
+        }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Flash")
+                    .field("flash", &self.flash())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Flash {
+                    flash: super::vals::Flash,
+                }
+                let proxy = Flash {
+                    flash: self.flash(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part Variant, Hardware version and Production configuration"]
@@ -1919,6 +2459,26 @@ pub mod ficr {
                 InfoVariant(0)
             }
         }
+        impl core::fmt::Debug for InfoVariant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("InfoVariant")
+                    .field("variant", &self.variant())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for InfoVariant {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct InfoVariant {
+                    variant: super::vals::Variant,
+                }
+                let proxy = InfoVariant {
+                    variant: self.variant(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Package option"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1941,6 +2501,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Package {
                 Package(0)
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Package")
+                    .field("package", &self.package())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Package {
+                    package: super::vals::Package,
+                }
+                let proxy = Package {
+                    package: self.package(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Part code"]
@@ -1967,6 +2547,22 @@ pub mod ficr {
                 Part(0)
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Part").field("part", &self.part()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Part {
+                    part: super::vals::Part,
+                }
+                let proxy = Part { part: self.part() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "SIP part number"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1987,6 +2583,26 @@ pub mod ficr {
             #[inline(always)]
             fn default() -> Partno {
                 Partno(0)
+            }
+        }
+        impl core::fmt::Debug for Partno {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Partno")
+                    .field("partno", &self.partno())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Partno {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Partno {
+                    partno: super::vals::Partno,
+                }
+                let proxy = Partno {
+                    partno: self.partno(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "RAM variant"]
@@ -2013,6 +2629,22 @@ pub mod ficr {
                 Ram(0)
             }
         }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ram").field("ram", &self.ram()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ram {
+                    ram: super::vals::Ram,
+                }
+                let proxy = Ram { ram: self.ram() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -2028,6 +2660,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codepagesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x1000 => f.write_str("K4096"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codepagesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x1000 => defmt::write!(f, "K4096"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codepagesize {
@@ -2055,6 +2704,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Codesize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("P256"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Codesize {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "P256"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Codesize {
@@ -2086,6 +2752,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Devicetype {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DIE"),
+                    0xffff_ffff => f.write_str("FPGA"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Devicetype {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DIE"),
+                    0xffff_ffff => defmt::write!(f, "FPGA"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Devicetype {
             #[inline(always)]
             fn from(val: u32) -> Devicetype {
@@ -2113,6 +2798,23 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Flash {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0400 => f.write_str("K1024"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Flash {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0400 => defmt::write!(f, "K1024"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Flash {
             #[inline(always)]
             fn from(val: u32) -> Flash {
@@ -2138,6 +2840,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Package {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x2002 => f.write_str("CF"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Package {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x2002 => defmt::write!(f, "CF"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Package {
@@ -2169,6 +2888,25 @@ pub mod ficr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Part {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x9120 => f.write_str("N9120"),
+                    0x9160 => f.write_str("N9160"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Part {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x9120 => defmt::write!(f, "N9120"),
+                    0x9160 => defmt::write!(f, "N9160"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Part {
             #[inline(always)]
             fn from(val: u32) -> Part {
@@ -2194,6 +2932,23 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Partno {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x9160 => f.write_str("_9160"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Partno {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x9160 => defmt::write!(f, "_9160"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Partno {
@@ -2223,6 +2978,25 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Ram {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0100 => f.write_str("K256"),
+                    0xffff_ffff => f.write_str("UNSPECIFIED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ram {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0100 => defmt::write!(f, "K256"),
+                    0xffff_ffff => defmt::write!(f, "UNSPECIFIED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Ram {
@@ -2256,6 +3030,29 @@ pub mod ficr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for Variant {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x4141_4130 => f.write_str("AAA0"),
+                    0x4141_4141 => f.write_str("AAAA"),
+                    0x4141_4230 => f.write_str("AAB0"),
+                    0x4141_4330 => f.write_str("AAC0"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Variant {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x4141_4130 => defmt::write!(f, "AAA0"),
+                    0x4141_4141 => defmt::write!(f, "AAAA"),
+                    0x4141_4230 => defmt::write!(f, "AAB0"),
+                    0x4141_4330 => defmt::write!(f, "AAC0"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for Variant {
@@ -2399,6 +3196,26 @@ pub mod gpio {
                 Detectmode(0)
             }
         }
+        impl core::fmt::Debug for Detectmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Detectmode")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Detectmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Detectmode {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = Detectmode {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select between default DETECT signal behavior and LDETECT mode (For secure pin only)"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2420,6 +3237,26 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> DetectmodeSec {
                 DetectmodeSec(0)
+            }
+        }
+        impl core::fmt::Debug for DetectmodeSec {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DetectmodeSec")
+                    .field("detectmode", &self.detectmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DetectmodeSec {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DetectmodeSec {
+                    detectmode: super::vals::Detectmode,
+                }
+                let proxy = DetectmodeSec {
+                    detectmode: self.detectmode(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Direction of GPIO pins"]
@@ -2449,6 +3286,95 @@ pub mod gpio {
                 Dir(0)
             }
         }
+        impl core::fmt::Debug for Dir {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dir")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dir {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dir {
+                    pin: [super::vals::Dir; 32usize],
+                }
+                let proxy = Dir {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "DIR clear register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2474,6 +3400,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Dirclr {
                 Dirclr(0)
+            }
+        }
+        impl core::fmt::Debug for Dirclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "DIR set register"]
@@ -2503,6 +3518,95 @@ pub mod gpio {
                 Dirset(0)
             }
         }
+        impl core::fmt::Debug for Dirset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dirset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dirset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dirset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Dirset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Read GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2528,6 +3632,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> In {
                 In(0)
+            }
+        }
+        impl core::fmt::Debug for In {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("In")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for In {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct In {
+                    pin: [bool; 32usize],
+                }
+                let proxy = In {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Latch register indicating what GPIO pins that have met the criteria set in the PIN_CNF\\[n\\].SENSE registers"]
@@ -2557,6 +3750,95 @@ pub mod gpio {
                 Latch(0)
             }
         }
+        impl core::fmt::Debug for Latch {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Latch")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Latch {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Latch {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Latch {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Write GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2582,6 +3864,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Out {
                 Out(0)
+            }
+        }
+        impl core::fmt::Debug for Out {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Out")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Out {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Out {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Out {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Clear individual bits in GPIO port"]
@@ -2611,6 +3982,95 @@ pub mod gpio {
                 Outclr(0)
             }
         }
+        impl core::fmt::Debug for Outclr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outclr")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outclr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outclr {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outclr {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Set individual bits in GPIO port"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2636,6 +4096,95 @@ pub mod gpio {
             #[inline(always)]
             fn default() -> Outset {
                 Outset(0)
+            }
+        }
+        impl core::fmt::Debug for Outset {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Outset")
+                    .field(
+                        "pin",
+                        &[
+                            self.pin(0usize),
+                            self.pin(1usize),
+                            self.pin(2usize),
+                            self.pin(3usize),
+                            self.pin(4usize),
+                            self.pin(5usize),
+                            self.pin(6usize),
+                            self.pin(7usize),
+                            self.pin(8usize),
+                            self.pin(9usize),
+                            self.pin(10usize),
+                            self.pin(11usize),
+                            self.pin(12usize),
+                            self.pin(13usize),
+                            self.pin(14usize),
+                            self.pin(15usize),
+                            self.pin(16usize),
+                            self.pin(17usize),
+                            self.pin(18usize),
+                            self.pin(19usize),
+                            self.pin(20usize),
+                            self.pin(21usize),
+                            self.pin(22usize),
+                            self.pin(23usize),
+                            self.pin(24usize),
+                            self.pin(25usize),
+                            self.pin(26usize),
+                            self.pin(27usize),
+                            self.pin(28usize),
+                            self.pin(29usize),
+                            self.pin(30usize),
+                            self.pin(31usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Outset {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Outset {
+                    pin: [bool; 32usize],
+                }
+                let proxy = Outset {
+                    pin: [
+                        self.pin(0usize),
+                        self.pin(1usize),
+                        self.pin(2usize),
+                        self.pin(3usize),
+                        self.pin(4usize),
+                        self.pin(5usize),
+                        self.pin(6usize),
+                        self.pin(7usize),
+                        self.pin(8usize),
+                        self.pin(9usize),
+                        self.pin(10usize),
+                        self.pin(11usize),
+                        self.pin(12usize),
+                        self.pin(13usize),
+                        self.pin(14usize),
+                        self.pin(15usize),
+                        self.pin(16usize),
+                        self.pin(17usize),
+                        self.pin(18usize),
+                        self.pin(19usize),
+                        self.pin(20usize),
+                        self.pin(21usize),
+                        self.pin(22usize),
+                        self.pin(23usize),
+                        self.pin(24usize),
+                        self.pin(25usize),
+                        self.pin(26usize),
+                        self.pin(27usize),
+                        self.pin(28usize),
+                        self.pin(29usize),
+                        self.pin(30usize),
+                        self.pin(31usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Configuration of GPIO pins"]
@@ -2706,10 +4255,43 @@ pub mod gpio {
                 PinCnf(0)
             }
         }
+        impl core::fmt::Debug for PinCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PinCnf")
+                    .field("dir", &self.dir())
+                    .field("input", &self.input())
+                    .field("pull", &self.pull())
+                    .field("drive", &self.drive())
+                    .field("sense", &self.sense())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PinCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PinCnf {
+                    dir: super::vals::Dir,
+                    input: super::vals::Input,
+                    pull: super::vals::Pull,
+                    drive: super::vals::Drive,
+                    sense: super::vals::Sense,
+                }
+                let proxy = PinCnf {
+                    dir: self.dir(),
+                    input: self.input(),
+                    pull: self.pull(),
+                    drive: self.drive(),
+                    sense: self.sense(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Detectmode {
             #[doc = "DETECT directly connected to PIN DETECT signals"]
             DEFAULT = 0x0,
@@ -2739,7 +4321,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dir {
             #[doc = "Configure pin as an input pin"]
             INPUT = 0x0,
@@ -2769,7 +4352,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Drive {
             #[doc = "Standard '0', standard '1'"]
             S0S1 = 0x0,
@@ -2811,7 +4395,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Input {
             #[doc = "Connect input buffer"]
             CONNECT = 0x0,
@@ -2841,7 +4426,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Pull {
             #[doc = "No pull"]
             DISABLED = 0x0,
@@ -2874,7 +4460,8 @@ pub mod gpio {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sense {
             #[doc = "Disabled"]
             DISABLED = 0x0,
@@ -3073,6 +4660,35 @@ pub mod gpiote {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("mode", &self.mode())
+                    .field("psel", &self.psel())
+                    .field("polarity", &self.polarity())
+                    .field("outinit", &self.outinit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    mode: super::vals::Mode,
+                    psel: u8,
+                    polarity: super::vals::Polarity,
+                    outinit: super::vals::Outinit,
+                }
+                let proxy = Config {
+                    mode: self.mode(),
+                    psel: self.psel(),
+                    polarity: self.polarity(),
+                    outinit: self.outinit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3111,10 +4727,55 @@ pub mod gpiote {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "in_",
+                        &[
+                            self.in_(0usize),
+                            self.in_(1usize),
+                            self.in_(2usize),
+                            self.in_(3usize),
+                            self.in_(4usize),
+                            self.in_(5usize),
+                            self.in_(6usize),
+                            self.in_(7usize),
+                        ],
+                    )
+                    .field("port", &self.port())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    in_: [bool; 8usize],
+                    port: bool,
+                }
+                let proxy = Int {
+                    in_: [
+                        self.in_(0usize),
+                        self.in_(1usize),
+                        self.in_(2usize),
+                        self.in_(3usize),
+                        self.in_(4usize),
+                        self.in_(5usize),
+                        self.in_(6usize),
+                        self.in_(7usize),
+                    ],
+                    port: self.port(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Disabled. Pin specified by PSEL will not be acquired by the GPIOTE module."]
             DISABLED = 0x0,
@@ -3147,7 +4808,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Outinit {
             #[doc = "Task mode: Initial value of pin before task triggering is low"]
             LOW = 0x0,
@@ -3177,7 +4839,8 @@ pub mod gpiote {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Polarity {
             #[doc = "Task mode: No effect on pin from OUT\\[n\\] task. Event mode: no IN\\[n\\] event generated on pin activity."]
             NONE = 0x0,
@@ -3540,6 +5203,26 @@ pub mod i2s {
                 Align(0)
             }
         }
+        impl core::fmt::Debug for Align {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Align")
+                    .field("align", &self.align())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Align {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Align {
+                    align: super::vals::Align,
+                }
+                let proxy = Align {
+                    align: self.align(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable channels."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3561,6 +5244,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Channels {
                 Channels(0)
+            }
+        }
+        impl core::fmt::Debug for Channels {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Channels")
+                    .field("channels", &self.channels())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Channels {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Channels {
+                    channels: super::vals::Channels,
+                }
+                let proxy = Channels {
+                    channels: self.channels(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable I2S module."]
@@ -3586,6 +5289,26 @@ pub mod i2s {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Frame format."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3607,6 +5330,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Format {
                 Format(0)
+            }
+        }
+        impl core::fmt::Debug for Format {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Format")
+                    .field("format", &self.format())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Format {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Format {
+                    format: super::vals::Format,
+                }
+                let proxy = Format {
+                    format: self.format(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -3654,6 +5397,32 @@ pub mod i2s {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("rxptrupd", &self.rxptrupd())
+                    .field("stopped", &self.stopped())
+                    .field("txptrupd", &self.txptrupd())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    rxptrupd: bool,
+                    stopped: bool,
+                    txptrupd: bool,
+                }
+                let proxy = Int {
+                    rxptrupd: self.rxptrupd(),
+                    stopped: self.stopped(),
+                    txptrupd: self.txptrupd(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Size of RXD and TXD buffers."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3677,6 +5446,26 @@ pub mod i2s {
                 Maxcnt(0)
             }
         }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Master clock generator enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3698,6 +5487,26 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mcken {
                 Mcken(0)
+            }
+        }
+        impl core::fmt::Debug for Mcken {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mcken")
+                    .field("mcken", &self.mcken())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mcken {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mcken {
+                    mcken: bool,
+                }
+                let proxy = Mcken {
+                    mcken: self.mcken(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Master clock generator frequency."]
@@ -3724,6 +5533,26 @@ pub mod i2s {
                 Mckfreq(0)
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mckfreq")
+                    .field("mckfreq", &self.mckfreq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mckfreq {
+                    mckfreq: super::vals::Mckfreq,
+                }
+                let proxy = Mckfreq {
+                    mckfreq: self.mckfreq(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "I2S mode."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3745,6 +5574,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "MCK / LRCK ratio."]
@@ -3770,6 +5615,26 @@ pub mod i2s {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Reception (RX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3791,6 +5656,22 @@ pub mod i2s {
             #[inline(always)]
             fn default() -> Rxen {
                 Rxen(0)
+            }
+        }
+        impl core::fmt::Debug for Rxen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rxen").field("rxen", &self.rxen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rxen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rxen {
+                    rxen: bool,
+                }
+                let proxy = Rxen { rxen: self.rxen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Sample width."]
@@ -3816,6 +5697,26 @@ pub mod i2s {
                 Swidth(0)
             }
         }
+        impl core::fmt::Debug for Swidth {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Swidth")
+                    .field("swidth", &self.swidth())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Swidth {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Swidth {
+                    swidth: super::vals::Swidth,
+                }
+                let proxy = Swidth {
+                    swidth: self.swidth(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Transmission (TX) enable."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -3839,10 +5740,27 @@ pub mod i2s {
                 Txen(0)
             }
         }
+        impl core::fmt::Debug for Txen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Txen").field("txen", &self.txen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Txen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Txen {
+                    txen: bool,
+                }
+                let proxy = Txen { txen: self.txen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Align {
             #[doc = "Left-aligned."]
             LEFT = 0x0,
@@ -3872,7 +5790,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Channels {
             #[doc = "Stereo."]
             STEREO = 0x0,
@@ -3905,7 +5824,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Format {
             #[doc = "Original I2S format."]
             I2S = 0x0,
@@ -3973,6 +5893,47 @@ pub mod i2s {
                 self.0
             }
         }
+        impl core::fmt::Debug for Mckfreq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x020c_0000 => f.write_str("_32MDIV125"),
+                    0x0410_0000 => f.write_str("_32MDIV63"),
+                    0x0600_0000 => f.write_str("_32MDIV42"),
+                    0x0800_0000 => f.write_str("_32MDIV32"),
+                    0x0840_0000 => f.write_str("_32MDIV31"),
+                    0x0880_0000 => f.write_str("_32MDIV30"),
+                    0x0b00_0000 => f.write_str("_32MDIV23"),
+                    0x0c00_0000 => f.write_str("_32MDIV21"),
+                    0x1000_0000 => f.write_str("_32MDIV16"),
+                    0x1100_0000 => f.write_str("_32MDIV15"),
+                    0x1600_0000 => f.write_str("_32MDIV11"),
+                    0x1800_0000 => f.write_str("_32MDIV10"),
+                    0x2000_0000 => f.write_str("_32MDIV8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mckfreq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x020c_0000 => defmt::write!(f, "_32MDIV125"),
+                    0x0410_0000 => defmt::write!(f, "_32MDIV63"),
+                    0x0600_0000 => defmt::write!(f, "_32MDIV42"),
+                    0x0800_0000 => defmt::write!(f, "_32MDIV32"),
+                    0x0840_0000 => defmt::write!(f, "_32MDIV31"),
+                    0x0880_0000 => defmt::write!(f, "_32MDIV30"),
+                    0x0b00_0000 => defmt::write!(f, "_32MDIV23"),
+                    0x0c00_0000 => defmt::write!(f, "_32MDIV21"),
+                    0x1000_0000 => defmt::write!(f, "_32MDIV16"),
+                    0x1100_0000 => defmt::write!(f, "_32MDIV15"),
+                    0x1600_0000 => defmt::write!(f, "_32MDIV11"),
+                    0x1800_0000 => defmt::write!(f, "_32MDIV10"),
+                    0x2000_0000 => defmt::write!(f, "_32MDIV8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Mckfreq {
             #[inline(always)]
             fn from(val: u32) -> Mckfreq {
@@ -3986,7 +5947,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Master mode. SCK and LRCK generated from internal master clcok (MCK) and output on pins defined by PSEL.xxx."]
             MASTER = 0x0,
@@ -4016,7 +5978,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "LRCK = MCK / 32"]
             _32X = 0x0,
@@ -4067,7 +6030,8 @@ pub mod i2s {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Swidth {
             #[doc = "8 bit."]
             _8BIT = 0x0,
@@ -4294,6 +6258,47 @@ pub mod ipc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("receive0", &self.receive0())
+                    .field("receive1", &self.receive1())
+                    .field("receive2", &self.receive2())
+                    .field("receive3", &self.receive3())
+                    .field("receive4", &self.receive4())
+                    .field("receive5", &self.receive5())
+                    .field("receive6", &self.receive6())
+                    .field("receive7", &self.receive7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    receive0: bool,
+                    receive1: bool,
+                    receive2: bool,
+                    receive3: bool,
+                    receive4: bool,
+                    receive5: bool,
+                    receive6: bool,
+                    receive7: bool,
+                }
+                let proxy = Int {
+                    receive0: self.receive0(),
+                    receive1: self.receive1(),
+                    receive2: self.receive2(),
+                    receive3: self.receive3(),
+                    receive4: self.receive4(),
+                    receive5: self.receive5(),
+                    receive6: self.receive6(),
+                    receive7: self.receive7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Receive event configuration for EVENTS_RECEIVE\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4394,6 +6399,47 @@ pub mod ipc {
                 ReceiveCnf(0)
             }
         }
+        impl core::fmt::Debug for ReceiveCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ReceiveCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ReceiveCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ReceiveCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                }
+                let proxy = ReceiveCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Send event configuration for TASKS_SEND\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4492,6 +6538,47 @@ pub mod ipc {
             #[inline(always)]
             fn default() -> SendCnf {
                 SendCnf(0)
+            }
+        }
+        impl core::fmt::Debug for SendCnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("SendCnf")
+                    .field("chen0", &self.chen0())
+                    .field("chen1", &self.chen1())
+                    .field("chen2", &self.chen2())
+                    .field("chen3", &self.chen3())
+                    .field("chen4", &self.chen4())
+                    .field("chen5", &self.chen5())
+                    .field("chen6", &self.chen6())
+                    .field("chen7", &self.chen7())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SendCnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct SendCnf {
+                    chen0: bool,
+                    chen1: bool,
+                    chen2: bool,
+                    chen3: bool,
+                    chen4: bool,
+                    chen5: bool,
+                    chen6: bool,
+                    chen7: bool,
+                }
+                let proxy = SendCnf {
+                    chen0: self.chen0(),
+                    chen1: self.chen1(),
+                    chen2: self.chen2(),
+                    chen3: self.chen3(),
+                    chen4: self.chen4(),
+                    chen5: self.chen5(),
+                    chen6: self.chen6(),
+                    chen7: self.chen7(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4612,6 +6699,32 @@ pub mod kmu {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("keyslot_pushed", &self.keyslot_pushed())
+                    .field("keyslot_revoked", &self.keyslot_revoked())
+                    .field("keyslot_error", &self.keyslot_error())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    keyslot_pushed: bool,
+                    keyslot_revoked: bool,
+                    keyslot_error: bool,
+                }
+                let proxy = Int {
+                    keyslot_pushed: self.keyslot_pushed(),
+                    keyslot_revoked: self.keyslot_revoked(),
+                    keyslot_error: self.keyslot_error(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Select key slot to be read over AHB or pushed over secure APB when TASKS_PUSH_KEYSLOT is started"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4633,6 +6746,24 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Selectkeyslot {
                 Selectkeyslot(0)
+            }
+        }
+        impl core::fmt::Debug for Selectkeyslot {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Selectkeyslot")
+                    .field("id", &self.id())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Selectkeyslot {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Selectkeyslot {
+                    id: u8,
+                }
+                let proxy = Selectkeyslot { id: self.id() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status bits for KMU operation"]
@@ -4667,6 +6798,29 @@ pub mod kmu {
             #[inline(always)]
             fn default() -> Status {
                 Status(0)
+            }
+        }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("selected", &self.selected())
+                    .field("blocked", &self.blocked())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    selected: bool,
+                    blocked: bool,
+                }
+                let proxy = Status {
+                    selected: self.selected(),
+                    blocked: self.blocked(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -4765,6 +6919,22 @@ pub mod nvmc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config").field("wen", &self.wen()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    wen: super::vals::Wen,
+                }
+                let proxy = Config { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Unspecified"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4786,6 +6956,24 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Configns {
                 Configns(0)
+            }
+        }
+        impl core::fmt::Debug for Configns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Configns")
+                    .field("wen", &self.wen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Configns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Configns {
+                    wen: super::vals::ConfignsWen,
+                }
+                let proxy = Configns { wen: self.wen() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Register for erasing all non-volatile user memory"]
@@ -4811,6 +6999,26 @@ pub mod nvmc {
                 Eraseall(0)
             }
         }
+        impl core::fmt::Debug for Eraseall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseall")
+                    .field("eraseall", &self.eraseall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseall {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseall {
+                    eraseall: bool,
+                }
+                let proxy = Eraseall {
+                    eraseall: self.eraseall(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Register for partial erase configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4832,6 +7040,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Erasepagepartialcfg {
                 Erasepagepartialcfg(0)
+            }
+        }
+        impl core::fmt::Debug for Erasepagepartialcfg {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Erasepagepartialcfg")
+                    .field("duration", &self.duration())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Erasepagepartialcfg {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Erasepagepartialcfg {
+                    duration: u8,
+                }
+                let proxy = Erasepagepartialcfg {
+                    duration: self.duration(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "I-code cache configuration register"]
@@ -4868,6 +7096,29 @@ pub mod nvmc {
                 Icachecnf(0)
             }
         }
+        impl core::fmt::Debug for Icachecnf {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Icachecnf")
+                    .field("cacheen", &self.cacheen())
+                    .field("cacheprofen", &self.cacheprofen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Icachecnf {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Icachecnf {
+                    cacheen: bool,
+                    cacheprofen: bool,
+                }
+                let proxy = Icachecnf {
+                    cacheen: self.cacheen(),
+                    cacheprofen: self.cacheprofen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4891,6 +7142,26 @@ pub mod nvmc {
                 Ready(0)
             }
         }
+        impl core::fmt::Debug for Ready {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ready")
+                    .field("ready", &self.ready())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ready {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ready {
+                    ready: bool,
+                }
+                let proxy = Ready {
+                    ready: self.ready(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Ready flag"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -4912,6 +7183,26 @@ pub mod nvmc {
             #[inline(always)]
             fn default() -> Readynext {
                 Readynext(0)
+            }
+        }
+        impl core::fmt::Debug for Readynext {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Readynext")
+                    .field("readynext", &self.readynext())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Readynext {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Readynext {
+                    readynext: bool,
+                }
+                let proxy = Readynext {
+                    readynext: self.readynext(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Non-secure APPROTECT enable register"]
@@ -4949,10 +7240,34 @@ pub mod nvmc {
                 Writeuicrns(0)
             }
         }
+        impl core::fmt::Debug for Writeuicrns {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Writeuicrns")
+                    .field("set", &self.set())
+                    .field("key", &self.key())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Writeuicrns {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Writeuicrns {
+                    set: bool,
+                    key: super::vals::Key,
+                }
+                let proxy = Writeuicrns {
+                    set: self.set(),
+                    key: self.key(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfignsWen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -4999,6 +7314,23 @@ pub mod nvmc {
                 self.0
             }
         }
+        impl core::fmt::Debug for Key {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0afb_e5a7 => f.write_str("KEYVALID"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Key {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0afb_e5a7 => defmt::write!(f, "KEYVALID"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Key {
             #[inline(always)]
             fn from(val: u32) -> Key {
@@ -5012,7 +7344,8 @@ pub mod nvmc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Wen {
             #[doc = "Read only access"]
             REN = 0x0,
@@ -5262,6 +7595,26 @@ pub mod pdm {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Left output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5285,6 +7638,26 @@ pub mod pdm {
                 Gainl(0)
             }
         }
+        impl core::fmt::Debug for Gainl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainl")
+                    .field("gainl", &self.gainl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainl {
+                    gainl: super::vals::Gain,
+                }
+                let proxy = Gainl {
+                    gainl: self.gainl(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Right output gain adjustment"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5306,6 +7679,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Gainr {
                 Gainr(0)
+            }
+        }
+        impl core::fmt::Debug for Gainr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gainr")
+                    .field("gainr", &self.gainr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gainr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gainr {
+                    gainr: super::vals::Gain,
+                }
+                let proxy = Gainr {
+                    gainr: self.gainr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5353,6 +7746,32 @@ pub mod pdm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("stopped", &self.stopped())
+                    .field("end", &self.end())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    stopped: bool,
+                    end: bool,
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    stopped: self.stopped(),
+                    end: self.end(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of samples to allocate memory for in EasyDMA mode"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5374,6 +7793,26 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("buffsize", &self.buffsize())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    buffsize: u16,
+                }
+                let proxy = Maxcnt {
+                    buffsize: self.buffsize(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Defines the routing of the connected PDM microphones' signals"]
@@ -5410,6 +7849,29 @@ pub mod pdm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("operation", &self.operation())
+                    .field("edge", &self.edge())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    operation: super::vals::Operation,
+                    edge: super::vals::Edge,
+                }
+                let proxy = Mode {
+                    operation: self.operation(),
+                    edge: self.edge(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PDM clock generator control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5432,6 +7894,24 @@ pub mod pdm {
             #[inline(always)]
             fn default() -> Pdmclkctrl {
                 Pdmclkctrl(0)
+            }
+        }
+        impl core::fmt::Debug for Pdmclkctrl {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pdmclkctrl")
+                    .field("freq", &self.freq())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pdmclkctrl {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pdmclkctrl {
+                    freq: super::vals::Freq,
+                }
+                let proxy = Pdmclkctrl { freq: self.freq() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects the ratio between PDM_CLK and output sample rate. Change PDMCLKCTRL accordingly."]
@@ -5457,10 +7937,31 @@ pub mod pdm {
                 Ratio(0)
             }
         }
+        impl core::fmt::Debug for Ratio {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Ratio")
+                    .field("ratio", &self.ratio())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Ratio {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Ratio {
+                    ratio: super::vals::Ratio,
+                }
+                let proxy = Ratio {
+                    ratio: self.ratio(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Edge {
             #[doc = "Left (or mono) is sampled on falling edge of PDM_CLK"]
             LEFT_FALLING = 0x0,
@@ -5514,6 +8015,33 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Freq {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0800_0000 => f.write_str("_1000K"),
+                    0x0840_0000 => f.write_str("DEFAULT"),
+                    0x0880_0000 => f.write_str("_1067K"),
+                    0x0980_0000 => f.write_str("_1231K"),
+                    0x0a00_0000 => f.write_str("_1280K"),
+                    0x0a80_0000 => f.write_str("_1333K"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Freq {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0800_0000 => defmt::write!(f, "_1000K"),
+                    0x0840_0000 => defmt::write!(f, "DEFAULT"),
+                    0x0880_0000 => defmt::write!(f, "_1067K"),
+                    0x0980_0000 => defmt::write!(f, "_1231K"),
+                    0x0a00_0000 => defmt::write!(f, "_1280K"),
+                    0x0a80_0000 => defmt::write!(f, "_1333K"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Freq {
             #[inline(always)]
             fn from(val: u32) -> Freq {
@@ -5545,6 +8073,27 @@ pub mod pdm {
                 self.0
             }
         }
+        impl core::fmt::Debug for Gain {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_GAIN"),
+                    0x28 => f.write_str("DEFAULT_GAIN"),
+                    0x50 => f.write_str("MAX_GAIN"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gain {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_GAIN"),
+                    0x28 => defmt::write!(f, "DEFAULT_GAIN"),
+                    0x50 => defmt::write!(f, "MAX_GAIN"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Gain {
             #[inline(always)]
             fn from(val: u8) -> Gain {
@@ -5558,7 +8107,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Operation {
             #[doc = "Sample and store one pair (left + right) of 16-bit samples per RAM word R=\\[31:16\\]; L=\\[15:0\\]"]
             STEREO = 0x0,
@@ -5588,7 +8138,8 @@ pub mod pdm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Ratio {
             #[doc = "Ratio of 64"]
             RATIO64 = 0x0,
@@ -5787,6 +8338,26 @@ pub mod power {
                 Forceoff(0)
             }
         }
+        impl core::fmt::Debug for Forceoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Forceoff")
+                    .field("forceoff", &self.forceoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Forceoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Forceoff {
+                    forceoff: super::vals::Forceoff,
+                }
+                let proxy = Forceoff {
+                    forceoff: self.forceoff(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: General purpose retention register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5808,6 +8379,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Gpregret {
                 Gpregret(0)
+            }
+        }
+        impl core::fmt::Debug for Gpregret {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Gpregret")
+                    .field("gpregret", &self.gpregret())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Gpregret {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Gpregret {
+                    gpregret: u8,
+                }
+                let proxy = Gpregret {
+                    gpregret: self.gpregret(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -5855,6 +8446,32 @@ pub mod power {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("pofwarn", &self.pofwarn())
+                    .field("sleepenter", &self.sleepenter())
+                    .field("sleepexit", &self.sleepexit())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    pofwarn: bool,
+                    sleepenter: bool,
+                    sleepexit: bool,
+                }
+                let proxy = Int {
+                    pofwarn: self.pofwarn(),
+                    sleepenter: self.sleepenter(),
+                    sleepexit: self.sleepexit(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Modem domain power status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5876,6 +8493,26 @@ pub mod power {
             #[inline(always)]
             fn default() -> Power {
                 Power(0)
+            }
+        }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field("ltemodem", &self.ltemodem())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    ltemodem: bool,
+                }
+                let proxy = Power {
+                    ltemodem: self.ltemodem(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Reset reason"]
@@ -5967,6 +8604,44 @@ pub mod power {
                 Resetreas(0)
             }
         }
+        impl core::fmt::Debug for Resetreas {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resetreas")
+                    .field("resetpin", &self.resetpin())
+                    .field("dog", &self.dog())
+                    .field("off", &self.off())
+                    .field("dif", &self.dif())
+                    .field("sreq", &self.sreq())
+                    .field("lockup", &self.lockup())
+                    .field("ctrlap", &self.ctrlap())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resetreas {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resetreas {
+                    resetpin: bool,
+                    dog: bool,
+                    off: bool,
+                    dif: bool,
+                    sreq: bool,
+                    lockup: bool,
+                    ctrlap: bool,
+                }
+                let proxy = Resetreas {
+                    resetpin: self.resetpin(),
+                    dog: self.dog(),
+                    off: self.off(),
+                    dif: self.dif(),
+                    sreq: self.sreq(),
+                    lockup: self.lockup(),
+                    ctrlap: self.ctrlap(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Start LTE modem"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -5990,10 +8665,31 @@ pub mod power {
                 Startn(0)
             }
         }
+        impl core::fmt::Debug for Startn {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Startn")
+                    .field("startn", &self.startn())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Startn {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Startn {
+                    startn: super::vals::Startn,
+                }
+                let proxy = Startn {
+                    startn: self.startn(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Forceoff {
             #[doc = "Release force off"]
             RELEASE = 0x0,
@@ -6023,7 +8719,8 @@ pub mod power {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Startn {
             #[doc = "Start LTE modem"]
             START = 0x0,
@@ -6329,6 +9026,22 @@ pub mod pwm {
                 Cnt(0)
             }
         }
+        impl core::fmt::Debug for Cnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cnt").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cnt {
+                    cnt: super::vals::CntCnt,
+                }
+                let proxy = Cnt { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Value up to which the pulse generator counter counts"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6350,6 +9063,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Countertop {
                 Countertop(0)
+            }
+        }
+        impl core::fmt::Debug for Countertop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Countertop")
+                    .field("countertop", &self.countertop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Countertop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Countertop {
+                    countertop: u16,
+                }
+                let proxy = Countertop {
+                    countertop: self.countertop(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Configuration of the decoder"]
@@ -6386,6 +9119,29 @@ pub mod pwm {
                 Decoder(0)
             }
         }
+        impl core::fmt::Debug for Decoder {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Decoder")
+                    .field("load", &self.load())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Decoder {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Decoder {
+                    load: super::vals::Load,
+                    mode: super::vals::Mode,
+                }
+                let proxy = Decoder {
+                    load: self.load(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "PWM module enable register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6407,6 +9163,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Time added after the sequence"]
@@ -6431,6 +9207,24 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Enddelay {
                 Enddelay(0)
+            }
+        }
+        impl core::fmt::Debug for Enddelay {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enddelay")
+                    .field("cnt", &self.cnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enddelay {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enddelay {
+                    cnt: u32,
+                }
+                let proxy = Enddelay { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -6522,6 +9316,44 @@ pub mod pwm {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("seqstarted0", &self.seqstarted0())
+                    .field("seqstarted1", &self.seqstarted1())
+                    .field("seqend0", &self.seqend0())
+                    .field("seqend1", &self.seqend1())
+                    .field("pwmperiodend", &self.pwmperiodend())
+                    .field("loopsdone", &self.loopsdone())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    seqstarted0: bool,
+                    seqstarted1: bool,
+                    seqend0: bool,
+                    seqend1: bool,
+                    pwmperiodend: bool,
+                    loopsdone: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    seqstarted0: self.seqstarted0(),
+                    seqstarted1: self.seqstarted1(),
+                    seqend0: self.seqend0(),
+                    seqend1: self.seqend1(),
+                    pwmperiodend: self.pwmperiodend(),
+                    loopsdone: self.loopsdone(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of playbacks of a loop"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6544,6 +9376,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Loop {
                 Loop(0)
+            }
+        }
+        impl core::fmt::Debug for Loop {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Loop").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Loop {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Loop {
+                    cnt: super::vals::LoopCnt,
+                }
+                let proxy = Loop { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Selects operating mode of the wave counter"]
@@ -6569,6 +9417,26 @@ pub mod pwm {
                 Mode(0)
             }
         }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode")
+                    .field("updown", &self.updown())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    updown: super::vals::Updown,
+                }
+                let proxy = Mode {
+                    updown: self.updown(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration for PWM_CLK"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6590,6 +9458,26 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: super::vals::Prescaler,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Number of additional PWM periods between samples loaded into compare register"]
@@ -6614,6 +9502,22 @@ pub mod pwm {
             #[inline(always)]
             fn default() -> Refresh {
                 Refresh(0)
+            }
+        }
+        impl core::fmt::Debug for Refresh {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Refresh").field("cnt", &self.cnt()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Refresh {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Refresh {
+                    cnt: super::vals::RefreshCnt,
+                }
+                let proxy = Refresh { cnt: self.cnt() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -6683,6 +9587,38 @@ pub mod pwm {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("seqend0_stop", &self.seqend0_stop())
+                    .field("seqend1_stop", &self.seqend1_stop())
+                    .field("loopsdone_seqstart0", &self.loopsdone_seqstart0())
+                    .field("loopsdone_seqstart1", &self.loopsdone_seqstart1())
+                    .field("loopsdone_stop", &self.loopsdone_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    seqend0_stop: bool,
+                    seqend1_stop: bool,
+                    loopsdone_seqstart0: bool,
+                    loopsdone_seqstart1: bool,
+                    loopsdone_stop: bool,
+                }
+                let proxy = Shorts {
+                    seqend0_stop: self.seqend0_stop(),
+                    seqend1_stop: self.seqend1_stop(),
+                    loopsdone_seqstart0: self.loopsdone_seqstart0(),
+                    loopsdone_seqstart1: self.loopsdone_seqstart1(),
+                    loopsdone_stop: self.loopsdone_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -6700,6 +9636,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for CntCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for CntCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for CntCnt {
             #[inline(always)]
             fn from(val: u16) -> CntCnt {
@@ -6713,7 +9666,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Load {
             #[doc = "1st half word (16-bit) used in all PWM channels 0..3"]
             COMMON = 0x0,
@@ -6761,6 +9715,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for LoopCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("DISABLED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for LoopCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "DISABLED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u16> for LoopCnt {
             #[inline(always)]
             fn from(val: u16) -> LoopCnt {
@@ -6774,7 +9745,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "SEQ\\[n\\].REFRESH is used to determine loading internal compare registers"]
             REFRESH_COUNT = 0x0,
@@ -6804,7 +9776,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Prescaler {
             #[doc = "Divide by 1 (16 MHz)"]
             DIV_1 = 0x0,
@@ -6860,6 +9833,23 @@ pub mod pwm {
                 self.0
             }
         }
+        impl core::fmt::Debug for RefreshCnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("CONTINUOUS"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RefreshCnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "CONTINUOUS"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for RefreshCnt {
             #[inline(always)]
             fn from(val: u32) -> RefreshCnt {
@@ -6873,7 +9863,8 @@ pub mod pwm {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Updown {
             #[doc = "Up counter, edge-aligned PWM duty cycle"]
             UP = 0x0,
@@ -6961,6 +9952,26 @@ pub mod regulators {
                 Dcdcen(0)
             }
         }
+        impl core::fmt::Debug for Dcdcen {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Dcdcen")
+                    .field("dcdcen", &self.dcdcen())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Dcdcen {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Dcdcen {
+                    dcdcen: bool,
+                }
+                let proxy = Dcdcen {
+                    dcdcen: self.dcdcen(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "External power failure warning configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -6984,6 +9995,24 @@ pub mod regulators {
                 Extpofcon(0)
             }
         }
+        impl core::fmt::Debug for Extpofcon {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Extpofcon")
+                    .field("pof", &self.pof())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Extpofcon {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Extpofcon {
+                    pof: bool,
+                }
+                let proxy = Extpofcon { pof: self.pof() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "System OFF register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7005,6 +10034,26 @@ pub mod regulators {
             #[inline(always)]
             fn default() -> Systemoff {
                 Systemoff(0)
+            }
+        }
+        impl core::fmt::Debug for Systemoff {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Systemoff")
+                    .field("systemoff", &self.systemoff())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Systemoff {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Systemoff {
+                    systemoff: bool,
+                }
+                let proxy = Systemoff {
+                    systemoff: self.systemoff(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7180,6 +10229,26 @@ pub mod rtc {
                 Cc(0)
             }
         }
+        impl core::fmt::Debug for Cc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cc")
+                    .field("compare", &self.compare())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cc {
+                    compare: u32,
+                }
+                let proxy = Cc {
+                    compare: self.compare(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Current counter value"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7202,6 +10271,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Counter {
                 Counter(0)
+            }
+        }
+        impl core::fmt::Debug for Counter {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Counter")
+                    .field("counter", &self.counter())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Counter {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Counter {
+                    counter: u32,
+                }
+                let proxy = Counter {
+                    counter: self.counter(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable event routing"]
@@ -7253,6 +10342,45 @@ pub mod rtc {
                 Evt(0)
             }
         }
+        impl core::fmt::Debug for Evt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Evt")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Evt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Evt {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Evt {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7302,6 +10430,45 @@ pub mod rtc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("tick", &self.tick())
+                    .field("ovrflw", &self.ovrflw())
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    tick: bool,
+                    ovrflw: bool,
+                    compare: [bool; 4usize],
+                }
+                let proxy = Int {
+                    tick: self.tick(),
+                    ovrflw: self.ovrflw(),
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "12-bit prescaler for counter frequency (32768/(PRESCALER+1)). Must be written when RTC is stopped."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7323,6 +10490,26 @@ pub mod rtc {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u16,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -7679,6 +10866,26 @@ pub mod saadc {
                 Amount(0)
             }
         }
+        impl core::fmt::Debug for Amount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Amount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Amount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Amount {
+                    amount: u16,
+                }
+                let proxy = Amount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input configuration for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7771,6 +10978,44 @@ pub mod saadc {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("resp", &self.resp())
+                    .field("resn", &self.resn())
+                    .field("gain", &self.gain())
+                    .field("refsel", &self.refsel())
+                    .field("tacq", &self.tacq())
+                    .field("mode", &self.mode())
+                    .field("burst", &self.burst())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    resp: super::vals::Resp,
+                    resn: super::vals::Resn,
+                    gain: super::vals::Gain,
+                    refsel: super::vals::Refsel,
+                    tacq: super::vals::Tacq,
+                    mode: super::vals::ConfigMode,
+                    burst: bool,
+                }
+                let proxy = Config {
+                    resp: self.resp(),
+                    resn: self.resn(),
+                    gain: self.gain(),
+                    refsel: self.refsel(),
+                    tacq: self.tacq(),
+                    mode: self.mode(),
+                    burst: self.burst(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable ADC"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7792,6 +11037,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -7902,6 +11167,89 @@ pub mod saadc {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("started", &self.started())
+                    .field("end", &self.end())
+                    .field("done", &self.done())
+                    .field("resultdone", &self.resultdone())
+                    .field("calibratedone", &self.calibratedone())
+                    .field("stopped", &self.stopped())
+                    .field(
+                        "chlimith",
+                        &[
+                            self.chlimith(0usize),
+                            self.chlimith(1usize),
+                            self.chlimith(2usize),
+                            self.chlimith(3usize),
+                            self.chlimith(4usize),
+                            self.chlimith(5usize),
+                            self.chlimith(6usize),
+                            self.chlimith(7usize),
+                        ],
+                    )
+                    .field(
+                        "chlimitl",
+                        &[
+                            self.chlimitl(0usize),
+                            self.chlimitl(1usize),
+                            self.chlimitl(2usize),
+                            self.chlimitl(3usize),
+                            self.chlimitl(4usize),
+                            self.chlimitl(5usize),
+                            self.chlimitl(6usize),
+                            self.chlimitl(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    started: bool,
+                    end: bool,
+                    done: bool,
+                    resultdone: bool,
+                    calibratedone: bool,
+                    stopped: bool,
+                    chlimith: [bool; 8usize],
+                    chlimitl: [bool; 8usize],
+                }
+                let proxy = Int {
+                    started: self.started(),
+                    end: self.end(),
+                    done: self.done(),
+                    resultdone: self.resultdone(),
+                    calibratedone: self.calibratedone(),
+                    stopped: self.stopped(),
+                    chlimith: [
+                        self.chlimith(0usize),
+                        self.chlimith(1usize),
+                        self.chlimith(2usize),
+                        self.chlimith(3usize),
+                        self.chlimith(4usize),
+                        self.chlimith(5usize),
+                        self.chlimith(6usize),
+                        self.chlimith(7usize),
+                    ],
+                    chlimitl: [
+                        self.chlimitl(0usize),
+                        self.chlimitl(1usize),
+                        self.chlimitl(2usize),
+                        self.chlimitl(3usize),
+                        self.chlimitl(4usize),
+                        self.chlimitl(5usize),
+                        self.chlimitl(6usize),
+                        self.chlimitl(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: High/low limits for event monitoring a channel"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7936,6 +11284,29 @@ pub mod saadc {
                 Limit(0)
             }
         }
+        impl core::fmt::Debug for Limit {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Limit")
+                    .field("low", &self.low())
+                    .field("high", &self.high())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Limit {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Limit {
+                    low: u16,
+                    high: u16,
+                }
+                let proxy = Limit {
+                    low: self.low(),
+                    high: self.high(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of buffer words to transfer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -7957,6 +11328,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Maxcnt {
                 Maxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for Maxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Maxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Maxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Maxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = Maxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oversampling configuration. OVERSAMPLE should not be combined with SCAN. The RESOLUTION is applied before averaging, thus for high OVERSAMPLE a higher RESOLUTION should be used."]
@@ -7982,6 +11373,26 @@ pub mod saadc {
                 Oversample(0)
             }
         }
+        impl core::fmt::Debug for Oversample {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oversample")
+                    .field("oversample", &self.oversample())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oversample {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oversample {
+                    oversample: super::vals::Oversample,
+                }
+                let proxy = Oversample {
+                    oversample: self.oversample(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Input negative pin selection for CH\\[n\\]"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8003,6 +11414,26 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Pseln {
                 Pseln(0)
+            }
+        }
+        impl core::fmt::Debug for Pseln {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pseln")
+                    .field("pseln", &self.pseln())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pseln {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pseln {
+                    pseln: super::vals::Psel,
+                }
+                let proxy = Pseln {
+                    pseln: self.pseln(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Input positive pin selection for CH\\[n\\]"]
@@ -8028,6 +11459,26 @@ pub mod saadc {
                 Pselp(0)
             }
         }
+        impl core::fmt::Debug for Pselp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Pselp")
+                    .field("pselp", &self.pselp())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Pselp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Pselp {
+                    pselp: super::vals::Psel,
+                }
+                let proxy = Pselp {
+                    pselp: self.pselp(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Resolution configuration"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8049,6 +11500,24 @@ pub mod saadc {
             #[inline(always)]
             fn default() -> Resolution {
                 Resolution(0)
+            }
+        }
+        impl core::fmt::Debug for Resolution {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Resolution")
+                    .field("val", &self.val())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Resolution {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Resolution {
+                    val: super::vals::Val,
+                }
+                let proxy = Resolution { val: self.val() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Controls normal or continuous sample rate"]
@@ -8086,6 +11555,29 @@ pub mod saadc {
                 Samplerate(0)
             }
         }
+        impl core::fmt::Debug for Samplerate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Samplerate")
+                    .field("cc", &self.cc())
+                    .field("mode", &self.mode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Samplerate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Samplerate {
+                    cc: u16,
+                    mode: super::vals::SamplerateMode,
+                }
+                let proxy = Samplerate {
+                    cc: self.cc(),
+                    mode: self.mode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8109,10 +11601,31 @@ pub mod saadc {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("status", &self.status())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    status: super::vals::Status,
+                }
+                let proxy = Status {
+                    status: self.status(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigMode {
             #[doc = "Single ended, PSELN will be ignored, negative input to ADC shorted to GND"]
             SE = 0x0,
@@ -8142,7 +11655,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Gain {
             #[doc = "1/6"]
             GAIN1_6 = 0x0,
@@ -8184,7 +11698,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Oversample {
             #[doc = "Bypass oversampling"]
             BYPASS = 0x0,
@@ -8235,7 +11750,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Psel {
             #[doc = "Not connected"]
             NC = 0x0,
@@ -8303,7 +11819,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Refsel {
             #[doc = "Internal reference (0.6 V)"]
             INTERNAL = 0x0,
@@ -8333,7 +11850,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resn {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -8367,7 +11885,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Resp {
             #[doc = "Bypass resistor ladder"]
             BYPASS = 0x0,
@@ -8401,7 +11920,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SamplerateMode {
             #[doc = "Rate is controlled from SAMPLE task"]
             TASK = 0x0,
@@ -8431,7 +11951,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Status {
             #[doc = "ADC is ready. No on-going conversion."]
             READY = 0x0,
@@ -8461,7 +11982,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tacq {
             #[doc = "3 us"]
             _3US = 0x0,
@@ -8501,7 +12023,8 @@ pub mod saadc {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Val {
             #[doc = "8 bit"]
             _8BIT = 0x0,
@@ -8577,6 +12100,29 @@ pub mod shared {
                 Psel(0)
             }
         }
+        impl core::fmt::Debug for Psel {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Psel")
+                    .field("pin", &self.pin())
+                    .field("connect", &self.connect())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Psel {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Psel {
+                    pin: u8,
+                    connect: super::vals::Connect,
+                }
+                let proxy = Psel {
+                    pin: self.pin(),
+                    connect: self.connect(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Publish configuration for event HFCLKSTARTED"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -8607,6 +12153,29 @@ pub mod shared {
             #[inline(always)]
             fn default() -> Publish {
                 Publish(0)
+            }
+        }
+        impl core::fmt::Debug for Publish {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Publish")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Publish {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Publish {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Publish {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Subscribe configuration for task HFCLKSTART"]
@@ -8641,10 +12210,34 @@ pub mod shared {
                 Subscribe(0)
             }
         }
+        impl core::fmt::Debug for Subscribe {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Subscribe")
+                    .field("chidx", &self.chidx())
+                    .field("en", &self.en())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Subscribe {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Subscribe {
+                    chidx: u8,
+                    en: bool,
+                }
+                let proxy = Subscribe {
+                    chidx: self.chidx(),
+                    en: self.en(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Connect {
             #[doc = "Connect"]
             CONNECTED = 0x0,
@@ -9007,6 +12600,32 @@ pub mod spim {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9028,6 +12647,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "SPI frequency. Accuracy depends on the HFCLK source selected."]
@@ -9052,6 +12691,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -9121,6 +12780,38 @@ pub mod spim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("endrx", &self.endrx())
+                    .field("end", &self.end())
+                    .field("endtx", &self.endtx())
+                    .field("started", &self.started())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    endrx: bool,
+                    end: bool,
+                    endtx: bool,
+                    started: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    endrx: self.endrx(),
+                    end: self.end(),
+                    endtx: self.endtx(),
+                    started: self.started(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character. Character clocked out in case an over-read of the TXD buffer."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9142,6 +12833,22 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -9167,6 +12874,26 @@ pub mod spim {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9188,6 +12915,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -9213,6 +12958,26 @@ pub mod spim {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9234,6 +12999,26 @@ pub mod spim {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_start", &self.end_start())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_start: bool,
+                }
+                let proxy = Shorts {
+                    end_start: self.end_start(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes transferred in the last transaction"]
@@ -9259,6 +13044,26 @@ pub mod spim {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9280,6 +13085,24 @@ pub mod spim {
             #[inline(always)]
             fn default() -> TxdList {
                 TxdList(0)
+            }
+        }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in transmit buffer"]
@@ -9305,10 +13128,31 @@ pub mod spim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -9338,7 +13182,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -9368,7 +13213,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPIM"]
             DISABLED = 0x0,
@@ -9438,6 +13284,35 @@ pub mod spim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0200_0000 => f.write_str("K125"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0800_0000 => f.write_str("K500"),
+                    0x1000_0000 => f.write_str("M1"),
+                    0x2000_0000 => f.write_str("M2"),
+                    0x4000_0000 => f.write_str("M4"),
+                    0x8000_0000 => f.write_str("M8"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0200_0000 => defmt::write!(f, "K125"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0800_0000 => defmt::write!(f, "K500"),
+                    0x1000_0000 => defmt::write!(f, "M1"),
+                    0x2000_0000 => defmt::write!(f, "M2"),
+                    0x4000_0000 => defmt::write!(f, "M4"),
+                    0x8000_0000 => defmt::write!(f, "M8"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -9451,7 +13326,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -9481,7 +13357,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -9513,7 +13390,8 @@ pub mod spim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -9845,6 +13723,32 @@ pub mod spis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("order", &self.order())
+                    .field("cpha", &self.cpha())
+                    .field("cpol", &self.cpol())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    order: super::vals::Order,
+                    cpha: super::vals::Cpha,
+                    cpol: super::vals::Cpol,
+                }
+                let proxy = Config {
+                    order: self.order(),
+                    cpha: self.cpha(),
+                    cpol: self.cpol(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Default character. Character clocked out in case of an ignored transaction."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9868,6 +13772,22 @@ pub mod spis {
                 Def(0)
             }
         }
+        impl core::fmt::Debug for Def {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Def").field("def", &self.def()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Def {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Def {
+                    def: u8,
+                }
+                let proxy = Def { def: self.def() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable SPI slave"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9889,6 +13809,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Disable interrupt"]
@@ -9936,6 +13876,32 @@ pub mod spis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("end", &self.end())
+                    .field("endrx", &self.endrx())
+                    .field("acquired", &self.acquired())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    end: bool,
+                    endrx: bool,
+                    acquired: bool,
+                }
+                let proxy = Int {
+                    end: self.end(),
+                    endrx: self.endrx(),
+                    acquired: self.acquired(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Over-read character"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -9957,6 +13923,22 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Orc {
                 Orc(0)
+            }
+        }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Number of bytes received in last granted transaction"]
@@ -9982,6 +13964,26 @@ pub mod spis {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "EasyDMA list type"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10003,6 +14005,24 @@ pub mod spis {
             #[inline(always)]
             fn default() -> RxdList {
                 RxdList(0)
+            }
+        }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Maximum number of bytes in receive buffer"]
@@ -10028,6 +14048,26 @@ pub mod spis {
                 RxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Semaphore status register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10051,6 +14091,26 @@ pub mod spis {
                 Semstat(0)
             }
         }
+        impl core::fmt::Debug for Semstat {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Semstat")
+                    .field("semstat", &self.semstat())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Semstat {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Semstat {
+                    semstat: super::vals::Semstat,
+                }
+                let proxy = Semstat {
+                    semstat: self.semstat(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Shortcuts between local events and tasks"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10072,6 +14132,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> Shorts {
                 Shorts(0)
+            }
+        }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("end_acquire", &self.end_acquire())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    end_acquire: bool,
+                }
+                let proxy = Shorts {
+                    end_acquire: self.end_acquire(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Status from last transaction"]
@@ -10108,6 +14188,29 @@ pub mod spis {
                 Status(0)
             }
         }
+        impl core::fmt::Debug for Status {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Status")
+                    .field("overread", &self.overread())
+                    .field("overflow", &self.overflow())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Status {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Status {
+                    overread: bool,
+                    overflow: bool,
+                }
+                let proxy = Status {
+                    overread: self.overread(),
+                    overflow: self.overflow(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transmitted in last granted transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10129,6 +14232,26 @@ pub mod spis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -10154,6 +14277,24 @@ pub mod spis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10177,10 +14318,31 @@ pub mod spis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpha {
             #[doc = "Sample on leading edge of clock, shift serial data on trailing edge"]
             LEADING = 0x0,
@@ -10210,7 +14372,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Cpol {
             #[doc = "Active high"]
             ACTIVE_HIGH = 0x0,
@@ -10240,7 +14403,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable SPI slave"]
             DISABLED = 0x0,
@@ -10284,7 +14448,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Order {
             #[doc = "Most significant bit shifted out first"]
             MSB_FIRST = 0x0,
@@ -10314,7 +14479,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -10346,7 +14512,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Semstat {
             #[doc = "Semaphore is free"]
             FREE = 0x0,
@@ -10380,7 +14547,8 @@ pub mod spis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -10755,6 +14923,22 @@ pub mod spu {
                 Cap(0)
             }
         }
+        impl core::fmt::Debug for Cap {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Cap").field("tzm", &self.tzm()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Cap {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Cap {
+                    tzm: super::vals::Tzm,
+                }
+                let proxy = Cap { tzm: self.tzm() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -10774,6 +14958,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> DppiLock {
                 DppiLock(0)
+            }
+        }
+        impl core::fmt::Debug for DppiLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiLock {
+                    lock: bool,
+                }
+                let proxy = DppiLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for the DPPI channels."]
@@ -10964,6 +15166,71 @@ pub mod spu {
                 DppiPerm(0)
             }
         }
+        impl core::fmt::Debug for DppiPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("DppiPerm")
+                    .field("channel0", &self.channel0())
+                    .field("channel1", &self.channel1())
+                    .field("channel2", &self.channel2())
+                    .field("channel3", &self.channel3())
+                    .field("channel4", &self.channel4())
+                    .field("channel5", &self.channel5())
+                    .field("channel6", &self.channel6())
+                    .field("channel7", &self.channel7())
+                    .field("channel8", &self.channel8())
+                    .field("channel9", &self.channel9())
+                    .field("channel10", &self.channel10())
+                    .field("channel11", &self.channel11())
+                    .field("channel12", &self.channel12())
+                    .field("channel13", &self.channel13())
+                    .field("channel14", &self.channel14())
+                    .field("channel15", &self.channel15())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for DppiPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct DppiPerm {
+                    channel0: bool,
+                    channel1: bool,
+                    channel2: bool,
+                    channel3: bool,
+                    channel4: bool,
+                    channel5: bool,
+                    channel6: bool,
+                    channel7: bool,
+                    channel8: bool,
+                    channel9: bool,
+                    channel10: bool,
+                    channel11: bool,
+                    channel12: bool,
+                    channel13: bool,
+                    channel14: bool,
+                    channel15: bool,
+                }
+                let proxy = DppiPerm {
+                    channel0: self.channel0(),
+                    channel1: self.channel1(),
+                    channel2: self.channel2(),
+                    channel3: self.channel3(),
+                    channel4: self.channel4(),
+                    channel5: self.channel5(),
+                    channel6: self.channel6(),
+                    channel7: self.channel7(),
+                    channel8: self.channel8(),
+                    channel9: self.channel9(),
+                    channel10: self.channel10(),
+                    channel11: self.channel11(),
+                    channel12: self.channel12(),
+                    channel13: self.channel13(),
+                    channel14: self.channel14(),
+                    channel15: self.channel15(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Access for bus access generated from the external domain n List capabilities of the external domain n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11007,6 +15274,32 @@ pub mod spu {
                 ExtdomainPerm(0)
             }
         }
+        impl core::fmt::Debug for ExtdomainPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("ExtdomainPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ExtdomainPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct ExtdomainPerm {
+                    securemapping: super::vals::ExtdomainPermSecuremapping,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = ExtdomainPerm {
+                    securemapping: self.securemapping(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which flash region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11039,6 +15332,29 @@ pub mod spu {
                 FlashnscRegion(0)
             }
         }
+        impl core::fmt::Debug for FlashnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = FlashnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11069,6 +15385,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> FlashnscSize {
                 FlashnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for FlashnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashnscSize {
+                    size: super::vals::FlashnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = FlashnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for flash region n"]
@@ -11136,6 +15475,38 @@ pub mod spu {
                 FlashregionPerm(0)
             }
         }
+        impl core::fmt::Debug for FlashregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("FlashregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for FlashregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct FlashregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = FlashregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Prevent further modification of the corresponding PERM register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11155,6 +15526,24 @@ pub mod spu {
             #[inline(always)]
             fn default() -> GpioportLock {
                 GpioportLock(0)
+            }
+        }
+        impl core::fmt::Debug for GpioportLock {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportLock")
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportLock {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportLock {
+                    lock: bool,
+                }
+                let proxy = GpioportLock { lock: self.lock() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Select between secure and non-secure attribute for pins 0 to 31 of port n."]
@@ -11521,6 +15910,119 @@ pub mod spu {
                 GpioportPerm(0)
             }
         }
+        impl core::fmt::Debug for GpioportPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("GpioportPerm")
+                    .field("pin0", &self.pin0())
+                    .field("pin1", &self.pin1())
+                    .field("pin2", &self.pin2())
+                    .field("pin3", &self.pin3())
+                    .field("pin4", &self.pin4())
+                    .field("pin5", &self.pin5())
+                    .field("pin6", &self.pin6())
+                    .field("pin7", &self.pin7())
+                    .field("pin8", &self.pin8())
+                    .field("pin9", &self.pin9())
+                    .field("pin10", &self.pin10())
+                    .field("pin11", &self.pin11())
+                    .field("pin12", &self.pin12())
+                    .field("pin13", &self.pin13())
+                    .field("pin14", &self.pin14())
+                    .field("pin15", &self.pin15())
+                    .field("pin16", &self.pin16())
+                    .field("pin17", &self.pin17())
+                    .field("pin18", &self.pin18())
+                    .field("pin19", &self.pin19())
+                    .field("pin20", &self.pin20())
+                    .field("pin21", &self.pin21())
+                    .field("pin22", &self.pin22())
+                    .field("pin23", &self.pin23())
+                    .field("pin24", &self.pin24())
+                    .field("pin25", &self.pin25())
+                    .field("pin26", &self.pin26())
+                    .field("pin27", &self.pin27())
+                    .field("pin28", &self.pin28())
+                    .field("pin29", &self.pin29())
+                    .field("pin30", &self.pin30())
+                    .field("pin31", &self.pin31())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for GpioportPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct GpioportPerm {
+                    pin0: bool,
+                    pin1: bool,
+                    pin2: bool,
+                    pin3: bool,
+                    pin4: bool,
+                    pin5: bool,
+                    pin6: bool,
+                    pin7: bool,
+                    pin8: bool,
+                    pin9: bool,
+                    pin10: bool,
+                    pin11: bool,
+                    pin12: bool,
+                    pin13: bool,
+                    pin14: bool,
+                    pin15: bool,
+                    pin16: bool,
+                    pin17: bool,
+                    pin18: bool,
+                    pin19: bool,
+                    pin20: bool,
+                    pin21: bool,
+                    pin22: bool,
+                    pin23: bool,
+                    pin24: bool,
+                    pin25: bool,
+                    pin26: bool,
+                    pin27: bool,
+                    pin28: bool,
+                    pin29: bool,
+                    pin30: bool,
+                    pin31: bool,
+                }
+                let proxy = GpioportPerm {
+                    pin0: self.pin0(),
+                    pin1: self.pin1(),
+                    pin2: self.pin2(),
+                    pin3: self.pin3(),
+                    pin4: self.pin4(),
+                    pin5: self.pin5(),
+                    pin6: self.pin6(),
+                    pin7: self.pin7(),
+                    pin8: self.pin8(),
+                    pin9: self.pin9(),
+                    pin10: self.pin10(),
+                    pin11: self.pin11(),
+                    pin12: self.pin12(),
+                    pin13: self.pin13(),
+                    pin14: self.pin14(),
+                    pin15: self.pin15(),
+                    pin16: self.pin16(),
+                    pin17: self.pin17(),
+                    pin18: self.pin18(),
+                    pin19: self.pin19(),
+                    pin20: self.pin20(),
+                    pin21: self.pin21(),
+                    pin22: self.pin22(),
+                    pin23: self.pin23(),
+                    pin24: self.pin24(),
+                    pin25: self.pin25(),
+                    pin26: self.pin26(),
+                    pin27: self.pin27(),
+                    pin28: self.pin28(),
+                    pin29: self.pin29(),
+                    pin30: self.pin30(),
+                    pin31: self.pin31(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable or disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11564,6 +16066,32 @@ pub mod spu {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("ramaccerr", &self.ramaccerr())
+                    .field("flashaccerr", &self.flashaccerr())
+                    .field("periphaccerr", &self.periphaccerr())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    ramaccerr: bool,
+                    flashaccerr: bool,
+                    periphaccerr: bool,
+                }
+                let proxy = Int {
+                    ramaccerr: self.ramaccerr(),
+                    flashaccerr: self.flashaccerr(),
+                    periphaccerr: self.periphaccerr(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: List capabilities and access permissions for the peripheral with ID n"]
@@ -11643,6 +16171,41 @@ pub mod spu {
                 PeriphidPerm(0)
             }
         }
+        impl core::fmt::Debug for PeriphidPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("PeriphidPerm")
+                    .field("securemapping", &self.securemapping())
+                    .field("dma", &self.dma())
+                    .field("secattr", &self.secattr())
+                    .field("dmasec", &self.dmasec())
+                    .field("lock", &self.lock())
+                    .field("present", &self.present())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PeriphidPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct PeriphidPerm {
+                    securemapping: super::vals::PeriphidPermSecuremapping,
+                    dma: super::vals::Dma,
+                    secattr: bool,
+                    dmasec: bool,
+                    lock: bool,
+                    present: super::vals::Present,
+                }
+                let proxy = PeriphidPerm {
+                    securemapping: self.securemapping(),
+                    dma: self.dma(),
+                    secattr: self.secattr(),
+                    dmasec: self.dmasec(),
+                    lock: self.lock(),
+                    present: self.present(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define which RAM region can contain the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11675,6 +16238,29 @@ pub mod spu {
                 RamnscRegion(0)
             }
         }
+        impl core::fmt::Debug for RamnscRegion {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscRegion")
+                    .field("region", &self.region())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscRegion {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscRegion {
+                    region: u8,
+                    lock: bool,
+                }
+                let proxy = RamnscRegion {
+                    region: self.region(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description cluster: Define the size of the non-secure callable (NSC) region n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11705,6 +16291,29 @@ pub mod spu {
             #[inline(always)]
             fn default() -> RamnscSize {
                 RamnscSize(0)
+            }
+        }
+        impl core::fmt::Debug for RamnscSize {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamnscSize")
+                    .field("size", &self.size())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamnscSize {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamnscSize {
+                    size: super::vals::RamnscSizeSize,
+                    lock: bool,
+                }
+                let proxy = RamnscSize {
+                    size: self.size(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Access permissions for RAM region n"]
@@ -11772,10 +16381,43 @@ pub mod spu {
                 RamregionPerm(0)
             }
         }
+        impl core::fmt::Debug for RamregionPerm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RamregionPerm")
+                    .field("execute", &self.execute())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("secattr", &self.secattr())
+                    .field("lock", &self.lock())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RamregionPerm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RamregionPerm {
+                    execute: bool,
+                    write: bool,
+                    read: bool,
+                    secattr: bool,
+                    lock: bool,
+                }
+                let proxy = RamregionPerm {
+                    execute: self.execute(),
+                    write: self.write(),
+                    read: self.read(),
+                    secattr: self.secattr(),
+                    lock: self.lock(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Dma {
             #[doc = "Peripheral has no DMA capability"]
             NO_DMA = 0x0,
@@ -11808,7 +16450,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ExtdomainPermSecuremapping {
             #[doc = "The bus access from this external domain always have the non-secure attribute set"]
             NON_SECURE = 0x0,
@@ -11841,7 +16484,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum FlashnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -11892,7 +16536,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PeriphidPermSecuremapping {
             #[doc = "This peripheral is always accessible as a non-secure peripheral"]
             NON_SECURE = 0x0,
@@ -11926,7 +16571,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Present {
             #[doc = "Peripheral is not present"]
             NOT_PRESENT = 0x0,
@@ -11956,7 +16602,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RamnscSizeSize {
             #[doc = "The region n is not defined as a non-secure callable region. Normal security attributes (secure or non-secure) are enforced."]
             DISABLED = 0x0,
@@ -12007,7 +16654,8 @@ pub mod spu {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Tzm {
             #[doc = "ARM TrustZone support not available"]
             NOT_AVAILABLE = 0x0,
@@ -12157,6 +16805,26 @@ pub mod tad {
                 Enable(0)
             }
         }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: bool,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Clocking options for the Trace Port debug interface Reset behavior is the same as debug components"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12180,6 +16848,26 @@ pub mod tad {
                 Traceportspeed(0)
             }
         }
+        impl core::fmt::Debug for Traceportspeed {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Traceportspeed")
+                    .field("traceportspeed", &self.traceportspeed())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Traceportspeed {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Traceportspeed {
+                    traceportspeed: super::vals::Traceportspeed,
+                }
+                let proxy = Traceportspeed {
+                    traceportspeed: self.traceportspeed(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -12195,6 +16883,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTraceclkPin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x15 => f.write_str("TRACECLK"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTraceclkPin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x15 => defmt::write!(f, "TRACECLK"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTraceclkPin {
@@ -12224,6 +16929,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata0Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x16 => f.write_str("TRACEDATA0"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata0Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x16 => defmt::write!(f, "TRACEDATA0"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata0Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata0Pin {
@@ -12249,6 +16971,23 @@ pub mod tad {
             }
             pub const fn to_bits(self) -> u8 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for PselTracedata1Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x17 => f.write_str("TRACEDATA1"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata1Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x17 => defmt::write!(f, "TRACEDATA1"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u8> for PselTracedata1Pin {
@@ -12278,6 +17017,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata2Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x18 => f.write_str("TRACEDATA2"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata2Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x18 => defmt::write!(f, "TRACEDATA2"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata2Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata2Pin {
@@ -12305,6 +17061,23 @@ pub mod tad {
                 self.0
             }
         }
+        impl core::fmt::Debug for PselTracedata3Pin {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x19 => f.write_str("TRACEDATA3"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for PselTracedata3Pin {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x19 => defmt::write!(f, "TRACEDATA3"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for PselTracedata3Pin {
             #[inline(always)]
             fn from(val: u8) -> PselTracedata3Pin {
@@ -12318,7 +17091,8 @@ pub mod tad {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Traceportspeed {
             #[doc = "Trace Port clock is: 32MHz"]
             _32MHZ = 0x0,
@@ -12530,6 +17304,26 @@ pub mod timer {
                 Bitmode(0)
             }
         }
+        impl core::fmt::Debug for Bitmode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Bitmode")
+                    .field("bitmode", &self.bitmode())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Bitmode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Bitmode {
+                    bitmode: super::vals::Bitmode,
+                }
+                let proxy = Bitmode {
+                    bitmode: self.bitmode(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12557,6 +17351,43 @@ pub mod timer {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field(
+                        "compare",
+                        &[
+                            self.compare(0usize),
+                            self.compare(1usize),
+                            self.compare(2usize),
+                            self.compare(3usize),
+                            self.compare(4usize),
+                            self.compare(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    compare: [bool; 6usize],
+                }
+                let proxy = Int {
+                    compare: [
+                        self.compare(0usize),
+                        self.compare(1usize),
+                        self.compare(2usize),
+                        self.compare(3usize),
+                        self.compare(4usize),
+                        self.compare(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer mode selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12578,6 +17409,22 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Mode {
                 Mode(0)
+            }
+        }
+        impl core::fmt::Debug for Mode {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Mode").field("mode", &self.mode()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Mode {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Mode {
+                    mode: super::vals::Mode,
+                }
+                let proxy = Mode { mode: self.mode() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: Enable one-shot operation for Capture/Compare channel n"]
@@ -12603,6 +17450,26 @@ pub mod timer {
                 Oneshoten(0)
             }
         }
+        impl core::fmt::Debug for Oneshoten {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Oneshoten")
+                    .field("oneshoten", &self.oneshoten())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Oneshoten {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Oneshoten {
+                    oneshoten: bool,
+                }
+                let proxy = Oneshoten {
+                    oneshoten: self.oneshoten(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Timer prescaler register"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -12624,6 +17491,26 @@ pub mod timer {
             #[inline(always)]
             fn default() -> Prescaler {
                 Prescaler(0)
+            }
+        }
+        impl core::fmt::Debug for Prescaler {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Prescaler")
+                    .field("prescaler", &self.prescaler())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Prescaler {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Prescaler {
+                    prescaler: u8,
+                }
+                let proxy = Prescaler {
+                    prescaler: self.prescaler(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -12668,10 +17555,68 @@ pub mod timer {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field(
+                        "compare_clear",
+                        &[
+                            self.compare_clear(0usize),
+                            self.compare_clear(1usize),
+                            self.compare_clear(2usize),
+                            self.compare_clear(3usize),
+                            self.compare_clear(4usize),
+                            self.compare_clear(5usize),
+                        ],
+                    )
+                    .field(
+                        "compare_stop",
+                        &[
+                            self.compare_stop(0usize),
+                            self.compare_stop(1usize),
+                            self.compare_stop(2usize),
+                            self.compare_stop(3usize),
+                            self.compare_stop(4usize),
+                            self.compare_stop(5usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    compare_clear: [bool; 6usize],
+                    compare_stop: [bool; 6usize],
+                }
+                let proxy = Shorts {
+                    compare_clear: [
+                        self.compare_clear(0usize),
+                        self.compare_clear(1usize),
+                        self.compare_clear(2usize),
+                        self.compare_clear(3usize),
+                        self.compare_clear(4usize),
+                        self.compare_clear(5usize),
+                    ],
+                    compare_stop: [
+                        self.compare_stop(0usize),
+                        self.compare_stop(1usize),
+                        self.compare_stop(2usize),
+                        self.compare_stop(3usize),
+                        self.compare_stop(4usize),
+                        self.compare_stop(5usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Bitmode {
             #[doc = "16 bit timer bit width"]
             _16BIT = 0x0,
@@ -12705,7 +17650,8 @@ pub mod timer {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Mode {
             #[doc = "Select Timer mode"]
             TIMER = 0x0,
@@ -13081,6 +18027,26 @@ pub mod twim {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIM"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13102,6 +18068,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -13149,6 +18135,32 @@ pub mod twim {
                 Errorsrc(0)
             }
         }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("anack", &self.anack())
+                    .field("dnack", &self.dnack())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    anack: bool,
+                    dnack: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    anack: self.anack(),
+                    dnack: self.dnack(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "TWI frequency. Accuracy depends on the HFCLK source selected."]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13171,6 +18183,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> Frequency {
                 Frequency(0)
+            }
+        }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Frequency")
+                    .field("frequency", &self.frequency())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Frequency {
+                    frequency: super::vals::Frequency,
+                }
+                let proxy = Frequency {
+                    frequency: self.frequency(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -13262,6 +18294,44 @@ pub mod twim {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("suspended", &self.suspended())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("lastrx", &self.lastrx())
+                    .field("lasttx", &self.lasttx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    suspended: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    lastrx: bool,
+                    lasttx: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    suspended: self.suspended(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    lastrx: self.lastrx(),
+                    lasttx: self.lasttx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13283,6 +18353,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13308,6 +18398,24 @@ pub mod twim {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13329,6 +18437,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -13409,6 +18537,41 @@ pub mod twim {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("lasttx_startrx", &self.lasttx_startrx())
+                    .field("lasttx_suspend", &self.lasttx_suspend())
+                    .field("lasttx_stop", &self.lasttx_stop())
+                    .field("lastrx_starttx", &self.lastrx_starttx())
+                    .field("lastrx_suspend", &self.lastrx_suspend())
+                    .field("lastrx_stop", &self.lastrx_stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    lasttx_startrx: bool,
+                    lasttx_suspend: bool,
+                    lasttx_stop: bool,
+                    lastrx_starttx: bool,
+                    lastrx_suspend: bool,
+                    lastrx_stop: bool,
+                }
+                let proxy = Shorts {
+                    lasttx_startrx: self.lasttx_startrx(),
+                    lasttx_suspend: self.lasttx_suspend(),
+                    lasttx_stop: self.lasttx_stop(),
+                    lastrx_starttx: self.lastrx_starttx(),
+                    lastrx_suspend: self.lastrx_suspend(),
+                    lastrx_stop: self.lastrx_stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13430,6 +18593,26 @@ pub mod twim {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -13455,6 +18638,24 @@ pub mod twim {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13478,10 +18679,31 @@ pub mod twim {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIM"]
             DISABLED = 0x0,
@@ -13543,6 +18765,27 @@ pub mod twim {
                 self.0
             }
         }
+        impl core::fmt::Debug for Frequency {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0198_0000 => f.write_str("K100"),
+                    0x0400_0000 => f.write_str("K250"),
+                    0x0640_0000 => f.write_str("K400"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Frequency {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0198_0000 => defmt::write!(f, "K100"),
+                    0x0400_0000 => defmt::write!(f, "K250"),
+                    0x0640_0000 => defmt::write!(f, "K400"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Frequency {
             #[inline(always)]
             fn from(val: u32) -> Frequency {
@@ -13556,7 +18799,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13588,7 +18832,8 @@ pub mod twim {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -13965,6 +19210,26 @@ pub mod twis {
                 Address(0)
             }
         }
+        impl core::fmt::Debug for Address {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Address")
+                    .field("address", &self.address())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Address {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Address {
+                    address: u8,
+                }
+                let proxy = Address {
+                    address: self.address(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration register for the address match mechanism"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -13999,6 +19264,29 @@ pub mod twis {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("address0", &self.address0())
+                    .field("address1", &self.address1())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    address0: bool,
+                    address1: bool,
+                }
+                let proxy = Config {
+                    address0: self.address0(),
+                    address1: self.address1(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable TWIS"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14020,6 +19308,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source"]
@@ -14065,6 +19373,32 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overflow", &self.overflow())
+                    .field("dnack", &self.dnack())
+                    .field("overread", &self.overread())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overflow: bool,
+                    dnack: bool,
+                    overread: bool,
+                }
+                let proxy = Errorsrc {
+                    overflow: self.overflow(),
+                    dnack: self.dnack(),
+                    overread: self.overread(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -14145,6 +19479,41 @@ pub mod twis {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("stopped", &self.stopped())
+                    .field("error", &self.error())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    stopped: bool,
+                    error: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    write: bool,
+                    read: bool,
+                }
+                let proxy = Int {
+                    stopped: self.stopped(),
+                    error: self.error(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    write: self.write(),
+                    read: self.read(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Status register indicating which address had a match"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14166,6 +19535,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> Match {
                 Match(0)
+            }
+        }
+        impl core::fmt::Debug for Match {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Match")
+                    .field("match_", &self.match_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Match {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Match {
+                    match_: bool,
+                }
+                let proxy = Match {
+                    match_: self.match_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Over-read character. Character sent out in case of an over-read of the transmit buffer."]
@@ -14191,6 +19580,22 @@ pub mod twis {
                 Orc(0)
             }
         }
+        impl core::fmt::Debug for Orc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Orc").field("orc", &self.orc()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Orc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Orc {
+                    orc: u8,
+                }
+                let proxy = Orc { orc: self.orc() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last RXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14212,6 +19617,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdAmount {
                 RxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14237,6 +19662,24 @@ pub mod twis {
                 RxdList(0)
             }
         }
+        impl core::fmt::Debug for RxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdList {
+                    list: super::vals::RxdListList,
+                }
+                let proxy = RxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in RXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14258,6 +19701,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -14294,6 +19757,29 @@ pub mod twis {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("write_suspend", &self.write_suspend())
+                    .field("read_suspend", &self.read_suspend())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    write_suspend: bool,
+                    read_suspend: bool,
+                }
+                let proxy = Shorts {
+                    write_suspend: self.write_suspend(),
+                    read_suspend: self.read_suspend(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last TXD transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14315,6 +19801,26 @@ pub mod twis {
             #[inline(always)]
             fn default() -> TxdAmount {
                 TxdAmount(0)
+            }
+        }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "EasyDMA list type"]
@@ -14340,6 +19846,24 @@ pub mod twis {
                 TxdList(0)
             }
         }
+        impl core::fmt::Debug for TxdList {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdList")
+                    .field("list", &self.list())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdList {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdList {
+                    list: super::vals::TxdListList,
+                }
+                let proxy = TxdList { list: self.list() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in TXD buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14363,10 +19887,31 @@ pub mod twis {
                 TxdMaxcnt(0)
             }
         }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable TWIS"]
             DISABLED = 0x0,
@@ -14410,7 +19955,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14442,7 +19988,8 @@ pub mod twis {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TxdListList {
             #[doc = "Disable EasyDMA list"]
             DISABLED = 0x0,
@@ -14866,6 +20413,26 @@ pub mod uarte {
                 Baudrate(0)
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Baudrate")
+                    .field("baudrate", &self.baudrate())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Baudrate {
+                    baudrate: super::vals::Baudrate,
+                }
+                let proxy = Baudrate {
+                    baudrate: self.baudrate(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Configuration of parity and hardware flow control"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14911,6 +20478,32 @@ pub mod uarte {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("hwfc", &self.hwfc())
+                    .field("parity", &self.parity())
+                    .field("stop", &self.stop())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    hwfc: bool,
+                    parity: super::vals::ConfigParity,
+                    stop: super::vals::Stop,
+                }
+                let proxy = Config {
+                    hwfc: self.hwfc(),
+                    parity: self.parity(),
+                    stop: self.stop(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Enable UART"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -14932,6 +20525,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Enable {
                 Enable(0)
+            }
+        }
+        impl core::fmt::Debug for Enable {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Enable")
+                    .field("enable", &self.enable())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Enable {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Enable {
+                    enable: super::vals::Enable,
+                }
+                let proxy = Enable {
+                    enable: self.enable(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Error source This register is read/write one to clear."]
@@ -14988,6 +20601,35 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> Errorsrc {
                 Errorsrc(0)
+            }
+        }
+        impl core::fmt::Debug for Errorsrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Errorsrc")
+                    .field("overrun", &self.overrun())
+                    .field("parity", &self.parity())
+                    .field("framing", &self.framing())
+                    .field("break_", &self.break_())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Errorsrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Errorsrc {
+                    overrun: bool,
+                    parity: bool,
+                    framing: bool,
+                    break_: bool,
+                }
+                let proxy = Errorsrc {
+                    overrun: self.overrun(),
+                    parity: self.parity(),
+                    framing: self.framing(),
+                    break_: self.break_(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable or disable interrupt"]
@@ -15123,6 +20765,56 @@ pub mod uarte {
                 Int(0)
             }
         }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("cts", &self.cts())
+                    .field("ncts", &self.ncts())
+                    .field("rxdrdy", &self.rxdrdy())
+                    .field("endrx", &self.endrx())
+                    .field("txdrdy", &self.txdrdy())
+                    .field("endtx", &self.endtx())
+                    .field("error", &self.error())
+                    .field("rxto", &self.rxto())
+                    .field("rxstarted", &self.rxstarted())
+                    .field("txstarted", &self.txstarted())
+                    .field("txstopped", &self.txstopped())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    cts: bool,
+                    ncts: bool,
+                    rxdrdy: bool,
+                    endrx: bool,
+                    txdrdy: bool,
+                    endtx: bool,
+                    error: bool,
+                    rxto: bool,
+                    rxstarted: bool,
+                    txstarted: bool,
+                    txstopped: bool,
+                }
+                let proxy = Int {
+                    cts: self.cts(),
+                    ncts: self.ncts(),
+                    rxdrdy: self.rxdrdy(),
+                    endrx: self.endrx(),
+                    txdrdy: self.txdrdy(),
+                    endtx: self.endtx(),
+                    error: self.error(),
+                    rxto: self.rxto(),
+                    rxstarted: self.rxstarted(),
+                    txstarted: self.txstarted(),
+                    txstopped: self.txstopped(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15146,6 +20838,26 @@ pub mod uarte {
                 RxdAmount(0)
             }
         }
+        impl core::fmt::Debug for RxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdAmount {
+                    amount: u16,
+                }
+                let proxy = RxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in receive buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15167,6 +20879,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> RxdMaxcnt {
                 RxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for RxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("RxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for RxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct RxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = RxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Shortcuts between local events and tasks"]
@@ -15203,6 +20935,29 @@ pub mod uarte {
                 Shorts(0)
             }
         }
+        impl core::fmt::Debug for Shorts {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Shorts")
+                    .field("endrx_startrx", &self.endrx_startrx())
+                    .field("endrx_stoprx", &self.endrx_stoprx())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Shorts {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Shorts {
+                    endrx_startrx: bool,
+                    endrx_stoprx: bool,
+                }
+                let proxy = Shorts {
+                    endrx_startrx: self.endrx_startrx(),
+                    endrx_stoprx: self.endrx_stoprx(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Number of bytes transferred in the last transaction"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15226,6 +20981,26 @@ pub mod uarte {
                 TxdAmount(0)
             }
         }
+        impl core::fmt::Debug for TxdAmount {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdAmount")
+                    .field("amount", &self.amount())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdAmount {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdAmount {
+                    amount: u16,
+                }
+                let proxy = TxdAmount {
+                    amount: self.amount(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Maximum number of bytes in transmit buffer"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15247,6 +21022,26 @@ pub mod uarte {
             #[inline(always)]
             fn default() -> TxdMaxcnt {
                 TxdMaxcnt(0)
+            }
+        }
+        impl core::fmt::Debug for TxdMaxcnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("TxdMaxcnt")
+                    .field("maxcnt", &self.maxcnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for TxdMaxcnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct TxdMaxcnt {
+                    maxcnt: u16,
+                }
+                let proxy = TxdMaxcnt {
+                    maxcnt: self.maxcnt(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
     }
@@ -15300,6 +21095,57 @@ pub mod uarte {
                 self.0
             }
         }
+        impl core::fmt::Debug for Baudrate {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0004_f000 => f.write_str("BAUD1200"),
+                    0x0009_d000 => f.write_str("BAUD2400"),
+                    0x0013_b000 => f.write_str("BAUD4800"),
+                    0x0027_5000 => f.write_str("BAUD9600"),
+                    0x003a_f000 => f.write_str("BAUD14400"),
+                    0x004e_a000 => f.write_str("BAUD19200"),
+                    0x0075_c000 => f.write_str("BAUD28800"),
+                    0x0080_0000 => f.write_str("BAUD31250"),
+                    0x009d_0000 => f.write_str("BAUD38400"),
+                    0x00e5_0000 => f.write_str("BAUD56000"),
+                    0x00eb_0000 => f.write_str("BAUD57600"),
+                    0x013a_9000 => f.write_str("BAUD76800"),
+                    0x01d6_0000 => f.write_str("BAUD115200"),
+                    0x03b0_0000 => f.write_str("BAUD230400"),
+                    0x0400_0000 => f.write_str("BAUD250000"),
+                    0x0740_0000 => f.write_str("BAUD460800"),
+                    0x0f00_0000 => f.write_str("BAUD921600"),
+                    0x1000_0000 => f.write_str("BAUD1M"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Baudrate {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0004_f000 => defmt::write!(f, "BAUD1200"),
+                    0x0009_d000 => defmt::write!(f, "BAUD2400"),
+                    0x0013_b000 => defmt::write!(f, "BAUD4800"),
+                    0x0027_5000 => defmt::write!(f, "BAUD9600"),
+                    0x003a_f000 => defmt::write!(f, "BAUD14400"),
+                    0x004e_a000 => defmt::write!(f, "BAUD19200"),
+                    0x0075_c000 => defmt::write!(f, "BAUD28800"),
+                    0x0080_0000 => defmt::write!(f, "BAUD31250"),
+                    0x009d_0000 => defmt::write!(f, "BAUD38400"),
+                    0x00e5_0000 => defmt::write!(f, "BAUD56000"),
+                    0x00eb_0000 => defmt::write!(f, "BAUD57600"),
+                    0x013a_9000 => defmt::write!(f, "BAUD76800"),
+                    0x01d6_0000 => defmt::write!(f, "BAUD115200"),
+                    0x03b0_0000 => defmt::write!(f, "BAUD230400"),
+                    0x0400_0000 => defmt::write!(f, "BAUD250000"),
+                    0x0740_0000 => defmt::write!(f, "BAUD460800"),
+                    0x0f00_0000 => defmt::write!(f, "BAUD921600"),
+                    0x1000_0000 => defmt::write!(f, "BAUD1M"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Baudrate {
             #[inline(always)]
             fn from(val: u32) -> Baudrate {
@@ -15313,7 +21159,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum ConfigParity {
             #[doc = "Exclude parity bit"]
             EXCLUDED = 0x0,
@@ -15349,7 +21196,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Enable {
             #[doc = "Disable UARTE"]
             DISABLED = 0x0,
@@ -15393,7 +21241,8 @@ pub mod uarte {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Stop {
             #[doc = "One stop bit"]
             ONE = 0x0,
@@ -15597,6 +21446,26 @@ pub mod uicr {
                 Appnvmcpofguard(0)
             }
         }
+        impl core::fmt::Debug for Appnvmcpofguard {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Appnvmcpofguard")
+                    .field("nvmcpofguarden", &self.nvmcpofguarden())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Appnvmcpofguard {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Appnvmcpofguard {
+                    nvmcpofguarden: bool,
+                }
+                let proxy = Appnvmcpofguard {
+                    nvmcpofguarden: self.nvmcpofguarden(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15619,6 +21488,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Approtect {
                 Approtect(0)
+            }
+        }
+        impl core::fmt::Debug for Approtect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Approtect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Approtect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Approtect {
+                    pall: super::vals::ApprotectPall,
+                }
+                let proxy = Approtect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Erase protection"]
@@ -15645,6 +21532,24 @@ pub mod uicr {
                 Eraseprotect(0)
             }
         }
+        impl core::fmt::Debug for Eraseprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Eraseprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Eraseprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Eraseprotect {
+                    pall: super::vals::EraseprotectPall,
+                }
+                let proxy = Eraseprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO startup counter"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15668,6 +21573,26 @@ pub mod uicr {
                 Hfxocnt(0)
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxocnt")
+                    .field("hfxocnt", &self.hfxocnt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxocnt {
+                    hfxocnt: super::vals::Hfxocnt,
+                }
+                let proxy = Hfxocnt {
+                    hfxocnt: self.hfxocnt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "HFXO clock source selection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15689,6 +21614,26 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Hfxosrc {
                 Hfxosrc(0)
+            }
+        }
+        impl core::fmt::Debug for Hfxosrc {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Hfxosrc")
+                    .field("hfxosrc", &self.hfxosrc())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxosrc {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Hfxosrc {
+                    hfxosrc: super::vals::Hfxosrc,
+                }
+                let proxy = Hfxosrc {
+                    hfxosrc: self.hfxosrc(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description collection: One time programmable memory"]
@@ -15723,6 +21668,29 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Otp {
                 Otp(0)
+            }
+        }
+        impl core::fmt::Debug for Otp {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Otp")
+                    .field("lower", &self.lower())
+                    .field("upper", &self.upper())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Otp {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Otp {
+                    lower: u16,
+                    upper: u16,
+                }
+                let proxy = Otp {
+                    lower: self.lower(),
+                    upper: self.upper(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Description cluster: Define permissions for the key slot. Bits 0-15 and 16-31 can only be written when equal to 0xFFFF."]
@@ -15782,6 +21750,35 @@ pub mod uicr {
                 Perm(0)
             }
         }
+        impl core::fmt::Debug for Perm {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Perm")
+                    .field("write", &self.write())
+                    .field("read", &self.read())
+                    .field("push", &self.push())
+                    .field("state", &self.state())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Perm {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Perm {
+                    write: bool,
+                    read: bool,
+                    push: bool,
+                    state: super::vals::State,
+                }
+                let proxy = Perm {
+                    write: self.write(),
+                    read: self.read(),
+                    push: self.push(),
+                    state: self.state(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Secure access port protection"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -15804,6 +21801,24 @@ pub mod uicr {
             #[inline(always)]
             fn default() -> Secureapprotect {
                 Secureapprotect(0)
+            }
+        }
+        impl core::fmt::Debug for Secureapprotect {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Secureapprotect")
+                    .field("pall", &self.pall())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Secureapprotect {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Secureapprotect {
+                    pall: super::vals::SecureapprotectPall,
+                }
+                let proxy = Secureapprotect { pall: self.pall() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Oscillator control"]
@@ -15829,6 +21844,24 @@ pub mod uicr {
                 Xosc32m(0)
             }
         }
+        impl core::fmt::Debug for Xosc32m {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Xosc32m")
+                    .field("ctrl", &self.ctrl())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Xosc32m {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Xosc32m {
+                    ctrl: u8,
+                }
+                let proxy = Xosc32m { ctrl: self.ctrl() };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(transparent)]
@@ -15846,6 +21879,25 @@ pub mod uicr {
             }
             pub const fn to_bits(self) -> u32 {
                 self.0
+            }
+        }
+        impl core::fmt::Debug for ApprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for ApprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
             }
         }
         impl From<u32> for ApprotectPall {
@@ -15877,6 +21929,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for EraseprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for EraseprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for EraseprotectPall {
             #[inline(always)]
             fn from(val: u32) -> EraseprotectPall {
@@ -15906,6 +21977,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for Hfxocnt {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("MIN_DEBOUNCE_TIME"),
+                    0xff => f.write_str("MAX_DEBOUNCE_TIME"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Hfxocnt {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "MIN_DEBOUNCE_TIME"),
+                    0xff => defmt::write!(f, "MAX_DEBOUNCE_TIME"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u8> for Hfxocnt {
             #[inline(always)]
             fn from(val: u8) -> Hfxocnt {
@@ -15919,7 +22009,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Hfxosrc {
             #[doc = "32 MHz temperature compensated crystal oscillator (TCXO)"]
             TCXO = 0x0,
@@ -15965,6 +22056,25 @@ pub mod uicr {
                 self.0
             }
         }
+        impl core::fmt::Debug for SecureapprotectPall {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x0 => f.write_str("PROTECTED"),
+                    0xffff_ffff => f.write_str("UNPROTECTED"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for SecureapprotectPall {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x0 => defmt::write!(f, "PROTECTED"),
+                    0xffff_ffff => defmt::write!(f, "UNPROTECTED"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for SecureapprotectPall {
             #[inline(always)]
             fn from(val: u32) -> SecureapprotectPall {
@@ -15978,7 +22088,8 @@ pub mod uicr {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum State {
             #[doc = "Key value registers can no longer be read or pushed"]
             REVOKED = 0x0,
@@ -16108,6 +22219,55 @@ pub mod vmc {
                 Power(0)
             }
         }
+        impl core::fmt::Debug for Power {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Power")
+                    .field(
+                        "spower",
+                        &[
+                            self.spower(0usize),
+                            self.spower(1usize),
+                            self.spower(2usize),
+                            self.spower(3usize),
+                        ],
+                    )
+                    .field(
+                        "sretention",
+                        &[
+                            self.sretention(0usize),
+                            self.sretention(1usize),
+                            self.sretention(2usize),
+                            self.sretention(3usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Power {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Power {
+                    spower: [bool; 4usize],
+                    sretention: [bool; 4usize],
+                }
+                let proxy = Power {
+                    spower: [
+                        self.spower(0usize),
+                        self.spower(1usize),
+                        self.spower(2usize),
+                        self.spower(3usize),
+                    ],
+                    sretention: [
+                        self.sretention(0usize),
+                        self.sretention(1usize),
+                        self.sretention(2usize),
+                        self.sretention(3usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
 }
 pub mod wdt {
@@ -16228,6 +22388,29 @@ pub mod wdt {
                 Config(0)
             }
         }
+        impl core::fmt::Debug for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Config")
+                    .field("sleep", &self.sleep())
+                    .field("halt", &self.halt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Config {
+                    sleep: super::vals::Sleep,
+                    halt: super::vals::Halt,
+                }
+                let proxy = Config {
+                    sleep: self.sleep(),
+                    halt: self.halt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Disable interrupt"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16249,6 +22432,26 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Int {
                 Int(0)
+            }
+        }
+        impl core::fmt::Debug for Int {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Int")
+                    .field("timeout", &self.timeout())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Int {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Int {
+                    timeout: bool,
+                }
+                let proxy = Int {
+                    timeout: self.timeout(),
+                };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Request status"]
@@ -16278,6 +22481,47 @@ pub mod wdt {
                 Reqstatus(0)
             }
         }
+        impl core::fmt::Debug for Reqstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Reqstatus")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Reqstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Reqstatus {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Reqstatus {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Description collection: Reload request n"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16300,6 +22544,22 @@ pub mod wdt {
             #[inline(always)]
             fn default() -> Rr {
                 Rr(0)
+            }
+        }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rr").field("rr", &self.rr()).finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rr {
+                    rr: super::vals::Rr,
+                }
+                let proxy = Rr { rr: self.rr() };
+                defmt::write!(f, "{}", proxy)
             }
         }
         #[doc = "Enable register for reload request registers"]
@@ -16329,6 +22589,47 @@ pub mod wdt {
                 Rren(0)
             }
         }
+        impl core::fmt::Debug for Rren {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Rren")
+                    .field(
+                        "rr",
+                        &[
+                            self.rr(0usize),
+                            self.rr(1usize),
+                            self.rr(2usize),
+                            self.rr(3usize),
+                            self.rr(4usize),
+                            self.rr(5usize),
+                            self.rr(6usize),
+                            self.rr(7usize),
+                        ],
+                    )
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rren {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Rren {
+                    rr: [bool; 8usize],
+                }
+                let proxy = Rren {
+                    rr: [
+                        self.rr(0usize),
+                        self.rr(1usize),
+                        self.rr(2usize),
+                        self.rr(3usize),
+                        self.rr(4usize),
+                        self.rr(5usize),
+                        self.rr(6usize),
+                        self.rr(7usize),
+                    ],
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
         #[doc = "Run status"]
         #[repr(transparent)]
         #[derive(Copy, Clone, Eq, PartialEq)]
@@ -16352,10 +22653,31 @@ pub mod wdt {
                 Runstatus(0)
             }
         }
+        impl core::fmt::Debug for Runstatus {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.debug_struct("Runstatus")
+                    .field("runstatuswdt", &self.runstatuswdt())
+                    .finish()
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Runstatus {
+            fn format(&self, f: defmt::Formatter) {
+                #[derive(defmt :: Format)]
+                struct Runstatus {
+                    runstatuswdt: bool,
+                }
+                let proxy = Runstatus {
+                    runstatuswdt: self.runstatuswdt(),
+                };
+                defmt::write!(f, "{}", proxy)
+            }
+        }
     }
     pub mod vals {
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Halt {
             #[doc = "Pause watchdog while the CPU is halted by the debugger"]
             PAUSE = 0x0,
@@ -16399,6 +22721,23 @@ pub mod wdt {
                 self.0
             }
         }
+        impl core::fmt::Debug for Rr {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                match self.0 {
+                    0x6e52_4635 => f.write_str("RELOAD"),
+                    other => core::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Rr {
+            fn format(&self, f: defmt::Formatter) {
+                match self.0 {
+                    0x6e52_4635 => defmt::write!(f, "RELOAD"),
+                    other => defmt::write!(f, "0x{:02X}", other),
+                }
+            }
+        }
         impl From<u32> for Rr {
             #[inline(always)]
             fn from(val: u32) -> Rr {
@@ -16412,7 +22751,8 @@ pub mod wdt {
             }
         }
         #[repr(u8)]
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Sleep {
             #[doc = "Pause watchdog while the CPU is sleeping"]
             PAUSE = 0x0,


### PR DESCRIPTION
This PR regenerates the PAC with the latest `chiptool` and adds a `defmt` feature.

Follow up for https://github.com/embassy-rs/chiptool/pull/44

Note that I manually removed the `GLOBAL_` prefixes from the source code as the versions of `chiptool` that I could find to not have the `RenamePeripherals` transform (see #5).