### PR TITLE
Do not rename UARTE TASK_FLUSHRX task to TASK_DMA.RX.FLUSH

### DIFF
--- a/src/chips/nrf52805/pac.rs
+++ b/src/chips/nrf52805/pac.rs
@@ -19651,11 +19651,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -19702,6 +19697,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52810/pac.rs
+++ b/src/chips/nrf52810/pac.rs
@@ -22061,11 +22061,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -22112,6 +22107,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52811/pac.rs
+++ b/src/chips/nrf52811/pac.rs
@@ -24067,11 +24067,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -24118,6 +24113,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52820/pac.rs
+++ b/src/chips/nrf52820/pac.rs
@@ -21212,11 +21212,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -21263,6 +21258,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52832/pac.rs
+++ b/src/chips/nrf52832/pac.rs
@@ -28962,11 +28962,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -29013,6 +29008,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52833/pac.rs
+++ b/src/chips/nrf52833/pac.rs
@@ -30425,11 +30425,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -30476,6 +30471,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf52840/pac.rs
+++ b/src/chips/nrf52840/pac.rs
@@ -38750,11 +38750,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -38801,6 +38796,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "CTS is activated (set low). Clear To Send."]
         #[inline(always)]

--- a/src/chips/nrf5340-app/pac.rs
+++ b/src/chips/nrf5340-app/pac.rs
@@ -42791,11 +42791,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -42842,6 +42837,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "Subscribe configuration for task STARTRX"]
         #[inline(always)]

--- a/src/chips/nrf5340-net/pac.rs
+++ b/src/chips/nrf5340-net/pac.rs
@@ -21633,11 +21633,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -21684,6 +21679,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "Subscribe configuration for task STARTRX"]
         #[inline(always)]

--- a/src/chips/nrf9120/pac.rs
+++ b/src/chips/nrf9120/pac.rs
@@ -44670,11 +44670,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -44721,6 +44716,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "Subscribe configuration for task STARTRX"]
         #[inline(always)]

--- a/src/chips/nrf9160/pac.rs
+++ b/src/chips/nrf9160/pac.rs
@@ -44247,11 +44247,6 @@ pub mod uarte {
         pub const fn stop(self) -> crate::common::Reg<u32, crate::common::W> {
             unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x04usize) as _) }
         }
-        #[doc = "Flush RX FIFO into RX buffer"]
-        #[inline(always)]
-        pub const fn flush(self) -> crate::common::Reg<u32, crate::common::W> {
-            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
-        }
     }
     #[derive(Copy, Clone, Eq, PartialEq)]
     pub struct TasksDmaTx {
@@ -44298,6 +44293,11 @@ pub mod uarte {
         #[inline(always)]
         pub const fn tasks_dma(self) -> TasksDma {
             unsafe { TasksDma::from_ptr(self.ptr.wrapping_add(0x0usize) as _) }
+        }
+        #[doc = "Flush RX FIFO into RX buffer"]
+        #[inline(always)]
+        pub const fn tasks_flushrx(self) -> crate::common::Reg<u32, crate::common::W> {
+            unsafe { crate::common::Reg::from_ptr(self.ptr.wrapping_add(0x2cusize) as _) }
         }
         #[doc = "Subscribe configuration for task STARTRX"]
         #[inline(always)]

--- a/transform-extra.yaml
+++ b/transform-extra.yaml
@@ -216,7 +216,7 @@
       to: uarte::DmaRx
   - !MakeBlock
       blocks: uarte::Uarte
-      from: tasks_(.+)(tx|rx)
+      from: tasks_(start|stop)(tx|rx)
       to_outer: tasks_dma
       to_inner: $1$2
       to_block: uarte::TasksDma


### PR DESCRIPTION
The `UART` `TASK_FLUSHRX` was unintentionally being renamed to `TASK_DMA.RX.FLUSH`. This PR adjusts the regex responsible to it only includes the `START`/`STOP` `RX`/`TX` tasks and regenerates the generated code.